### PR TITLE
Issue #1: complete Google OAuth callback/revoke hardening and contract alignment

### DIFF
--- a/alfred/Packages/AlfredAPIClient/Sources/Models.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/Models.swift
@@ -73,12 +73,23 @@ public struct StartGoogleConnectResponse: Codable, Sendable {
 }
 
 public struct CompleteGoogleConnectRequest: Codable, Sendable {
-    public let code: String
+    public let code: String?
     public let state: String
+    public let error: String?
+    public let errorDescription: String?
 
-    public init(code: String, state: String) {
+    enum CodingKeys: String, CodingKey {
+        case code
+        case state
+        case error
+        case errorDescription = "error_description"
+    }
+
+    public init(code: String? = nil, state: String, error: String? = nil, errorDescription: String? = nil) {
         self.code = code
         self.state = state
+        self.error = error
+        self.errorDescription = errorDescription
     }
 }
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -73,6 +73,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/StartGoogleConnectResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
   /v1/connectors/google/callback:
@@ -95,6 +97,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CompleteGoogleConnectResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "502":
+          $ref: "#/components/responses/BadGateway"
         "401":
           $ref: "#/components/responses/Unauthorized"
   /v1/connectors/{connector_id}:
@@ -121,6 +127,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "502":
+          $ref: "#/components/responses/BadGateway"
   /v1/preferences:
     get:
       tags: [Preferences]
@@ -202,6 +210,18 @@ components:
       scheme: bearer
       bearerFormat: JWT
   responses:
+    BadRequest:
+      description: Request rejected due to invalid input or OAuth error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    BadGateway:
+      description: Upstream OAuth provider unavailable or failed
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
     Unauthorized:
       description: Unauthorized
       content:
@@ -264,11 +284,16 @@ components:
           type: string
     CompleteGoogleConnectRequest:
       type: object
-      required: [code, state]
+      required: [state]
       properties:
         code:
           type: string
+          nullable: true
         state:
+          type: string
+        error:
+          type: string
+        error_description:
           type: string
     CompleteGoogleConnectResponse:
       type: object

--- a/backend/crates/api-server/src/main.rs
+++ b/backend/crates/api-server/src/main.rs
@@ -58,6 +58,7 @@ async fn main() {
             redirect_uri: config.google_redirect_uri,
             auth_url: config.google_auth_url,
             token_url: config.google_token_url,
+            revoke_url: config.google_revoke_url,
             scopes: vec![
                 "https://www.googleapis.com/auth/gmail.readonly".to_string(),
                 "https://www.googleapis.com/auth/calendar.readonly".to_string(),

--- a/backend/crates/shared/src/config.rs
+++ b/backend/crates/shared/src/config.rs
@@ -17,6 +17,7 @@ pub struct ApiConfig {
     pub google_redirect_uri: String,
     pub google_auth_url: String,
     pub google_token_url: String,
+    pub google_revoke_url: String,
 }
 
 #[derive(Debug, Clone)]
@@ -56,6 +57,8 @@ impl ApiConfig {
                 .unwrap_or_else(|_| "https://accounts.google.com/o/oauth2/v2/auth".to_string()),
             google_token_url: env::var("GOOGLE_OAUTH_TOKEN_URL")
                 .unwrap_or_else(|_| "https://oauth2.googleapis.com/token".to_string()),
+            google_revoke_url: env::var("GOOGLE_OAUTH_REVOKE_URL")
+                .unwrap_or_else(|_| "https://oauth2.googleapis.com/revoke".to_string()),
         })
     }
 }

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -43,8 +43,13 @@ pub struct StartGoogleConnectResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompleteGoogleConnectRequest {
-    pub code: String,
+    #[serde(default)]
+    pub code: Option<String>,
     pub state: String,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub error_description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -59,9 +59,9 @@ Ship a private beta where iOS users can:
 | BE-002 | P0 | Add health/readiness endpoints | BE | 2026-02-20 | TODO | - | `/healthz` and `/readyz` live |
 | BE-003 | P0 | Add structured logging with request_id | BE | 2026-02-21 | TODO | BE-002 | Request logs include trace fields |
 | BE-004 | P0 | Standardize API error envelope/codes | BE | 2026-02-22 | TODO | BE-001 | All endpoints use common error format |
-| BE-005 | P0 | Implement `/v1/connectors/google/start` real OAuth URL + state | BE | 2026-03-01 | TODO | BE-004 | Endpoint returns valid provider URL/state |
-| BE-006 | P0 | Implement `/v1/connectors/google/callback` token exchange | BE | 2026-03-03 | TODO | BE-005 | Real token exchange succeeds |
-| BE-007 | P0 | Implement `/v1/connectors/{id}` revoke + provider-side revoke | BE | 2026-03-05 | TODO | BE-006 | Connector revoke fully works |
+| BE-005 | P0 | Implement `/v1/connectors/google/start` real OAuth URL + state | BE | 2026-03-01 | DONE | BE-004 | Endpoint returns valid provider URL/state |
+| BE-006 | P0 | Implement `/v1/connectors/google/callback` token exchange | BE | 2026-03-03 | DONE | BE-005 | Real token exchange succeeds |
+| BE-007 | P0 | Implement `/v1/connectors/{id}` revoke + provider-side revoke | BE | 2026-03-05 | DONE | BE-006 | Connector revoke fully works |
 | BE-008 | P0 | Implement `/v1/preferences` persistence | BE | 2026-03-06 | TODO | DB-001 | Read/write preferences backed by DB |
 | BE-009 | P0 | Implement `/v1/audit-events` pagination and filters | BE | 2026-03-10 | TODO | DB-004 | Cursor pagination works |
 | BE-010 | P0 | Implement `/v1/privacy/delete-all` async job trigger | BE | 2026-03-12 | TODO | DB-007 | Delete request queued and trackable |


### PR DESCRIPTION
## Summary
Implements issue #1 end-to-end for Google connector flow by completing secure OAuth start/callback/revoke behavior and aligning API contracts/docs.

## What Changed
- Added deterministic callback error handling for:
  - invalid/expired state (`invalid_state`)
  - denied consent (`oauth_consent_denied`)
  - invalid/missing auth code (`invalid_oauth_code`)
- Added provider-side revoke flow:
  - fetches active connector refresh token from repo layer (decrypted server-side)
  - revokes token via Google revoke endpoint
  - treats Google `invalid_token` as idempotent revoke success
  - only marks connector revoked in Alfred after upstream revoke attempt succeeds
- Added configurable Google revoke endpoint (`GOOGLE_OAUTH_REVOKE_URL`, default `https://oauth2.googleapis.com/revoke`)
- Extended callback request model to support provider callback error fields (`error`, `error_description`)
- Updated OpenAPI to document new error responses and callback payload fields
- Updated Phase I board status for BE-005/BE-006/BE-007 to `DONE`

## Security / Scalability Notes
- Sensitive token handling remains centralized in `backend/crates/shared/src/repos`.
- HTTP/OAuth orchestration remains in `backend/crates/api-server/src/http.rs`.
- No SQL moved into HTTP layer; architecture boundaries remain enforced.

## AI Review Summary
### 1) Security Audit
- Findings fixed:
  - Provider-side token revocation was missing.
  - Callback error paths were non-deterministic for denied consent / missing code.
- Current residual risk:
  - No integration tests yet for full OAuth/revoke provider interactions; behavior validated via code-path review and command gates.

### 2) Bug Check
- Findings: no functional regressions identified in changed paths.
- Deterministic OAuth error mapping now explicit for key failure cases.

### 3) Scalability / Code Quality Review
- Layering preserved (`repos` for DB/crypto, `http` for API/provider calls, `main` for wiring).
- Contract drift addressed by OpenAPI + API client model updates.

### 4) Final Status
- `just backend-deep-review`: PASS
- `just ios-build`: PASS
- Merge recommendation: `APPROVE`

## Validation
- `just check-tools` ✅
- `just backend-check` ✅
- `just ios-build` ✅
- `just backend-deep-review` ✅

## Issue
Closes #1
