### PR TITLE
Implement P0-07 privacy delete-all workflow and SLA tracking

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -227,6 +227,30 @@ paths:
                 $ref: "#/components/schemas/DeleteAllResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /v1/privacy/delete-all/{request_id}:
+    get:
+      tags: [Privacy]
+      summary: Get delete-all request status
+      operationId: getDeleteAllStatus
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: request_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Delete request status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteAllStatusResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 components:
   securitySchemes:
     bearerAuth:
@@ -429,6 +453,30 @@ components:
         status:
           type: string
           enum: [QUEUED]
+    DeleteAllStatusResponse:
+      type: object
+      required: [request_id, status, created_at]
+      properties:
+        request_id:
+          type: string
+        status:
+          type: string
+          enum: [QUEUED, RUNNING, COMPLETED, FAILED]
+        created_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        failed_at:
+          type: string
+          format: date-time
+          nullable: true
     OkResponse:
       type: object
       required: [ok]

--- a/backend/crates/api-server/src/http/mod.rs
+++ b/backend/crates/api-server/src/http/mod.rs
@@ -74,6 +74,10 @@ pub fn build_router(app_state: AppState) -> Router {
         )
         .route("/v1/audit-events", get(audit::list_audit_events))
         .route("/v1/privacy/delete-all", post(privacy::delete_all))
+        .route(
+            "/v1/privacy/delete-all/{request_id}",
+            get(privacy::get_delete_all_status),
+        )
         .layer(middleware::from_fn_with_state(
             auth_layer_state,
             authn::auth_middleware,

--- a/backend/crates/api-server/src/http/privacy.rs
+++ b/backend/crates/api-server/src/http/privacy.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
 use axum::Json;
-use axum::extract::{Extension, State};
+use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use shared::models::DeleteAllResponse;
+use shared::models::{DeleteAllResponse, DeleteAllStatusResponse, ErrorBody, ErrorResponse};
 use shared::repos::AuditResult;
+use uuid::Uuid;
 
 use super::errors::store_error_response;
 use super::{AppState, AuthUser};
@@ -41,6 +42,62 @@ pub(super) async fn delete_all(
         Json(DeleteAllResponse {
             request_id: request_id.to_string(),
             status: "QUEUED".to_string(),
+        }),
+    )
+        .into_response()
+}
+
+pub(super) async fn get_delete_all_status(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Path(request_id): Path<String>,
+) -> Response {
+    let request_id = match Uuid::parse_str(&request_id) {
+        Ok(request_id) => request_id,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: ErrorBody {
+                        code: "not_found".to_string(),
+                        message: "Delete request not found".to_string(),
+                    },
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let delete_status = match state
+        .store
+        .get_delete_request_status(user.user_id, request_id)
+        .await
+    {
+        Ok(Some(delete_status)) => delete_status,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: ErrorBody {
+                        code: "not_found".to_string(),
+                        message: "Delete request not found".to_string(),
+                    },
+                }),
+            )
+                .into_response();
+        }
+        Err(err) => return store_error_response(err),
+    };
+
+    (
+        StatusCode::OK,
+        Json(DeleteAllStatusResponse {
+            request_id: delete_status.id.to_string(),
+            status: delete_status.status.as_str().to_string(),
+            created_at: delete_status.created_at,
+            started_at: delete_status.started_at,
+            completed_at: delete_status.completed_at,
+            failed_at: delete_status.failed_at,
         }),
     )
         .into_response()

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -117,6 +117,16 @@ pub struct DeleteAllResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteAllStatusResponse {
+    pub request_id: String,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub failed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OkResponse {
     pub ok: bool,
 }

--- a/backend/crates/shared/src/repos/mod.rs
+++ b/backend/crates/shared/src/repos/mod.rs
@@ -87,6 +87,14 @@ pub struct ConnectorKeyMetadata {
 }
 
 #[derive(Debug, Clone)]
+pub struct ActiveConnectorMetadata {
+    pub connector_id: Uuid,
+    pub provider: String,
+    pub token_key_id: String,
+    pub token_version: i32,
+}
+
+#[derive(Debug, Clone)]
 pub struct ClaimedJob {
     pub id: Uuid,
     pub user_id: Uuid,
@@ -96,6 +104,54 @@ pub struct ClaimedJob {
     pub attempts: i32,
     pub max_attempts: i32,
     pub idempotency_key: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum PrivacyDeleteStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+}
+
+impl PrivacyDeleteStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Queued => "QUEUED",
+            Self::Running => "RUNNING",
+            Self::Completed => "COMPLETED",
+            Self::Failed => "FAILED",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, StoreError> {
+        match value {
+            "QUEUED" => Ok(Self::Queued),
+            "RUNNING" => Ok(Self::Running),
+            "COMPLETED" => Ok(Self::Completed),
+            "FAILED" => Ok(Self::Failed),
+            _ => Err(StoreError::InvalidData(format!(
+                "unknown privacy delete status persisted: {value}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ClaimedDeleteRequest {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrivacyDeleteRequestStatus {
+    pub id: Uuid,
+    pub status: PrivacyDeleteStatus,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub failed_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone)]

--- a/backend/crates/shared/src/repos/privacy.rs
+++ b/backend/crates/shared/src/repos/privacy.rs
@@ -1,10 +1,30 @@
+use chrono::{DateTime, Duration, Utc};
+use sqlx::Row;
 use uuid::Uuid;
 
-use super::{Store, StoreError};
+use super::{
+    ClaimedDeleteRequest, PrivacyDeleteRequestStatus, PrivacyDeleteStatus, Store, StoreError,
+};
 
 impl Store {
     pub async fn queue_delete_all(&self, user_id: Uuid) -> Result<Uuid, StoreError> {
         self.ensure_user(user_id).await?;
+
+        let existing_request_id = sqlx::query_scalar(
+            "SELECT id
+             FROM privacy_delete_requests
+             WHERE user_id = $1
+               AND status IN ('QUEUED', 'RUNNING')
+             ORDER BY created_at ASC, id ASC
+             LIMIT 1",
+        )
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if let Some(existing_request_id) = existing_request_id {
+            return Ok(existing_request_id);
+        }
 
         let request_id: Uuid = sqlx::query_scalar(
             "INSERT INTO privacy_delete_requests (user_id, status)
@@ -16,5 +36,250 @@ impl Store {
         .await?;
 
         Ok(request_id)
+    }
+
+    pub async fn claim_delete_requests(
+        &self,
+        now: DateTime<Utc>,
+        worker_id: Uuid,
+        max_requests: i64,
+        lease_seconds: i64,
+    ) -> Result<Vec<ClaimedDeleteRequest>, StoreError> {
+        if max_requests <= 0 {
+            return Ok(Vec::new());
+        }
+        if lease_seconds <= 0 {
+            return Err(StoreError::InvalidData(
+                "privacy delete lease_seconds must be > 0".to_string(),
+            ));
+        }
+
+        sqlx::query(
+            "UPDATE privacy_delete_requests
+             SET status = 'QUEUED',
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 updated_at = NOW()
+             WHERE status = 'RUNNING'
+               AND lease_expires_at IS NOT NULL
+               AND lease_expires_at <= $1",
+        )
+        .bind(now)
+        .execute(&self.pool)
+        .await?;
+
+        let lease_until = now + Duration::seconds(lease_seconds);
+        let worker_id = worker_id.to_string();
+
+        let rows = sqlx::query(
+            "WITH candidate_ids AS (
+                SELECT id
+                FROM privacy_delete_requests
+                WHERE status = 'QUEUED'
+                ORDER BY created_at ASC, id ASC
+                LIMIT $1
+                FOR UPDATE SKIP LOCKED
+             ),
+             claimed AS (
+                UPDATE privacy_delete_requests p
+                SET status = 'RUNNING',
+                    started_at = COALESCE(p.started_at, $2),
+                    failed_at = NULL,
+                    failure_reason = NULL,
+                    lease_owner = $3,
+                    lease_expires_at = $4,
+                    updated_at = NOW()
+                FROM candidate_ids c
+                WHERE p.id = c.id
+                RETURNING p.id, p.user_id, p.created_at
+             )
+             SELECT id, user_id, created_at
+             FROM claimed
+             ORDER BY created_at ASC, id ASC",
+        )
+        .bind(max_requests)
+        .bind(now)
+        .bind(worker_id)
+        .bind(lease_until)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(ClaimedDeleteRequest {
+                    id: row.try_get("id")?,
+                    user_id: row.try_get("user_id")?,
+                    created_at: row.try_get("created_at")?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn mark_delete_request_completed(
+        &self,
+        request_id: Uuid,
+        worker_id: Uuid,
+        completed_at: DateTime<Utc>,
+    ) -> Result<bool, StoreError> {
+        let result = sqlx::query(
+            "UPDATE privacy_delete_requests
+             SET status = 'COMPLETED',
+                 completed_at = $3,
+                 failed_at = NULL,
+                 failure_reason = NULL,
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 updated_at = NOW()
+             WHERE id = $1
+               AND status = 'RUNNING'
+               AND lease_owner = $2",
+        )
+        .bind(request_id)
+        .bind(worker_id.to_string())
+        .bind(completed_at)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn mark_delete_request_failed(
+        &self,
+        request_id: Uuid,
+        worker_id: Uuid,
+        failed_at: DateTime<Utc>,
+        failure_reason: &str,
+    ) -> Result<bool, StoreError> {
+        let result = sqlx::query(
+            "UPDATE privacy_delete_requests
+             SET status = 'FAILED',
+                 failed_at = $3,
+                 failure_reason = $4,
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 updated_at = NOW()
+             WHERE id = $1
+               AND status = 'RUNNING'
+               AND lease_owner = $2",
+        )
+        .bind(request_id)
+        .bind(worker_id.to_string())
+        .bind(failed_at)
+        .bind(failure_reason)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn get_delete_request_status(
+        &self,
+        user_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<Option<PrivacyDeleteRequestStatus>, StoreError> {
+        let row = sqlx::query(
+            "SELECT id, status, created_at, started_at, completed_at, failed_at
+             FROM privacy_delete_requests
+             WHERE user_id = $1
+               AND id = $2",
+        )
+        .bind(user_id)
+        .bind(request_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(|row| {
+            let status: String = row.try_get("status")?;
+            Ok(PrivacyDeleteRequestStatus {
+                id: row.try_get("id")?,
+                status: PrivacyDeleteStatus::from_db(&status)?,
+                created_at: row.try_get("created_at")?,
+                started_at: row.try_get("started_at")?,
+                completed_at: row.try_get("completed_at")?,
+                failed_at: row.try_get("failed_at")?,
+            })
+        })
+        .transpose()
+    }
+
+    pub async fn count_pending_delete_requests(&self) -> Result<i64, StoreError> {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*)::bigint
+             FROM privacy_delete_requests
+             WHERE status IN ('QUEUED', 'RUNNING')",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count)
+    }
+
+    pub async fn count_delete_requests_sla_overdue(
+        &self,
+        now: DateTime<Utc>,
+        sla_hours: i64,
+    ) -> Result<i64, StoreError> {
+        if sla_hours <= 0 {
+            return Err(StoreError::InvalidData(
+                "privacy delete sla_hours must be > 0".to_string(),
+            ));
+        }
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*)::bigint
+             FROM privacy_delete_requests
+             WHERE status <> 'COMPLETED'
+               AND created_at <= ($1 - ($2::text || ' hours')::interval)",
+        )
+        .bind(now)
+        .bind(sla_hours)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count)
+    }
+
+    pub async fn purge_user_operational_data(&self, user_id: Uuid) -> Result<(), StoreError> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("DELETE FROM audit_events WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM oauth_states WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM auth_sessions WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM connectors WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM devices WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM jobs WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM user_preferences WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "UPDATE users
+             SET status = 'DELETED'
+             WHERE id = $1",
+        )
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
     }
 }

--- a/backend/crates/worker/src/privacy_delete.rs
+++ b/backend/crates/worker/src/privacy_delete.rs
@@ -1,0 +1,299 @@
+use std::collections::HashMap;
+
+use chrono::Utc;
+use shared::config::WorkerConfig;
+use shared::repos::{AuditResult, ClaimedDeleteRequest, Store};
+use shared::security::SecretRuntime;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use crate::privacy_delete_revoke::{DeleteRequestError, revoke_active_connectors};
+
+#[derive(Default)]
+pub(crate) struct PrivacyDeleteTickMetrics {
+    pub claimed_requests: usize,
+    pub completed_requests: usize,
+    pub failed_requests: usize,
+    pub revoked_connectors: usize,
+    pub pending_requests: i64,
+    pub overdue_requests: i64,
+}
+
+pub(crate) async fn process_delete_requests(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    worker_id: Uuid,
+) -> PrivacyDeleteTickMetrics {
+    let now = Utc::now();
+    let claimed_requests = match store
+        .claim_delete_requests(
+            now,
+            worker_id,
+            i64::from(config.privacy_delete_batch_size),
+            i64::try_from(config.privacy_delete_lease_seconds).unwrap_or(i64::MAX),
+        )
+        .await
+    {
+        Ok(claimed_requests) => claimed_requests,
+        Err(err) => {
+            error!(
+                worker_id = %worker_id,
+                "failed to claim privacy delete requests: {err}"
+            );
+            return PrivacyDeleteTickMetrics::default();
+        }
+    };
+
+    let mut metrics = PrivacyDeleteTickMetrics {
+        claimed_requests: claimed_requests.len(),
+        ..PrivacyDeleteTickMetrics::default()
+    };
+
+    for request in claimed_requests {
+        process_claimed_delete_request(
+            store,
+            config,
+            secret_runtime,
+            oauth_client,
+            worker_id,
+            request,
+            &mut metrics,
+        )
+        .await;
+    }
+
+    metrics.pending_requests = store.count_pending_delete_requests().await.unwrap_or(-1);
+    metrics.overdue_requests = store
+        .count_delete_requests_sla_overdue(
+            Utc::now(),
+            i64::try_from(config.privacy_delete_sla_hours).unwrap_or(i64::MAX),
+        )
+        .await
+        .unwrap_or(-1);
+
+    if metrics.overdue_requests > 0 {
+        warn!(
+            worker_id = %worker_id,
+            overdue_requests = metrics.overdue_requests,
+            sla_hours = config.privacy_delete_sla_hours,
+            "privacy delete SLA alert threshold reached"
+        );
+    }
+
+    info!(
+        worker_id = %worker_id,
+        claimed_requests = metrics.claimed_requests,
+        completed_requests = metrics.completed_requests,
+        failed_requests = metrics.failed_requests,
+        revoked_connectors = metrics.revoked_connectors,
+        pending_requests = metrics.pending_requests,
+        overdue_requests = metrics.overdue_requests,
+        "privacy delete tick metrics"
+    );
+
+    metrics
+}
+
+async fn process_claimed_delete_request(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    worker_id: Uuid,
+    request: ClaimedDeleteRequest,
+    metrics: &mut PrivacyDeleteTickMetrics,
+) {
+    match execute_delete_request(store, config, secret_runtime, oauth_client, &request).await {
+        Ok(revoked_connectors) => {
+            let completed_at = Utc::now();
+            match store
+                .mark_delete_request_completed(request.id, worker_id, completed_at)
+                .await
+            {
+                Ok(true) => {
+                    metrics.completed_requests += 1;
+                    metrics.revoked_connectors += revoked_connectors;
+                    record_delete_completion_audit(
+                        store,
+                        request.user_id,
+                        request.id,
+                        completed_at,
+                        revoked_connectors,
+                        config.privacy_delete_sla_hours,
+                    )
+                    .await;
+                }
+                Ok(false) => {
+                    warn!(
+                        worker_id = %worker_id,
+                        request_id = %request.id,
+                        "delete request completion skipped because lease ownership was lost"
+                    );
+                    metrics.failed_requests += 1;
+                }
+                Err(err) => {
+                    error!(
+                        worker_id = %worker_id,
+                        request_id = %request.id,
+                        "failed to mark delete request completed: {err}"
+                    );
+                    metrics.failed_requests += 1;
+                }
+            }
+        }
+        Err(err) => {
+            let failed_at = Utc::now();
+            let failure_reason = format_failure_reason(&err);
+            match store
+                .mark_delete_request_failed(request.id, worker_id, failed_at, &failure_reason)
+                .await
+            {
+                Ok(true) => {
+                    metrics.failed_requests += 1;
+                    record_delete_failure_audit(
+                        store,
+                        request.user_id,
+                        request.id,
+                        failed_at,
+                        &failure_reason,
+                    )
+                    .await;
+                }
+                Ok(false) => {
+                    warn!(
+                        worker_id = %worker_id,
+                        request_id = %request.id,
+                        "delete request failure update skipped because lease ownership was lost"
+                    );
+                    metrics.failed_requests += 1;
+                }
+                Err(store_err) => {
+                    error!(
+                        worker_id = %worker_id,
+                        request_id = %request.id,
+                        "failed to mark delete request failed: {store_err}"
+                    );
+                    metrics.failed_requests += 1;
+                }
+            }
+        }
+    }
+}
+
+async fn execute_delete_request(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    request: &ClaimedDeleteRequest,
+) -> Result<usize, DeleteRequestError> {
+    let active_connectors = store
+        .list_active_connector_metadata(request.user_id)
+        .await
+        .map_err(|err| {
+            DeleteRequestError::new(
+                "CONNECTOR_LOOKUP_FAILED",
+                format!("failed to load connectors: {err}"),
+            )
+        })?;
+
+    let revoked_connectors = revoke_active_connectors(
+        store,
+        config,
+        secret_runtime,
+        oauth_client,
+        request.user_id,
+        active_connectors,
+    )
+    .await?;
+
+    store
+        .purge_user_operational_data(request.user_id)
+        .await
+        .map_err(|err| {
+            DeleteRequestError::new(
+                "PURGE_FAILED",
+                format!("failed to purge user operational data: {err}"),
+            )
+        })?;
+
+    Ok(revoked_connectors)
+}
+
+async fn record_delete_completion_audit(
+    store: &Store,
+    user_id: Uuid,
+    request_id: Uuid,
+    completed_at: chrono::DateTime<Utc>,
+    revoked_connectors: usize,
+    sla_hours: u64,
+) {
+    let mut metadata = HashMap::new();
+    metadata.insert("request_id".to_string(), request_id.to_string());
+    metadata.insert("status".to_string(), "COMPLETED".to_string());
+    metadata.insert("completed_at".to_string(), completed_at.to_rfc3339());
+    metadata.insert(
+        "revoked_connectors".to_string(),
+        revoked_connectors.to_string(),
+    );
+    metadata.insert("sla_hours".to_string(), sla_hours.to_string());
+
+    if let Err(err) = store
+        .add_audit_event(
+            user_id,
+            "PRIVACY_DELETE_ALL_COMPLETED",
+            None,
+            AuditResult::Success,
+            &metadata,
+        )
+        .await
+    {
+        warn!(
+            user_id = %user_id,
+            request_id = %request_id,
+            "failed to persist delete completion audit event: {err}"
+        );
+    }
+}
+
+async fn record_delete_failure_audit(
+    store: &Store,
+    user_id: Uuid,
+    request_id: Uuid,
+    failed_at: chrono::DateTime<Utc>,
+    failure_reason: &str,
+) {
+    let mut metadata = HashMap::new();
+    metadata.insert("request_id".to_string(), request_id.to_string());
+    metadata.insert("status".to_string(), "FAILED".to_string());
+    metadata.insert("failed_at".to_string(), failed_at.to_rfc3339());
+    metadata.insert("reason".to_string(), failure_reason.to_string());
+
+    if let Err(err) = store
+        .add_audit_event(
+            user_id,
+            "PRIVACY_DELETE_ALL_FAILED",
+            None,
+            AuditResult::Failure,
+            &metadata,
+        )
+        .await
+    {
+        warn!(
+            user_id = %user_id,
+            request_id = %request_id,
+            "failed to persist delete failure audit event: {err}"
+        );
+    }
+}
+
+fn format_failure_reason(err: &DeleteRequestError) -> String {
+    let mut reason = format!("{}: {}", err.code, err.message);
+    const MAX_REASON_LEN: usize = 350;
+    if reason.len() > MAX_REASON_LEN {
+        reason.truncate(MAX_REASON_LEN);
+    }
+    reason
+}

--- a/backend/crates/worker/src/privacy_delete_revoke.rs
+++ b/backend/crates/worker/src/privacy_delete_revoke.rs
@@ -1,0 +1,203 @@
+use reqwest::StatusCode;
+use serde::Deserialize;
+use shared::config::WorkerConfig;
+use shared::repos::{ActiveConnectorMetadata, LEGACY_CONNECTOR_TOKEN_KEY_ID, Store};
+use shared::security::{ConnectorKeyMetadata, SecretRuntime};
+use tracing::info;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub(crate) struct DeleteRequestError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl DeleteRequestError {
+    pub(crate) fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+pub(crate) async fn revoke_active_connectors(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    user_id: Uuid,
+    connectors: Vec<ActiveConnectorMetadata>,
+) -> Result<usize, DeleteRequestError> {
+    let mut revoked_count = 0_usize;
+
+    for connector in connectors {
+        revoke_single_connector(
+            store,
+            config,
+            secret_runtime,
+            oauth_client,
+            user_id,
+            connector,
+        )
+        .await?;
+        revoked_count += 1;
+    }
+
+    Ok(revoked_count)
+}
+
+async fn revoke_single_connector(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    user_id: Uuid,
+    connector: ActiveConnectorMetadata,
+) -> Result<(), DeleteRequestError> {
+    if connector.provider != "google" {
+        return Err(DeleteRequestError::new(
+            "UNSUPPORTED_CONNECTOR_PROVIDER",
+            format!("unsupported connector provider: {}", connector.provider),
+        ));
+    }
+
+    let connector = normalize_connector_metadata(store, config, user_id, connector).await?;
+
+    let attested_identity = secret_runtime
+        .authorize_connector_decrypt(&ConnectorKeyMetadata {
+            key_id: connector.token_key_id.clone(),
+            key_version: connector.token_version,
+        })
+        .map_err(|err| {
+            DeleteRequestError::new(
+                "CONNECTOR_DECRYPT_NOT_AUTHORIZED",
+                format!("decrypt authorization failed: {err}"),
+            )
+        })?;
+
+    let refresh_token = store
+        .decrypt_active_connector_refresh_token(
+            user_id,
+            connector.connector_id,
+            &connector.token_key_id,
+            connector.token_version,
+        )
+        .await
+        .map_err(|err| {
+            DeleteRequestError::new(
+                "CONNECTOR_TOKEN_DECRYPT_FAILED",
+                format!("failed to decrypt refresh token: {err}"),
+            )
+        })?
+        .ok_or_else(|| {
+            DeleteRequestError::new(
+                "CONNECTOR_TOKEN_MISSING",
+                "refresh token was unavailable for active connector",
+            )
+        })?;
+
+    revoke_google_token(oauth_client, &config.google_revoke_url, &refresh_token).await?;
+
+    info!(
+        user_id = %user_id,
+        connector_id = %connector.connector_id,
+        attested_measurement = %attested_identity.measurement,
+        "revoked connector token for privacy delete request"
+    );
+
+    Ok(())
+}
+
+async fn normalize_connector_metadata(
+    store: &Store,
+    config: &WorkerConfig,
+    user_id: Uuid,
+    mut connector: ActiveConnectorMetadata,
+) -> Result<ActiveConnectorMetadata, DeleteRequestError> {
+    if connector.token_key_id != LEGACY_CONNECTOR_TOKEN_KEY_ID {
+        return Ok(connector);
+    }
+
+    store
+        .adopt_legacy_connector_token_key_id(
+            user_id,
+            connector.connector_id,
+            &config.kms_key_id,
+            config.kms_key_version,
+        )
+        .await
+        .map_err(|err| {
+            DeleteRequestError::new(
+                "CONNECTOR_KEY_METADATA_UPDATE_FAILED",
+                format!("failed to adopt connector key metadata: {err}"),
+            )
+        })?;
+
+    let refreshed = store
+        .get_active_connector_key_metadata(user_id, connector.connector_id)
+        .await
+        .map_err(|err| {
+            DeleteRequestError::new(
+                "CONNECTOR_KEY_METADATA_READ_FAILED",
+                format!("failed to read connector key metadata: {err}"),
+            )
+        })?
+        .ok_or_else(|| {
+            DeleteRequestError::new(
+                "CONNECTOR_KEY_METADATA_MISSING",
+                "connector key metadata changed during delete workflow",
+            )
+        })?;
+
+    connector.token_key_id = refreshed.token_key_id;
+    connector.token_version = refreshed.token_version;
+
+    Ok(connector)
+}
+
+async fn revoke_google_token(
+    client: &reqwest::Client,
+    revoke_url: &str,
+    refresh_token: &str,
+) -> Result<(), DeleteRequestError> {
+    let response = client
+        .post(revoke_url)
+        .form(&[("token", refresh_token)])
+        .send()
+        .await
+        .map_err(|err| {
+            DeleteRequestError::new(
+                "GOOGLE_REVOKE_UNAVAILABLE",
+                format!("failed to call Google revoke endpoint: {err}"),
+            )
+        })?;
+
+    if response.status().is_success() {
+        return Ok(());
+    }
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+
+    if status == StatusCode::BAD_REQUEST
+        && let Some(parsed) = parse_google_oauth_error(&body)
+        && parsed.error == "invalid_token"
+    {
+        return Ok(());
+    }
+
+    Err(DeleteRequestError::new(
+        "GOOGLE_REVOKE_FAILED",
+        format!("Google revoke endpoint returned HTTP {}", status.as_u16()),
+    ))
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleOAuthErrorResponse {
+    error: String,
+}
+
+fn parse_google_oauth_error(body: &str) -> Option<GoogleOAuthErrorResponse> {
+    serde_json::from_str::<GoogleOAuthErrorResponse>(body).ok()
+}

--- a/db/migrations/0007_privacy_delete_workflow.sql
+++ b/db/migrations/0007_privacy_delete_workflow.sql
@@ -1,0 +1,28 @@
+ALTER TABLE privacy_delete_requests
+ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ NULL;
+
+ALTER TABLE privacy_delete_requests
+ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ NULL;
+
+ALTER TABLE privacy_delete_requests
+ADD COLUMN IF NOT EXISTS failed_at TIMESTAMPTZ NULL;
+
+ALTER TABLE privacy_delete_requests
+ADD COLUMN IF NOT EXISTS lease_owner TEXT NULL;
+
+ALTER TABLE privacy_delete_requests
+ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ NULL;
+
+ALTER TABLE privacy_delete_requests
+ADD COLUMN IF NOT EXISTS failure_reason TEXT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_privacy_delete_requests_status_created
+  ON privacy_delete_requests (status, created_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_privacy_delete_requests_running_lease
+  ON privacy_delete_requests (status, lease_expires_at)
+  WHERE status = 'RUNNING';
+
+CREATE INDEX IF NOT EXISTS idx_privacy_delete_requests_sla
+  ON privacy_delete_requests (created_at ASC)
+  WHERE status <> 'COMPLETED';

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -64,7 +64,7 @@ Ship a private beta where iOS users can:
 | BE-007 | P0 | Implement `/v1/connectors/{id}` revoke + provider-side revoke | BE | 2026-03-05 | DONE | BE-006 | Connector revoke fully works |
 | BE-008 | P0 | Implement `/v1/preferences` persistence | BE | 2026-03-06 | TODO | DB-001 | Read/write preferences backed by DB |
 | BE-009 | P0 | Implement `/v1/audit-events` pagination and filters | BE | 2026-03-10 | TODO | DB-004 | Cursor pagination works |
-| BE-010 | P0 | Implement `/v1/privacy/delete-all` async job trigger | BE | 2026-03-12 | TODO | DB-007 | Delete request queued and trackable |
+| BE-010 | P0 | Implement `/v1/privacy/delete-all` async job trigger | BE | 2026-03-12 | DONE | DB-007 | Delete request queued and trackable |
 | BE-011 | P1 | Add endpoint-level rate limiting | BE | 2026-03-14 | TODO | BE-004 | Rate-limits enforced |
 | BE-012 | P1 | OpenAPI drift check in CI | BE | 2026-03-14 | TODO | BE-004 | CI fails on contract drift |
 
@@ -78,7 +78,7 @@ Ship a private beta where iOS users can:
 | DB-004 | P0 | Add audit_events indexes and query plan checks | BE | 2026-03-01 | TODO | DB-002 | Audit endpoint query < target latency |
 | DB-005 | P0 | Add jobs table locking/lease fields | BE | 2026-03-02 | DONE | DB-002 | Worker-safe leasing possible |
 | DB-006 | P1 | Add dead-letter table for failed jobs | BE | 2026-03-04 | DONE | DB-005 | Failed job archival works |
-| DB-007 | P0 | Add privacy_delete_requests workflow states | BE | 2026-03-05 | TODO | DB-002 | Delete-all flow persists state |
+| DB-007 | P0 | Add privacy_delete_requests workflow states | BE | 2026-03-05 | DONE | DB-002 | Delete-all flow persists state |
 | DB-008 | P1 | Add retention policy job schema support | BE | 2026-03-10 | TODO | DB-004 | Retention window stored/configured |
 | DB-009 | P1 | Migration smoke tests in CI | QA | 2026-03-12 | TODO | DB-002 | CI executes migrations cleanly |
 
@@ -176,7 +176,7 @@ Ship a private beta where iOS users can:
 | GOV-001 | P0 | Data retention matrix by table/event type | SEC | 2026-03-15 | TODO | DB-008 | Retention policy approved |
 | GOV-002 | P0 | Privacy policy draft aligned with real architecture | FOUNDER | 2026-03-20 | TODO | SEC-010 | Legal-review ready draft |
 | GOV-003 | P0 | Terms + connector consent language | FOUNDER | 2026-03-22 | TODO | PROD-005 | Approved UX/legal copy |
-| GOV-004 | P0 | Delete-all SLA monitoring | SEC | 2026-03-25 | TODO | BE-010 | Delete requests tracked vs SLA |
+| GOV-004 | P0 | Delete-all SLA monitoring | SEC | 2026-03-25 | DONE | BE-010 | Delete requests tracked vs SLA |
 | GOV-005 | P1 | Data export workflow (basic) | BE | 2026-03-28 | TODO | DB-002 | Export available for support |
 | GOV-006 | P0 | Incident response plan + notification template | SEC | 2026-04-01 | TODO | OBS-008 | Playbook approved |
 | GOV-007 | P0 | External pentest and remediation complete | SEC | 2026-04-17 | TODO | SEC-011 | No critical unresolved issues |

--- a/docs/privacy-delete-sla-monitoring.md
+++ b/docs/privacy-delete-sla-monitoring.md
@@ -1,0 +1,48 @@
+# Privacy Delete SLA Monitoring
+
+This runbook defines the baseline dashboard and alert for the Phase I delete-all SLA.
+
+## SLA Target
+
+- Privacy delete request completion within `24 hours` of request creation.
+
+## Dashboard Queries
+
+Use `privacy_delete_requests` as the source table.
+
+```sql
+-- Pending and running backlog
+SELECT status, COUNT(*) AS request_count
+FROM privacy_delete_requests
+GROUP BY status
+ORDER BY status;
+```
+
+```sql
+-- SLA breaches (not completed within 24 hours)
+SELECT COUNT(*) AS overdue_requests
+FROM privacy_delete_requests
+WHERE status <> 'COMPLETED'
+  AND created_at <= NOW() - INTERVAL '24 hours';
+```
+
+```sql
+-- End-to-end completion latency distribution
+SELECT
+  DATE_TRUNC('hour', completed_at) AS completed_hour,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (completed_at - created_at))) AS p50_seconds,
+  PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (completed_at - created_at))) AS p95_seconds
+FROM privacy_delete_requests
+WHERE status = 'COMPLETED'
+GROUP BY completed_hour
+ORDER BY completed_hour DESC;
+```
+
+## Alert Rule
+
+- Name: `privacy-delete-sla-breach`
+- Condition: `overdue_requests > 0` for `10 minutes`
+- Severity: high
+- Primary signal:
+  - Worker warning log: `privacy delete SLA alert threshold reached`
+  - Fields: `overdue_requests`, `sla_hours`, `worker_id`


### PR DESCRIPTION
## Summary
Implements issue #7 by completing the end-to-end delete-all workflow with queued requests, worker execution, persisted lifecycle state, auditable completion, and SLA monitoring.

## Changes
- Added migration `db/migrations/0007_privacy_delete_workflow.sql` to extend `privacy_delete_requests` lifecycle fields and indexes.
- Expanded privacy repository workflow for queue dedupe, claim/lease, complete/fail transitions, status lookups, SLA overdue counts, and operational data purge.
- Added worker privacy-delete modules:
  - `backend/crates/worker/src/privacy_delete.rs`
  - `backend/crates/worker/src/privacy_delete_revoke.rs`
- Wired worker tick to process delete requests and emit SLA alert signal when overdue requests exist.
- Added queryable API endpoint `GET /v1/privacy/delete-all/{request_id}` and updated OpenAPI/shared models.
- Added SLA dashboard/alert runbook: `docs/privacy-delete-sla-monitoring.md`.
- Updated Phase I board statuses (`BE-010`, `DB-007`, `GOV-004`) to keep docs aligned.

## Validation
- `just check-tools` ✅
- `just backend-check` ✅
- `just ios-build` ✅
- `just backend-verify` ✅
- `just backend-deep-review` ✅
- `just check-infra-tools` ✅
- `just infra-up` ✅
- `just backend-migrate` (with local `DATABASE_URL`) ✅
- `just backend-migrate-check` ✅
- `just infra-stop` ✅

## AI Review Summary
### 1) Security Audit
- Findings: no findings.
- Risk level: low.
- Required fixes: none.

### 2) Bug Check
- Findings: no findings.
- Repro or test evidence: `just backend-verify`, `just backend-deep-review`, and migration apply/check all pass.
- Required fixes: none.

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no violations; DB logic remains in `backend/crates/shared/src/repos`, HTTP in `backend/crates/api-server/src/http`, worker orchestration split into dedicated modules.
- Performance/scalability concerns: low for current scope; claim-and-lease plus indexes added for privacy delete queue.
- Refactor recommendations: none required for this issue.

### 4) Final Status
- `just backend-deep-review`: pass.
- Merge recommendation: `APPROVE`.

Closes #7
