### PR TITLE
Implement APNs delivery pipeline and set iOS test default to iPhone 17

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -31,7 +31,7 @@ ios-build:
   xcodebuild -project {{ios_project}} -scheme {{ios_scheme}} -destination 'generic/platform=iOS Simulator' build
 
 # Run iOS tests on a specific simulator.
-ios-test destination='platform=iOS Simulator,name=iPhone 16':
+ios-test destination='platform=iOS Simulator,name=iPhone 17':
   xcodebuild -project {{ios_project}} -scheme {{ios_scheme}} -destination '{{destination}}' test
 
 # Compile the local Swift package used by the iOS app.

--- a/alfred/Packages/AlfredAPIClient/Sources/AlfredAPIClient.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/AlfredAPIClient.swift
@@ -53,6 +53,15 @@ public final class AlfredAPIClient: Sendable {
         )
     }
 
+    public func sendAPNSTestNotification(_ request: SendTestNotificationRequest) async throws -> SendTestNotificationResponse {
+        try await send(
+            method: "POST",
+            path: "/v1/devices/apns/test",
+            body: request,
+            requiresAuth: true
+        )
+    }
+
     public func startGoogleOAuth(_ request: StartGoogleConnectRequest) async throws -> StartGoogleConnectResponse {
         try await send(
             method: "POST",

--- a/alfred/Packages/AlfredAPIClient/Sources/Models.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/Models.swift
@@ -50,6 +50,26 @@ public struct RegisterDeviceRequest: Codable, Sendable {
     }
 }
 
+public struct SendTestNotificationRequest: Codable, Sendable {
+    public let title: String?
+    public let body: String?
+
+    public init(title: String? = nil, body: String? = nil) {
+        self.title = title
+        self.body = body
+    }
+}
+
+public struct SendTestNotificationResponse: Codable, Sendable {
+    public let queuedJobId: String
+    public let status: String
+
+    enum CodingKeys: String, CodingKey {
+        case queuedJobId = "queued_job_id"
+        case status
+    }
+}
+
 public struct StartGoogleConnectRequest: Codable, Sendable {
     public let redirectURI: String
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -53,6 +53,30 @@ paths:
                 $ref: "#/components/schemas/OkResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /v1/devices/apns/test:
+    post:
+      tags: [Devices]
+      summary: Queue a test push notification
+      operationId: sendAPNSTestNotification
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SendTestNotificationRequest"
+      responses:
+        "200":
+          description: Test notification queued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendTestNotificationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
   /v1/connectors/google/start:
     post:
       tags: [Connectors]
@@ -266,6 +290,26 @@ components:
         environment:
           type: string
           enum: [sandbox, production]
+    SendTestNotificationRequest:
+      type: object
+      properties:
+        title:
+          type: string
+          nullable: true
+          maxLength: 120
+        body:
+          type: string
+          nullable: true
+          maxLength: 500
+    SendTestNotificationResponse:
+      type: object
+      required: [queued_job_id, status]
+      properties:
+        queued_job_id:
+          type: string
+        status:
+          type: string
+          enum: [QUEUED]
     StartGoogleConnectRequest:
       type: object
       required: [redirect_uri]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2835,6 +2835,9 @@ name = "worker"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "reqwest",
+ "serde",
+ "serde_json",
  "shared",
  "tokio",
  "tracing",

--- a/backend/README.md
+++ b/backend/README.md
@@ -60,3 +60,13 @@ These vars control TEE/KMS-bound decrypt policy for connector refresh tokens:
 10. `KMS_KEY_ID` (default: `kms/local/alfred-refresh-token`)
 11. `KMS_KEY_VERSION` (default: `1`)
 12. `KMS_ALLOWED_MEASUREMENTS` (CSV; defaults to `TEE_ALLOWED_MEASUREMENTS`)
+
+## Push Delivery Environment (Worker)
+
+Optional worker vars for APNs delivery abstraction:
+
+1. `APNS_SANDBOX_ENDPOINT` (HTTP endpoint used for sandbox device deliveries)
+2. `APNS_PRODUCTION_ENDPOINT` (HTTP endpoint used for production device deliveries)
+3. `APNS_AUTH_TOKEN` (optional bearer token attached to push delivery requests)
+
+If no endpoint is configured for a device environment, worker delivery is simulated and still logged/audited for local development.

--- a/backend/crates/shared/src/config.rs
+++ b/backend/crates/shared/src/config.rs
@@ -39,6 +39,9 @@ pub struct WorkerConfig {
     pub per_user_concurrency_limit: u32,
     pub retry_base_delay_seconds: u64,
     pub retry_max_delay_seconds: u64,
+    pub apns_sandbox_endpoint: Option<String>,
+    pub apns_production_endpoint: Option<String>,
+    pub apns_auth_token: Option<String>,
     pub database_url: String,
     pub database_max_connections: u32,
     pub data_encryption_key: String,
@@ -174,6 +177,9 @@ impl WorkerConfig {
             per_user_concurrency_limit,
             retry_base_delay_seconds,
             retry_max_delay_seconds,
+            apns_sandbox_endpoint: optional_trimmed_env("APNS_SANDBOX_ENDPOINT"),
+            apns_production_endpoint: optional_trimmed_env("APNS_PRODUCTION_ENDPOINT"),
+            apns_auth_token: optional_trimmed_env("APNS_AUTH_TOKEN"),
             database_url: require_env("DATABASE_URL")?,
             database_max_connections: parse_u32_env("DATABASE_MAX_CONNECTIONS", 5)?,
             data_encryption_key: require_env("DATA_ENCRYPTION_KEY")?,
@@ -253,4 +259,15 @@ fn parse_csv_list(raw: String) -> Vec<String> {
     } else {
         parsed
     }
+}
+
+fn optional_trimmed_env(key: &str) -> Option<String> {
+    env::var(key).ok().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
 }

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -31,6 +31,20 @@ pub struct RegisterDeviceRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendTestNotificationRequest {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendTestNotificationResponse {
+    pub queued_job_id: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StartGoogleConnectRequest {
     pub redirect_uri: String,
 }

--- a/backend/crates/worker/Cargo.toml
+++ b/backend/crates/worker/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 
 [dependencies]
 chrono.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/backend/crates/worker/src/main.rs
+++ b/backend/crates/worker/src/main.rs
@@ -1,6 +1,11 @@
-use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration as ChronoDuration, NaiveTime, Utc};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
 use shared::config::WorkerConfig;
-use shared::repos::{ClaimedJob, JobType, Store};
+use shared::models::ApnsEnvironment;
+use shared::repos::{AuditResult, ClaimedJob, DeviceRegistration, JobType, Store};
 use tokio::signal;
 use tokio::time::{self, Duration};
 use tracing::{error, info, warn};
@@ -45,6 +50,11 @@ struct WorkerTickMetrics {
     retryable_failures: usize,
     permanent_failures: usize,
     dead_lettered_jobs: usize,
+    push_attempts: usize,
+    push_delivered: usize,
+    push_quiet_hours_suppressed: usize,
+    push_transient_failures: usize,
+    push_permanent_failures: usize,
     total_lag_seconds: i64,
     max_lag_seconds: i64,
 }
@@ -71,6 +81,57 @@ impl WorkerTickMetrics {
 
         self.successful_jobs as f64 / self.processed_jobs as f64
     }
+}
+
+#[derive(Clone)]
+struct PushSender {
+    client: reqwest::Client,
+    sandbox_endpoint: Option<String>,
+    production_endpoint: Option<String>,
+    auth_token: Option<String>,
+}
+
+#[derive(Debug)]
+enum PushSendError {
+    Transient { code: String, message: String },
+    Permanent { code: String, message: String },
+}
+
+impl PushSendError {
+    fn to_job_error(&self) -> JobExecutionError {
+        match self {
+            Self::Transient { code, message } => {
+                JobExecutionError::transient(code.clone(), message.clone())
+            }
+            Self::Permanent { code, message } => {
+                JobExecutionError::permanent(code.clone(), message.clone())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NotificationContent {
+    title: String,
+    body: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct NotificationJobPayload {
+    notification: Option<NotificationPayloadBody>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NotificationPayloadBody {
+    title: String,
+    body: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PushDeliveryRequest<'a> {
+    device_token: &'a str,
+    title: &'a str,
+    body: &'a str,
 }
 
 #[tokio::main]
@@ -101,6 +162,12 @@ async fn main() {
         }
     };
 
+    let push_sender = PushSender::new(
+        config.apns_sandbox_endpoint.clone(),
+        config.apns_production_endpoint.clone(),
+        config.apns_auth_token.clone(),
+    );
+
     let worker_id = Uuid::new_v4();
     info!(
         worker_id = %worker_id,
@@ -108,6 +175,8 @@ async fn main() {
         batch_size = config.batch_size,
         lease_seconds = config.lease_seconds,
         per_user_concurrency_limit = config.per_user_concurrency_limit,
+        apns_sandbox_endpoint_configured = config.apns_sandbox_endpoint.is_some(),
+        apns_production_endpoint_configured = config.apns_production_endpoint.is_some(),
         "worker starting"
     );
 
@@ -120,13 +189,90 @@ async fn main() {
                 break;
             }
             _ = ticker.tick() => {
-                process_due_jobs(&store, &config, worker_id).await;
+                process_due_jobs(&store, &config, &push_sender, worker_id).await;
             }
         }
     }
 }
 
-async fn process_due_jobs(store: &Store, config: &WorkerConfig, worker_id: Uuid) {
+impl PushSender {
+    fn new(
+        sandbox_endpoint: Option<String>,
+        production_endpoint: Option<String>,
+        auth_token: Option<String>,
+    ) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            sandbox_endpoint,
+            production_endpoint,
+            auth_token,
+        }
+    }
+
+    async fn send(
+        &self,
+        device: &DeviceRegistration,
+        content: &NotificationContent,
+    ) -> Result<(), PushSendError> {
+        let endpoint = match device.environment {
+            ApnsEnvironment::Sandbox => self.sandbox_endpoint.as_deref(),
+            ApnsEnvironment::Production => self.production_endpoint.as_deref(),
+        };
+
+        let Some(endpoint) = endpoint else {
+            info!(
+                device_id = %device.device_id,
+                environment = %apns_environment_label(&device.environment),
+                "apns endpoint not configured for environment; simulated delivery"
+            );
+            return Ok(());
+        };
+
+        let request = PushDeliveryRequest {
+            device_token: &device.apns_token,
+            title: &content.title,
+            body: &content.body,
+        };
+
+        let mut builder = self.client.post(endpoint).json(&request);
+        if let Some(auth_token) = self.auth_token.as_deref() {
+            builder = builder.bearer_auth(auth_token);
+        }
+
+        let response = builder
+            .send()
+            .await
+            .map_err(|err| PushSendError::Transient {
+                code: "APNS_NETWORK_ERROR".to_string(),
+                message: format!("APNs request failed: {err}"),
+            })?;
+
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+
+        let body = response.text().await.unwrap_or_default();
+        let code = format!("APNS_HTTP_{}", status.as_u16());
+        let message = if body.is_empty() {
+            format!("APNs responded with status {status}")
+        } else {
+            format!("APNs responded with status {status}: {body}")
+        };
+
+        match classify_http_failure(status) {
+            FailureClass::Transient => Err(PushSendError::Transient { code, message }),
+            FailureClass::Permanent => Err(PushSendError::Permanent { code, message }),
+        }
+    }
+}
+
+async fn process_due_jobs(
+    store: &Store,
+    config: &WorkerConfig,
+    push_sender: &PushSender,
+    worker_id: Uuid,
+) {
     let now = Utc::now();
     let claimed_jobs = match store
         .claim_due_jobs(
@@ -152,7 +298,7 @@ async fn process_due_jobs(store: &Store, config: &WorkerConfig, worker_id: Uuid)
 
     for job in claimed_jobs {
         metrics.record_lag(job.due_at, now);
-        process_claimed_job(store, config, worker_id, job, &mut metrics).await;
+        process_claimed_job(store, config, push_sender, worker_id, job, &mut metrics).await;
     }
 
     let due_count = store.count_due_jobs(Utc::now()).await.unwrap_or(-1);
@@ -166,6 +312,11 @@ async fn process_due_jobs(store: &Store, config: &WorkerConfig, worker_id: Uuid)
         retryable_failures = metrics.retryable_failures,
         permanent_failures = metrics.permanent_failures,
         dead_lettered_jobs = metrics.dead_lettered_jobs,
+        push_attempts = metrics.push_attempts,
+        push_delivered = metrics.push_delivered,
+        push_quiet_hours_suppressed = metrics.push_quiet_hours_suppressed,
+        push_transient_failures = metrics.push_transient_failures,
+        push_permanent_failures = metrics.push_permanent_failures,
         average_lag_seconds = metrics.average_lag_seconds(),
         max_lag_seconds = metrics.max_lag_seconds,
         success_rate = metrics.success_rate(),
@@ -176,13 +327,14 @@ async fn process_due_jobs(store: &Store, config: &WorkerConfig, worker_id: Uuid)
 async fn process_claimed_job(
     store: &Store,
     config: &WorkerConfig,
+    push_sender: &PushSender,
     worker_id: Uuid,
     job: ClaimedJob,
     metrics: &mut WorkerTickMetrics,
 ) {
     metrics.processed_jobs += 1;
 
-    match execute_job(store, &job).await {
+    match execute_job(store, push_sender, &job, metrics).await {
         Ok(()) => match store.mark_job_done(job.id, worker_id).await {
             Ok(true) => {
                 metrics.successful_jobs += 1;
@@ -295,7 +447,12 @@ async fn process_claimed_job(
     }
 }
 
-async fn execute_job(store: &Store, job: &ClaimedJob) -> Result<(), JobExecutionError> {
+async fn execute_job(
+    store: &Store,
+    push_sender: &PushSender,
+    job: &ClaimedJob,
+    metrics: &mut WorkerTickMetrics,
+) -> Result<(), JobExecutionError> {
     let has_action_lease = store
         .record_outbound_action_idempotency(job.user_id, &job.idempotency_key, job.id)
         .await
@@ -316,7 +473,7 @@ async fn execute_job(store: &Store, job: &ClaimedJob) -> Result<(), JobExecution
         return Ok(());
     }
 
-    if let Err(err) = dispatch_job_action(job) {
+    if let Err(err) = dispatch_job_action(store, push_sender, job, metrics).await {
         if let Err(release_err) = store
             .release_outbound_action_idempotency(job.user_id, &job.idempotency_key, job.id)
             .await
@@ -333,14 +490,242 @@ async fn execute_job(store: &Store, job: &ClaimedJob) -> Result<(), JobExecution
     Ok(())
 }
 
-fn dispatch_job_action(job: &ClaimedJob) -> Result<(), JobExecutionError> {
+async fn dispatch_job_action(
+    store: &Store,
+    push_sender: &PushSender,
+    job: &ClaimedJob,
+    metrics: &mut WorkerTickMetrics,
+) -> Result<(), JobExecutionError> {
     if let Some(simulated_failure) = parse_simulated_failure(job.payload_ciphertext.as_deref()) {
         return Err(simulated_failure);
     }
 
-    match job.job_type {
-        JobType::MeetingReminder | JobType::MorningBrief | JobType::UrgentEmailCheck => Ok(()),
+    let content = resolve_notification_content(job);
+
+    let preferences = store
+        .get_or_create_preferences(job.user_id)
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "PREFERENCES_READ_FAILED",
+                format!("failed to read user preferences: {err}"),
+            )
+        })?;
+
+    if is_within_quiet_hours(
+        Utc::now().time(),
+        &preferences.quiet_hours_start,
+        &preferences.quiet_hours_end,
+    )
+    .map_err(|message| JobExecutionError::permanent("INVALID_QUIET_HOURS", message))?
+    {
+        metrics.push_quiet_hours_suppressed += 1;
+
+        let mut metadata = HashMap::new();
+        metadata.insert("job_id".to_string(), job.id.to_string());
+        metadata.insert("job_type".to_string(), job.job_type.as_str().to_string());
+        metadata.insert("reason".to_string(), "quiet_hours".to_string());
+        metadata.insert(
+            "quiet_hours_start".to_string(),
+            preferences.quiet_hours_start.clone(),
+        );
+        metadata.insert(
+            "quiet_hours_end".to_string(),
+            preferences.quiet_hours_end.clone(),
+        );
+
+        record_notification_audit(
+            store,
+            job.user_id,
+            "NOTIFICATION_SUPPRESSED",
+            AuditResult::Success,
+            metadata,
+        )
+        .await;
+
+        info!(
+            job_id = %job.id,
+            user_id = %job.user_id,
+            quiet_hours_start = %preferences.quiet_hours_start,
+            quiet_hours_end = %preferences.quiet_hours_end,
+            "notification suppressed by quiet hours"
+        );
+
+        return Ok(());
     }
+
+    let devices = store
+        .list_registered_devices(job.user_id)
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "DEVICE_LOOKUP_FAILED",
+                format!("failed to fetch registered devices: {err}"),
+            )
+        })?;
+
+    if devices.is_empty() {
+        return Err(JobExecutionError::permanent(
+            "NO_REGISTERED_DEVICE",
+            "no APNs device registered for user",
+        ));
+    }
+
+    let mut delivered = 0_usize;
+    let mut first_transient_error: Option<JobExecutionError> = None;
+    let mut first_permanent_error: Option<JobExecutionError> = None;
+
+    for device in &devices {
+        metrics.push_attempts += 1;
+
+        match push_sender.send(device, &content).await {
+            Ok(()) => {
+                delivered += 1;
+                metrics.push_delivered += 1;
+
+                let mut metadata = HashMap::new();
+                metadata.insert("job_id".to_string(), job.id.to_string());
+                metadata.insert("job_type".to_string(), job.job_type.as_str().to_string());
+                metadata.insert("device_id".to_string(), device.device_id.clone());
+                metadata.insert(
+                    "environment".to_string(),
+                    apns_environment_label(&device.environment).to_string(),
+                );
+                metadata.insert("outcome".to_string(), "delivered".to_string());
+
+                record_notification_audit(
+                    store,
+                    job.user_id,
+                    "NOTIFICATION_DELIVERY_ATTEMPT",
+                    AuditResult::Success,
+                    metadata,
+                )
+                .await;
+            }
+            Err(err) => {
+                let (error_code, error_message, class) = match &err {
+                    PushSendError::Transient { code, message } => {
+                        metrics.push_transient_failures += 1;
+                        (code.clone(), message.clone(), FailureClass::Transient)
+                    }
+                    PushSendError::Permanent { code, message } => {
+                        metrics.push_permanent_failures += 1;
+                        (code.clone(), message.clone(), FailureClass::Permanent)
+                    }
+                };
+
+                let mut metadata = HashMap::new();
+                metadata.insert("job_id".to_string(), job.id.to_string());
+                metadata.insert("job_type".to_string(), job.job_type.as_str().to_string());
+                metadata.insert("device_id".to_string(), device.device_id.clone());
+                metadata.insert(
+                    "environment".to_string(),
+                    apns_environment_label(&device.environment).to_string(),
+                );
+                metadata.insert("outcome".to_string(), "failed".to_string());
+                metadata.insert("error_code".to_string(), error_code.clone());
+
+                record_notification_audit(
+                    store,
+                    job.user_id,
+                    "NOTIFICATION_DELIVERY_ATTEMPT",
+                    AuditResult::Failure,
+                    metadata,
+                )
+                .await;
+
+                match class {
+                    FailureClass::Transient if first_transient_error.is_none() => {
+                        first_transient_error = Some(err.to_job_error())
+                    }
+                    FailureClass::Permanent if first_permanent_error.is_none() => {
+                        first_permanent_error = Some(err.to_job_error())
+                    }
+                    _ => {}
+                }
+
+                warn!(
+                    job_id = %job.id,
+                    user_id = %job.user_id,
+                    device_id = %device.device_id,
+                    error_code = %error_code,
+                    error_message = %error_message,
+                    "push delivery attempt failed"
+                );
+            }
+        }
+    }
+
+    if delivered > 0 {
+        return Ok(());
+    }
+
+    if let Some(err) = first_transient_error {
+        return Err(err);
+    }
+
+    if let Some(err) = first_permanent_error {
+        return Err(err);
+    }
+
+    Err(JobExecutionError::permanent(
+        "PUSH_DELIVERY_FAILED",
+        "push delivery failed without a classified error",
+    ))
+}
+
+async fn record_notification_audit(
+    store: &Store,
+    user_id: Uuid,
+    event_type: &str,
+    result: AuditResult,
+    metadata: HashMap<String, String>,
+) {
+    if let Err(err) = store
+        .add_audit_event(user_id, event_type, None, result, &metadata)
+        .await
+    {
+        warn!(
+            user_id = %user_id,
+            event_type = %event_type,
+            "failed to persist notification audit event: {err}"
+        );
+    }
+}
+
+fn resolve_notification_content(job: &ClaimedJob) -> NotificationContent {
+    if let Some(payload) = parse_notification_payload(job.payload_ciphertext.as_deref()) {
+        let title = payload.title.trim();
+        let body = payload.body.trim();
+
+        if !title.is_empty() && !body.is_empty() {
+            return NotificationContent {
+                title: title.to_string(),
+                body: body.to_string(),
+            };
+        }
+    }
+
+    match job.job_type {
+        JobType::MeetingReminder => NotificationContent {
+            title: "Meeting reminder".to_string(),
+            body: "You have a meeting coming up soon.".to_string(),
+        },
+        JobType::MorningBrief => NotificationContent {
+            title: "Morning brief".to_string(),
+            body: "Your Alfred morning brief is ready.".to_string(),
+        },
+        JobType::UrgentEmailCheck => NotificationContent {
+            title: "Urgent email alert".to_string(),
+            body: "Alfred detected an urgent email that needs attention.".to_string(),
+        },
+    }
+}
+
+fn parse_notification_payload(payload: Option<&[u8]>) -> Option<NotificationPayloadBody> {
+    let payload = payload?;
+    let parsed: NotificationJobPayload = serde_json::from_slice(payload).ok()?;
+    parsed.notification
 }
 
 fn parse_simulated_failure(payload: Option<&[u8]>) -> Option<JobExecutionError> {
@@ -363,6 +748,40 @@ fn parse_simulated_failure(payload: Option<&[u8]>) -> Option<JobExecutionError> 
     }
 }
 
+fn apns_environment_label(environment: &ApnsEnvironment) -> &'static str {
+    match environment {
+        ApnsEnvironment::Sandbox => "sandbox",
+        ApnsEnvironment::Production => "production",
+    }
+}
+
+fn is_within_quiet_hours(now: NaiveTime, start: &str, end: &str) -> Result<bool, String> {
+    let start = parse_hhmm(start)?;
+    let end = parse_hhmm(end)?;
+
+    if start == end {
+        return Ok(true);
+    }
+
+    if start < end {
+        Ok(now >= start && now < end)
+    } else {
+        Ok(now >= start || now < end)
+    }
+}
+
+fn parse_hhmm(value: &str) -> Result<NaiveTime, String> {
+    NaiveTime::parse_from_str(value, "%H:%M")
+        .map_err(|_| format!("time must be in HH:MM format: {value}"))
+}
+
+fn classify_http_failure(status: StatusCode) -> FailureClass {
+    match status.as_u16() {
+        408 | 425 | 429 | 500 | 502 | 503 | 504 => FailureClass::Transient,
+        _ => FailureClass::Permanent,
+    }
+}
+
 fn retry_delay_seconds(base_seconds: u64, max_seconds: u64, attempt: i32) -> u64 {
     if attempt <= 1 {
         return base_seconds.min(max_seconds);
@@ -377,7 +796,10 @@ fn retry_delay_seconds(base_seconds: u64, max_seconds: u64, attempt: i32) -> u64
 
 #[cfg(test)]
 mod tests {
-    use super::retry_delay_seconds;
+    use chrono::NaiveTime;
+    use reqwest::StatusCode;
+
+    use super::{FailureClass, classify_http_failure, is_within_quiet_hours, retry_delay_seconds};
 
     #[test]
     fn retry_backoff_is_exponential_and_capped() {
@@ -385,5 +807,55 @@ mod tests {
         assert_eq!(retry_delay_seconds(30, 900, 2), 60);
         assert_eq!(retry_delay_seconds(30, 900, 3), 120);
         assert_eq!(retry_delay_seconds(30, 900, 10), 900);
+    }
+
+    #[test]
+    fn quiet_hours_supports_wrapped_ranges() {
+        let before_midnight = NaiveTime::from_hms_opt(23, 15, 0).expect("valid time");
+        let after_midnight = NaiveTime::from_hms_opt(6, 45, 0).expect("valid time");
+        let outside = NaiveTime::from_hms_opt(14, 0, 0).expect("valid time");
+
+        assert!(is_within_quiet_hours(before_midnight, "22:00", "07:00").expect("valid range"));
+        assert!(is_within_quiet_hours(after_midnight, "22:00", "07:00").expect("valid range"));
+        assert!(!is_within_quiet_hours(outside, "22:00", "07:00").expect("valid range"));
+    }
+
+    #[test]
+    fn quiet_hours_supports_non_wrapped_ranges() {
+        let in_range = NaiveTime::from_hms_opt(13, 0, 0).expect("valid time");
+        let out_of_range = NaiveTime::from_hms_opt(17, 0, 0).expect("valid time");
+
+        assert!(is_within_quiet_hours(in_range, "12:00", "14:00").expect("valid range"));
+        assert!(!is_within_quiet_hours(out_of_range, "12:00", "14:00").expect("valid range"));
+    }
+
+    #[test]
+    fn quiet_hours_with_equal_bounds_suppresses_all_day() {
+        let now = NaiveTime::from_hms_opt(9, 30, 0).expect("valid time");
+        assert!(is_within_quiet_hours(now, "08:00", "08:00").expect("valid range"));
+    }
+
+    #[test]
+    fn classifies_retryable_http_status_codes_as_transient() {
+        assert!(matches!(
+            classify_http_failure(StatusCode::TOO_MANY_REQUESTS),
+            FailureClass::Transient
+        ));
+        assert!(matches!(
+            classify_http_failure(StatusCode::SERVICE_UNAVAILABLE),
+            FailureClass::Transient
+        ));
+    }
+
+    #[test]
+    fn classifies_client_errors_as_permanent() {
+        assert!(matches!(
+            classify_http_failure(StatusCode::BAD_REQUEST),
+            FailureClass::Permanent
+        ));
+        assert!(matches!(
+            classify_http_failure(StatusCode::GONE),
+            FailureClass::Permanent
+        ));
     }
 }


### PR DESCRIPTION
## Summary
Implements issue #5 APNs delivery pipeline work end-to-end: test notification queueing API, worker push delivery abstraction with retry/quiet-hours behavior, redacted notification auditing, and aligned API/client contracts. Also updates `just ios-test` default simulator from iPhone 16 to iPhone 17.

## Changes
- Added `POST /v1/devices/apns/test` to queue authenticated test notification jobs.
- Added shared repo methods to check/list/decrypt registered APNs devices for worker delivery.
- Implemented worker push sender path with:
  - per-environment endpoints
  - transient/permanent APNs failure classification
  - quiet-hours suppression
  - push observability counters/logs
  - redacted notification audit events
- Hardened test notification input validation (`title`/`body` length limits).
- Updated OpenAPI + AlfredAPIClient for new test-notification request/response models.
- Updated `Justfile` default `ios-test` destination to `platform=iOS Simulator,name=iPhone 17`.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just backend-verify`
- `just backend-deep-review`
- `just ios-test`

## AI Review Summary

### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: fixed one reliability defect during review (audit-write failure no longer causes retries after successful push sends, preventing duplicate notifications)
- Repro or test evidence: verified via code path review and full validation rerun (`backend-verify`, `backend-deep-review`, `ios-test`)
- Required fixes: none remaining

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no violations (`sqlx` remains in shared repo layer, HTTP logic remains in api-server HTTP module)
- Performance/scalability concerns: no blockers found; push attempt metrics added for operational observability
- Refactor recommendations: none required for merge

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #5
