### PR TITLE
Follow up review: simplify privacy delete SLA interval SQL

### DIFF
--- a/backend/crates/shared/src/repos/privacy.rs
+++ b/backend/crates/shared/src/repos/privacy.rs
@@ -229,7 +229,7 @@ impl Store {
             "SELECT COUNT(*)::bigint
              FROM privacy_delete_requests
              WHERE status <> 'COMPLETED'
-               AND created_at <= ($1 - ($2::text || ' hours')::interval)",
+               AND created_at <= ($1 - ($2 * INTERVAL '1 hour'))",
         )
         .bind(now)
         .bind(sla_hours)


### PR DESCRIPTION
## Summary
Follow-up to review comments after #26. Applies the valid SQL refinement and documents triage for the other comments.

## Review Triage
1. `updated_at` missing in `privacy_delete_requests` migration: **not valid**.
`updated_at` already exists in `/Users/niteshchowdharybalusu/Documents/alfred/db/migrations/0002_core_tables.sql` for `privacy_delete_requests`, and is therefore available before `0007` runs.

2. SLA interval expression style in `/Users/niteshchowdharybalusu/Documents/alfred/backend/crates/shared/src/repos/privacy.rs`: **valid**.
Applied suggested expression using interval multiplication.

3. Config duplication between `ApiConfig` and `WorkerConfig`: **valid observation, not a correctness bug**.
Deferred for a dedicated refactor issue to avoid broad, risky scope in a review-fix patch.

## Change
- Updated SQL in `/Users/niteshchowdharybalusu/Documents/alfred/backend/crates/shared/src/repos/privacy.rs`:
  - from: `($1 - ($2::text || ' hours')::interval)`
  - to: `($1 - ($2 * INTERVAL '1 hour'))`

## Validation
- `just ios-build` ✅
- `just backend-verify` ✅
- `just backend-deep-review` ✅

## AI Review Summary
### 1) Security Audit
- Findings: no findings.
- Risk level: low.
- Required fixes: none.

### 2) Bug Check
- Findings: no findings.
- Repro or test evidence: `just backend-verify` and `just backend-deep-review` pass.
- Required fixes: none.

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no violations.
- Performance/scalability concerns: none introduced.
- Refactor recommendations: keep config deduplication for separate scoped refactor.

### 4) Final Status
- `just backend-deep-review`: pass.
- Merge recommendation: `APPROVE`.
