### PR TITLE
Worker: fail closed on idempotency release persistence failures

### DIFF
--- a/backend/crates/worker/src/main.rs
+++ b/backend/crates/worker/src/main.rs
@@ -321,7 +321,7 @@ async fn execute_job(store: &Store, job: &ClaimedJob) -> Result<(), JobExecution
             .release_outbound_action_idempotency(job.user_id, &job.idempotency_key, job.id)
             .await
         {
-            return Err(JobExecutionError::transient(
+            return Err(JobExecutionError::permanent(
                 "IDEMPOTENCY_RELEASE_FAILED",
                 format!("failed to release idempotency reservation: {release_err}"),
             ));


### PR DESCRIPTION
## Summary
Follow-up reliability fix from review: fail closed when idempotency release cannot be persisted after a dispatch error.

## Change
- Updated `/Users/niteshchowdharybalusu/Documents/alfred/backend/crates/worker/src/main.rs` so `IDEMPOTENCY_RELEASE_FAILED` is classified as permanent instead of transient.

## Why
A transient classification could allow a retry path that treats the retained idempotency row as a duplicate and marks the job done even though dispatch previously failed. Permanent classification dead-letters this ambiguous state for manual recovery, preventing false-success completion.

## Validation
- `just backend-deep-review`
- `just ios-build`

## Issue
Follow-up hardening for #4
