### PR TITLE
P0-12: Implement real worker actions for meeting reminders morning brief and urgent email alerts

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -152,6 +152,8 @@ backend-worker:
   cd {{backend_dir}} && \
     DATABASE_URL="${DATABASE_URL:-postgres://postgres:postgres@127.0.0.1:5432/alfred}" \
     DATA_ENCRYPTION_KEY="${DATA_ENCRYPTION_KEY:-dev-only-change-me}" \
+    GOOGLE_OAUTH_CLIENT_ID="${GOOGLE_OAUTH_CLIENT_ID:-dev-client-id}" \
+    GOOGLE_OAUTH_CLIENT_SECRET="${GOOGLE_OAUTH_CLIENT_SECRET:-dev-client-secret}" \
     cargo run -p worker
 
 # Run API and worker together in one terminal session.
@@ -167,6 +169,8 @@ dev:
     (cd {{backend_dir}} && \
       DATABASE_URL="${DATABASE_URL:-postgres://postgres:postgres@127.0.0.1:5432/alfred}" \
       DATA_ENCRYPTION_KEY="${DATA_ENCRYPTION_KEY:-dev-only-change-me}" \
+      GOOGLE_OAUTH_CLIENT_ID="${GOOGLE_OAUTH_CLIENT_ID:-dev-client-id}" \
+      GOOGLE_OAUTH_CLIENT_SECRET="${GOOGLE_OAUTH_CLIENT_SECRET:-dev-client-secret}" \
       cargo run -p worker) & \
     wait
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,7 +4,7 @@ API_BIND_ADDR=127.0.0.1:8080
 # Worker
 WORKER_TICK_SECONDS=30
 
-# Planned next step vars (not used by scaffold yet)
+# Shared OAuth vars (used by API + worker job execution)
 # DATABASE_URL=postgres://postgres:postgres@localhost:5432/alfred
 # GOOGLE_OAUTH_CLIENT_ID=replace-me
 # GOOGLE_OAUTH_CLIENT_SECRET=replace-me

--- a/backend/crates/shared/src/config.rs
+++ b/backend/crates/shared/src/config.rs
@@ -42,6 +42,9 @@ pub struct WorkerConfig {
     pub apns_sandbox_endpoint: Option<String>,
     pub apns_production_endpoint: Option<String>,
     pub apns_auth_token: Option<String>,
+    pub google_client_id: String,
+    pub google_client_secret: String,
+    pub google_token_url: String,
     pub google_revoke_url: String,
     pub privacy_delete_batch_size: u32,
     pub privacy_delete_lease_seconds: u64,
@@ -224,6 +227,10 @@ impl WorkerConfig {
             apns_sandbox_endpoint: optional_trimmed_env("APNS_SANDBOX_ENDPOINT"),
             apns_production_endpoint: optional_trimmed_env("APNS_PRODUCTION_ENDPOINT"),
             apns_auth_token: optional_trimmed_env("APNS_AUTH_TOKEN"),
+            google_client_id: require_env("GOOGLE_OAUTH_CLIENT_ID")?,
+            google_client_secret: require_env("GOOGLE_OAUTH_CLIENT_SECRET")?,
+            google_token_url: env::var("GOOGLE_OAUTH_TOKEN_URL")
+                .unwrap_or_else(|_| "https://oauth2.googleapis.com/token".to_string()),
             google_revoke_url: env::var("GOOGLE_OAUTH_REVOKE_URL")
                 .unwrap_or_else(|_| "https://oauth2.googleapis.com/revoke".to_string()),
             privacy_delete_batch_size,

--- a/backend/crates/worker/src/job_actions/google/fetch.rs
+++ b/backend/crates/worker/src/job_actions/google/fetch.rs
@@ -1,0 +1,253 @@
+use chrono::{DateTime, Utc};
+use reqwest::StatusCode;
+use serde::Deserialize;
+
+use crate::{FailureClass, JobExecutionError};
+
+const GOOGLE_CALENDAR_EVENTS_URL: &str =
+    "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+const GOOGLE_GMAIL_MESSAGES_URL: &str = "https://gmail.googleapis.com/gmail/v1/users/me/messages";
+
+pub(super) async fn fetch_calendar_events(
+    oauth_client: &reqwest::Client,
+    access_token: &str,
+    time_min: DateTime<Utc>,
+    time_max: DateTime<Utc>,
+    max_results: usize,
+) -> Result<Vec<GoogleCalendarEvent>, JobExecutionError> {
+    let response = oauth_client
+        .get(GOOGLE_CALENDAR_EVENTS_URL)
+        .bearer_auth(access_token)
+        .query(&[
+            ("singleEvents", "true"),
+            ("orderBy", "startTime"),
+            ("timeMin", &time_min.to_rfc3339()),
+            ("timeMax", &time_max.to_rfc3339()),
+            ("maxResults", &max_results.to_string()),
+        ])
+        .send()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_CALENDAR_UNAVAILABLE",
+                format!("calendar request failed: {err}"),
+            )
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        return Err(classified_http_error(
+            status,
+            "GOOGLE_CALENDAR_FAILED",
+            format!("calendar request failed with HTTP {}", status.as_u16()),
+        ));
+    }
+
+    let payload = response
+        .json::<GoogleCalendarEventsResponse>()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_CALENDAR_PARSE_FAILED",
+                format!("calendar response was invalid: {err}"),
+            )
+        })?;
+
+    Ok(payload.items)
+}
+
+pub(super) async fn fetch_unread_email_count(
+    oauth_client: &reqwest::Client,
+    access_token: &str,
+) -> Result<usize, JobExecutionError> {
+    let response = oauth_client
+        .get(GOOGLE_GMAIL_MESSAGES_URL)
+        .bearer_auth(access_token)
+        .query(&[("q", "is:unread newer_than:1d"), ("maxResults", "1")])
+        .send()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_GMAIL_UNAVAILABLE",
+                format!("gmail request failed: {err}"),
+            )
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        return Err(classified_http_error(
+            status,
+            "GOOGLE_GMAIL_FAILED",
+            format!("gmail request failed with HTTP {}", status.as_u16()),
+        ));
+    }
+
+    let payload = response
+        .json::<GoogleGmailListResponse>()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_GMAIL_PARSE_FAILED",
+                format!("gmail response was invalid: {err}"),
+            )
+        })?;
+
+    Ok(payload.result_size_estimate)
+}
+
+pub(super) async fn fetch_gmail_messages(
+    oauth_client: &reqwest::Client,
+    access_token: &str,
+    query: &str,
+    max_results: usize,
+) -> Result<Vec<GoogleGmailMessageRef>, JobExecutionError> {
+    let response = oauth_client
+        .get(GOOGLE_GMAIL_MESSAGES_URL)
+        .bearer_auth(access_token)
+        .query(&[("q", query), ("maxResults", &max_results.to_string())])
+        .send()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_GMAIL_UNAVAILABLE",
+                format!("gmail request failed: {err}"),
+            )
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        return Err(classified_http_error(
+            status,
+            "GOOGLE_GMAIL_FAILED",
+            format!("gmail request failed with HTTP {}", status.as_u16()),
+        ));
+    }
+
+    let payload = response
+        .json::<GoogleGmailListResponse>()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_GMAIL_PARSE_FAILED",
+                format!("gmail response was invalid: {err}"),
+            )
+        })?;
+
+    Ok(payload.messages)
+}
+
+pub(super) async fn fetch_gmail_message_detail(
+    oauth_client: &reqwest::Client,
+    access_token: &str,
+    message_id: &str,
+) -> Result<GoogleGmailMessageDetail, JobExecutionError> {
+    let url = format!("{GOOGLE_GMAIL_MESSAGES_URL}/{message_id}");
+
+    let response = oauth_client
+        .get(url)
+        .bearer_auth(access_token)
+        .query(&[
+            ("format", "metadata"),
+            ("metadataHeaders", "Subject"),
+            ("metadataHeaders", "From"),
+        ])
+        .send()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_GMAIL_MESSAGE_UNAVAILABLE",
+                format!("gmail message request failed: {err}"),
+            )
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        return Err(classified_http_error(
+            status,
+            "GOOGLE_GMAIL_MESSAGE_FAILED",
+            format!("gmail message request failed with HTTP {}", status.as_u16()),
+        ));
+    }
+
+    response
+        .json::<GoogleGmailMessageDetail>()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_GMAIL_MESSAGE_PARSE_FAILED",
+                format!("gmail message response was invalid: {err}"),
+            )
+        })
+}
+
+pub(super) fn classified_http_error(
+    status: StatusCode,
+    code: &str,
+    message: String,
+) -> JobExecutionError {
+    match classify_http_failure(status) {
+        FailureClass::Transient => JobExecutionError::transient(code, message),
+        FailureClass::Permanent => JobExecutionError::permanent(code, message),
+    }
+}
+
+fn classify_http_failure(status: StatusCode) -> FailureClass {
+    match status.as_u16() {
+        408 | 425 | 429 | 500 | 502 | 503 | 504 => FailureClass::Transient,
+        _ => FailureClass::Permanent,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleCalendarEventsResponse {
+    #[serde(default)]
+    items: Vec<GoogleCalendarEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GoogleCalendarEvent {
+    pub(super) id: Option<String>,
+    pub(super) summary: Option<String>,
+    pub(super) start: Option<GoogleCalendarEventStart>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GoogleCalendarEventStart {
+    #[serde(rename = "dateTime")]
+    pub(super) date_time: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleGmailListResponse {
+    #[serde(default)]
+    messages: Vec<GoogleGmailMessageRef>,
+    #[serde(rename = "resultSizeEstimate", default)]
+    result_size_estimate: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GoogleGmailMessageRef {
+    pub(super) id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GoogleGmailMessageDetail {
+    pub(super) id: String,
+    #[serde(rename = "labelIds", default)]
+    pub(super) label_ids: Vec<String>,
+    #[serde(default)]
+    pub(super) snippet: String,
+    pub(super) payload: Option<GoogleGmailPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GoogleGmailPayload {
+    #[serde(default)]
+    pub(super) headers: Vec<GoogleGmailHeader>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GoogleGmailHeader {
+    pub(super) name: String,
+    pub(super) value: String,
+}

--- a/backend/crates/worker/src/job_actions/google/mod.rs
+++ b/backend/crates/worker/src/job_actions/google/mod.rs
@@ -1,0 +1,203 @@
+use std::collections::HashMap;
+
+use chrono::{Duration as ChronoDuration, Utc};
+use shared::config::WorkerConfig;
+use shared::models::Preferences;
+use shared::repos::{ClaimedJob, JobType, Store};
+use shared::security::SecretRuntime;
+
+use super::JobActionResult;
+use crate::{JobExecutionError, NotificationContent};
+
+mod fetch;
+mod session;
+mod util;
+
+use fetch::{
+    fetch_calendar_events, fetch_gmail_message_detail, fetch_gmail_messages,
+    fetch_unread_email_count,
+};
+use session::build_google_session;
+use util::{classify_urgent_message, first_timed_event, message_header, truncate_for_notification};
+
+pub(super) async fn resolve_job_action(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    job: &ClaimedJob,
+    preferences: &Preferences,
+) -> Result<JobActionResult, JobExecutionError> {
+    let session =
+        build_google_session(store, config, secret_runtime, oauth_client, job.user_id).await?;
+
+    match job.job_type {
+        JobType::MeetingReminder => {
+            build_meeting_reminder(
+                oauth_client,
+                &session.access_token,
+                &session.attested_measurement,
+                preferences.meeting_reminder_minutes,
+            )
+            .await
+        }
+        JobType::MorningBrief => {
+            build_morning_brief(
+                oauth_client,
+                &session.access_token,
+                &session.attested_measurement,
+                preferences,
+            )
+            .await
+        }
+        JobType::UrgentEmailCheck => {
+            build_urgent_email_alert(
+                oauth_client,
+                &session.access_token,
+                &session.attested_measurement,
+            )
+            .await
+        }
+    }
+}
+
+async fn build_meeting_reminder(
+    oauth_client: &reqwest::Client,
+    access_token: &str,
+    attested_measurement: &str,
+    reminder_minutes: u32,
+) -> Result<JobActionResult, JobExecutionError> {
+    let now = Utc::now();
+    let lead_minutes = reminder_minutes.max(1);
+    let time_max = now + ChronoDuration::minutes(i64::from(lead_minutes));
+    let events = fetch_calendar_events(oauth_client, access_token, now, time_max, 5).await?;
+
+    let mut metadata = HashMap::new();
+    metadata.insert("action_source".to_string(), "google_calendar".to_string());
+    metadata.insert("lead_minutes".to_string(), lead_minutes.to_string());
+    metadata.insert("events_found".to_string(), events.len().to_string());
+    metadata.insert(
+        "attested_measurement".to_string(),
+        attested_measurement.to_string(),
+    );
+
+    let Some(event) = first_timed_event(events) else {
+        metadata.insert("reason".to_string(), "no_upcoming_event".to_string());
+        return Ok(JobActionResult {
+            notification: None,
+            metadata,
+        });
+    };
+
+    let minutes_until = (event.start_at - now).num_minutes().max(0);
+    let title = if minutes_until <= 1 {
+        "Meeting now".to_string()
+    } else {
+        format!("Meeting in {minutes_until} min")
+    };
+
+    let event_summary = event
+        .summary
+        .unwrap_or_else(|| "Upcoming meeting".to_string());
+    let body = format!(
+        "{} at {}",
+        truncate_for_notification(&event_summary, 80),
+        event.start_at.format("%H:%M UTC")
+    );
+
+    metadata.insert("selected_event_id".to_string(), event.id);
+
+    Ok(JobActionResult {
+        notification: Some(NotificationContent { title, body }),
+        metadata,
+    })
+}
+
+async fn build_morning_brief(
+    oauth_client: &reqwest::Client,
+    access_token: &str,
+    attested_measurement: &str,
+    preferences: &Preferences,
+) -> Result<JobActionResult, JobExecutionError> {
+    let now = Utc::now();
+    let tomorrow = now + ChronoDuration::hours(24);
+
+    let events = fetch_calendar_events(oauth_client, access_token, now, tomorrow, 10).await?;
+    let unread_count = fetch_unread_email_count(oauth_client, access_token).await?;
+
+    let title = "Morning brief".to_string();
+    let body = format!(
+        "Today: {} upcoming meetings, {} unread emails.",
+        events.len(),
+        unread_count
+    );
+
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "action_source".to_string(),
+        "google_calendar_gmail".to_string(),
+    );
+    metadata.insert("upcoming_events".to_string(), events.len().to_string());
+    metadata.insert("unread_emails".to_string(), unread_count.to_string());
+    metadata.insert(
+        "morning_brief_local_time".to_string(),
+        preferences.morning_brief_local_time.clone(),
+    );
+    metadata.insert(
+        "attested_measurement".to_string(),
+        attested_measurement.to_string(),
+    );
+
+    Ok(JobActionResult {
+        notification: Some(NotificationContent { title, body }),
+        metadata,
+    })
+}
+
+async fn build_urgent_email_alert(
+    oauth_client: &reqwest::Client,
+    access_token: &str,
+    attested_measurement: &str,
+) -> Result<JobActionResult, JobExecutionError> {
+    let messages =
+        fetch_gmail_messages(oauth_client, access_token, "is:unread newer_than:2d", 15).await?;
+
+    let mut metadata = HashMap::new();
+    metadata.insert("action_source".to_string(), "gmail_rule_engine".to_string());
+    metadata.insert("messages_scanned".to_string(), messages.len().to_string());
+    metadata.insert(
+        "attested_measurement".to_string(),
+        attested_measurement.to_string(),
+    );
+
+    for message_ref in messages.into_iter().take(10) {
+        let detail =
+            fetch_gmail_message_detail(oauth_client, access_token, &message_ref.id).await?;
+
+        if let Some(rule_match) = classify_urgent_message(&detail) {
+            let subject = message_header(&detail, "Subject").unwrap_or("Urgent email");
+            let sender = message_header(&detail, "From").unwrap_or("Unknown sender");
+
+            metadata.insert("matched_message_id".to_string(), detail.id.clone());
+            metadata.insert("matched_rule".to_string(), rule_match.to_string());
+
+            return Ok(JobActionResult {
+                notification: Some(NotificationContent {
+                    title: "Urgent email alert".to_string(),
+                    body: format!(
+                        "{}: {}",
+                        truncate_for_notification(sender, 45),
+                        truncate_for_notification(subject, 90)
+                    ),
+                }),
+                metadata,
+            });
+        }
+    }
+
+    metadata.insert("reason".to_string(), "no_urgent_match".to_string());
+    Ok(JobActionResult {
+        notification: None,
+        metadata,
+    })
+}

--- a/backend/crates/worker/src/job_actions/google/session.rs
+++ b/backend/crates/worker/src/job_actions/google/session.rs
@@ -1,0 +1,200 @@
+use reqwest::StatusCode;
+use serde::Deserialize;
+use shared::config::WorkerConfig;
+use shared::repos::{LEGACY_CONNECTOR_TOKEN_KEY_ID, Store};
+use shared::security::{ConnectorKeyMetadata, SecretRuntime};
+
+use super::fetch::classified_http_error;
+use crate::JobExecutionError;
+
+pub(super) struct GoogleSession {
+    pub(super) access_token: String,
+    pub(super) attested_measurement: String,
+}
+
+pub(super) async fn build_google_session(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    user_id: uuid::Uuid,
+) -> Result<GoogleSession, JobExecutionError> {
+    let connector = load_active_google_connector(store, config, user_id).await?;
+
+    let attested_identity = secret_runtime
+        .authorize_connector_decrypt(&ConnectorKeyMetadata {
+            key_id: connector.token_key_id.clone(),
+            key_version: connector.token_version,
+        })
+        .map_err(|err| {
+            JobExecutionError::permanent(
+                "CONNECTOR_DECRYPT_NOT_AUTHORIZED",
+                format!("decrypt authorization failed: {err}"),
+            )
+        })?;
+
+    let refresh_token = store
+        .decrypt_active_connector_refresh_token(
+            user_id,
+            connector.connector_id,
+            &connector.token_key_id,
+            connector.token_version,
+        )
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "CONNECTOR_TOKEN_DECRYPT_FAILED",
+                format!("failed to decrypt refresh token: {err}"),
+            )
+        })?
+        .ok_or_else(|| {
+            JobExecutionError::permanent(
+                "CONNECTOR_TOKEN_MISSING",
+                "refresh token was unavailable for active connector",
+            )
+        })?;
+
+    let access_token = exchange_refresh_token(oauth_client, config, &refresh_token).await?;
+
+    Ok(GoogleSession {
+        access_token,
+        attested_measurement: attested_identity.measurement,
+    })
+}
+
+#[derive(Clone)]
+struct ActiveGoogleConnector {
+    connector_id: uuid::Uuid,
+    token_key_id: String,
+    token_version: i32,
+}
+
+async fn load_active_google_connector(
+    store: &Store,
+    config: &WorkerConfig,
+    user_id: uuid::Uuid,
+) -> Result<ActiveGoogleConnector, JobExecutionError> {
+    let mut connector = store
+        .list_active_connector_metadata(user_id)
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "CONNECTOR_METADATA_READ_FAILED",
+                format!("failed to read connector metadata: {err}"),
+            )
+        })?
+        .into_iter()
+        .find(|item| item.provider == "google")
+        .ok_or_else(|| {
+            JobExecutionError::permanent(
+                "GOOGLE_CONNECTOR_NOT_ACTIVE",
+                "no active Google connector found for user",
+            )
+        })?;
+
+    if connector.token_key_id == LEGACY_CONNECTOR_TOKEN_KEY_ID {
+        store
+            .adopt_legacy_connector_token_key_id(
+                user_id,
+                connector.connector_id,
+                &config.kms_key_id,
+                config.kms_key_version,
+            )
+            .await
+            .map_err(|err| {
+                JobExecutionError::transient(
+                    "CONNECTOR_KEY_METADATA_UPDATE_FAILED",
+                    format!("failed to adopt connector key metadata: {err}"),
+                )
+            })?;
+
+        let refreshed = store
+            .get_active_connector_key_metadata(user_id, connector.connector_id)
+            .await
+            .map_err(|err| {
+                JobExecutionError::transient(
+                    "CONNECTOR_KEY_METADATA_READ_FAILED",
+                    format!("failed to read connector key metadata: {err}"),
+                )
+            })?
+            .ok_or_else(|| {
+                JobExecutionError::permanent(
+                    "CONNECTOR_KEY_METADATA_MISSING",
+                    "connector key metadata changed; retry the job",
+                )
+            })?;
+
+        connector.token_key_id = refreshed.token_key_id;
+        connector.token_version = refreshed.token_version;
+    }
+
+    Ok(ActiveGoogleConnector {
+        connector_id: connector.connector_id,
+        token_key_id: connector.token_key_id,
+        token_version: connector.token_version,
+    })
+}
+
+async fn exchange_refresh_token(
+    oauth_client: &reqwest::Client,
+    config: &WorkerConfig,
+    refresh_token: &str,
+) -> Result<String, JobExecutionError> {
+    let response = oauth_client
+        .post(&config.google_token_url)
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("client_id", config.google_client_id.as_str()),
+            ("client_secret", config.google_client_secret.as_str()),
+            ("refresh_token", refresh_token),
+        ])
+        .send()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_TOKEN_REFRESH_UNAVAILABLE",
+                format!("google token refresh request failed: {err}"),
+            )
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+
+        let mut message = format!("google token refresh failed with HTTP {}", status.as_u16());
+        if status == StatusCode::BAD_REQUEST
+            && let Ok(parsed) = serde_json::from_str::<GoogleOAuthErrorResponse>(&body)
+            && let Some(error) = parsed.error
+        {
+            message = format!("google token refresh rejected: {error}");
+        }
+
+        return Err(classified_http_error(
+            status,
+            "GOOGLE_TOKEN_REFRESH_FAILED",
+            message,
+        ));
+    }
+
+    let payload = response
+        .json::<GoogleRefreshTokenResponse>()
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "GOOGLE_TOKEN_REFRESH_PARSE_FAILED",
+                format!("google token refresh response was invalid: {err}"),
+            )
+        })?;
+
+    Ok(payload.access_token)
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleRefreshTokenResponse {
+    access_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleOAuthErrorResponse {
+    error: Option<String>,
+}

--- a/backend/crates/worker/src/job_actions/google/util.rs
+++ b/backend/crates/worker/src/job_actions/google/util.rs
@@ -1,0 +1,151 @@
+use chrono::{DateTime, Utc};
+
+use super::fetch::{GoogleCalendarEvent, GoogleGmailMessageDetail};
+
+const URGENT_KEYWORDS: &[&str] = &[
+    "urgent",
+    "asap",
+    "immediately",
+    "action required",
+    "deadline",
+    "important",
+];
+
+pub(super) struct TimedCalendarEvent {
+    pub(super) id: String,
+    pub(super) summary: Option<String>,
+    pub(super) start_at: DateTime<Utc>,
+}
+
+pub(super) fn first_timed_event(events: Vec<GoogleCalendarEvent>) -> Option<TimedCalendarEvent> {
+    events.into_iter().find_map(|event| {
+        let start = event.start?.date_time?;
+        let start_at = DateTime::parse_from_rfc3339(&start)
+            .ok()?
+            .with_timezone(&Utc);
+
+        Some(TimedCalendarEvent {
+            id: event.id.unwrap_or_else(|| "unknown".to_string()),
+            summary: event.summary,
+            start_at,
+        })
+    })
+}
+
+pub(super) fn classify_urgent_message(message: &GoogleGmailMessageDetail) -> Option<&'static str> {
+    if message.label_ids.iter().any(|label| label == "IMPORTANT") {
+        return Some("important_label");
+    }
+
+    let subject = message_header(message, "Subject").unwrap_or_default();
+    if contains_urgent_keyword(subject) {
+        return Some("subject_keyword");
+    }
+
+    let sender = message_header(message, "From").unwrap_or_default();
+    if contains_urgent_keyword(sender) {
+        return Some("sender_keyword");
+    }
+
+    if contains_urgent_keyword(&message.snippet) {
+        return Some("snippet_keyword");
+    }
+
+    None
+}
+
+pub(super) fn message_header<'a>(
+    message: &'a GoogleGmailMessageDetail,
+    header_name: &str,
+) -> Option<&'a str> {
+    let payload = message.payload.as_ref()?;
+
+    payload
+        .headers
+        .iter()
+        .find(|header| header.name.eq_ignore_ascii_case(header_name))
+        .map(|header| header.value.trim())
+}
+
+pub(super) fn truncate_for_notification(value: &str, max_chars: usize) -> String {
+    let trimmed = value.trim();
+    let mut out = trimmed.chars().take(max_chars).collect::<String>();
+    if trimmed.chars().count() > max_chars {
+        out.push_str("...");
+    }
+    out
+}
+
+fn contains_urgent_keyword(value: &str) -> bool {
+    let lowered = value.to_ascii_lowercase();
+    URGENT_KEYWORDS
+        .iter()
+        .any(|keyword| lowered.contains(keyword))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_urgent_message, truncate_for_notification};
+    use crate::job_actions::google::fetch::{
+        GoogleGmailHeader, GoogleGmailMessageDetail, GoogleGmailPayload,
+    };
+
+    fn message(
+        subject: &str,
+        from: &str,
+        snippet: &str,
+        labels: &[&str],
+    ) -> GoogleGmailMessageDetail {
+        GoogleGmailMessageDetail {
+            id: "msg-1".to_string(),
+            label_ids: labels.iter().map(|item| (*item).to_string()).collect(),
+            snippet: snippet.to_string(),
+            payload: Some(GoogleGmailPayload {
+                headers: vec![
+                    GoogleGmailHeader {
+                        name: "Subject".to_string(),
+                        value: subject.to_string(),
+                    },
+                    GoogleGmailHeader {
+                        name: "From".to_string(),
+                        value: from.to_string(),
+                    },
+                ],
+            }),
+        }
+    }
+
+    #[test]
+    fn urgent_rule_matches_important_label() {
+        let detail = message(
+            "status update",
+            "team@example.com",
+            "all good",
+            &["IMPORTANT"],
+        );
+        assert_eq!(classify_urgent_message(&detail), Some("important_label"));
+    }
+
+    #[test]
+    fn urgent_rule_matches_subject_keyword() {
+        let detail = message(
+            "Action Required: contract",
+            "team@example.com",
+            "all good",
+            &[],
+        );
+        assert_eq!(classify_urgent_message(&detail), Some("subject_keyword"));
+    }
+
+    #[test]
+    fn urgent_rule_returns_none_for_non_urgent_message() {
+        let detail = message("weekly notes", "team@example.com", "regular summary", &[]);
+        assert_eq!(classify_urgent_message(&detail), None);
+    }
+
+    #[test]
+    fn notification_truncation_appends_ellipsis() {
+        let truncated = truncate_for_notification("abcdefghijklmnop", 5);
+        assert_eq!(truncated, "abcde...");
+    }
+}

--- a/backend/crates/worker/src/job_actions/helpers.rs
+++ b/backend/crates/worker/src/job_actions/helpers.rs
@@ -1,0 +1,121 @@
+use chrono::NaiveTime;
+use serde::Deserialize;
+
+use crate::{JobExecutionError, NotificationContent};
+
+#[derive(Debug, Deserialize)]
+struct NotificationJobPayload {
+    notification: Option<NotificationPayloadBody>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NotificationPayloadBody {
+    title: String,
+    body: String,
+}
+
+pub(super) fn parse_notification_payload(payload: Option<&[u8]>) -> Option<NotificationContent> {
+    let payload = payload?;
+    let parsed: NotificationJobPayload = serde_json::from_slice(payload).ok()?;
+    let notification = parsed.notification?;
+
+    let title = notification.title.trim();
+    let body = notification.body.trim();
+
+    if title.is_empty() || body.is_empty() {
+        return None;
+    }
+
+    Some(NotificationContent {
+        title: title.to_string(),
+        body: body.to_string(),
+    })
+}
+
+pub(super) fn parse_simulated_failure(payload: Option<&[u8]>) -> Option<JobExecutionError> {
+    let payload = payload?;
+    let text = std::str::from_utf8(payload).ok()?;
+
+    let mut parts = text.splitn(4, ':');
+    if parts.next()? != "simulate-failure" {
+        return None;
+    }
+
+    let class = parts.next()?;
+    let code = parts.next()?.trim();
+    let message = parts.next()?.trim();
+
+    match class {
+        "transient" => Some(JobExecutionError::transient(code, message)),
+        "permanent" => Some(JobExecutionError::permanent(code, message)),
+        _ => None,
+    }
+}
+
+pub(super) fn is_within_quiet_hours(
+    now: NaiveTime,
+    start: &str,
+    end: &str,
+) -> Result<bool, String> {
+    let start = parse_hhmm(start)?;
+    let end = parse_hhmm(end)?;
+
+    if start == end {
+        return Ok(true);
+    }
+
+    if start < end {
+        Ok(now >= start && now < end)
+    } else {
+        Ok(now >= start || now < end)
+    }
+}
+
+fn parse_hhmm(value: &str) -> Result<NaiveTime, String> {
+    NaiveTime::parse_from_str(value, "%H:%M")
+        .map_err(|_| format!("time must be in HH:MM format: {value}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveTime;
+
+    use super::{is_within_quiet_hours, parse_simulated_failure};
+
+    #[test]
+    fn quiet_hours_supports_wrapped_ranges() {
+        let before_midnight = NaiveTime::from_hms_opt(23, 15, 0).expect("valid time");
+        let after_midnight = NaiveTime::from_hms_opt(6, 45, 0).expect("valid time");
+        let outside = NaiveTime::from_hms_opt(14, 0, 0).expect("valid time");
+
+        assert!(is_within_quiet_hours(before_midnight, "22:00", "07:00").expect("valid range"));
+        assert!(is_within_quiet_hours(after_midnight, "22:00", "07:00").expect("valid range"));
+        assert!(!is_within_quiet_hours(outside, "22:00", "07:00").expect("valid range"));
+    }
+
+    #[test]
+    fn quiet_hours_supports_non_wrapped_ranges() {
+        let in_range = NaiveTime::from_hms_opt(13, 0, 0).expect("valid time");
+        let out_of_range = NaiveTime::from_hms_opt(17, 0, 0).expect("valid time");
+
+        assert!(is_within_quiet_hours(in_range, "12:00", "14:00").expect("valid range"));
+        assert!(!is_within_quiet_hours(out_of_range, "12:00", "14:00").expect("valid range"));
+    }
+
+    #[test]
+    fn quiet_hours_with_equal_bounds_suppresses_all_day() {
+        let now = NaiveTime::from_hms_opt(9, 30, 0).expect("valid time");
+        assert!(is_within_quiet_hours(now, "08:00", "08:00").expect("valid range"));
+    }
+
+    #[test]
+    fn simulated_failures_are_parsed() {
+        let transient = parse_simulated_failure(Some(b"simulate-failure:transient:TEMP:retry"))
+            .expect("transient error");
+        assert_eq!(transient.code, "TEMP");
+
+        let permanent = parse_simulated_failure(Some(b"simulate-failure:permanent:FATAL:stop"))
+            .expect("permanent error");
+        assert_eq!(permanent.code, "FATAL");
+    }
+}

--- a/backend/crates/worker/src/job_actions/mod.rs
+++ b/backend/crates/worker/src/job_actions/mod.rs
@@ -1,0 +1,287 @@
+use std::collections::HashMap;
+
+use chrono::Utc;
+use shared::config::WorkerConfig;
+use shared::repos::{AuditResult, ClaimedJob, Store};
+use shared::security::SecretRuntime;
+use tracing::{info, warn};
+
+use crate::{
+    FailureClass, JobExecutionError, NotificationContent, PushSendError, PushSender,
+    WorkerTickMetrics, apns_environment_label,
+};
+
+mod google;
+mod helpers;
+
+struct JobActionResult {
+    notification: Option<NotificationContent>,
+    metadata: HashMap<String, String>,
+}
+
+pub(super) async fn dispatch_job_action(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    push_sender: &PushSender,
+    job: &ClaimedJob,
+    metrics: &mut WorkerTickMetrics,
+) -> Result<(), JobExecutionError> {
+    if let Some(simulated_failure) =
+        helpers::parse_simulated_failure(job.payload_ciphertext.as_deref())
+    {
+        return Err(simulated_failure);
+    }
+
+    let preferences = store
+        .get_or_create_preferences(job.user_id)
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "PREFERENCES_READ_FAILED",
+                format!("failed to read user preferences: {err}"),
+            )
+        })?;
+
+    let mut action = if let Some(content) =
+        helpers::parse_notification_payload(job.payload_ciphertext.as_deref())
+    {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "action_source".to_string(),
+            "payload_notification".to_string(),
+        );
+        JobActionResult {
+            notification: Some(content),
+            metadata,
+        }
+    } else {
+        google::resolve_job_action(
+            store,
+            config,
+            secret_runtime,
+            oauth_client,
+            job,
+            &preferences,
+        )
+        .await?
+    };
+
+    action
+        .metadata
+        .insert("job_id".to_string(), job.id.to_string());
+    action
+        .metadata
+        .insert("job_type".to_string(), job.job_type.as_str().to_string());
+
+    let Some(content) = action.notification.as_ref() else {
+        let mut metadata = action.metadata.clone();
+        metadata.insert("outcome".to_string(), "no_notification".to_string());
+
+        record_notification_audit(
+            store,
+            job.user_id,
+            "JOB_ACTION_SKIPPED",
+            AuditResult::Success,
+            metadata,
+        )
+        .await;
+
+        return Ok(());
+    };
+
+    if helpers::is_within_quiet_hours(
+        Utc::now().time(),
+        &preferences.quiet_hours_start,
+        &preferences.quiet_hours_end,
+    )
+    .map_err(|message| JobExecutionError::permanent("INVALID_QUIET_HOURS", message))?
+    {
+        metrics.push_quiet_hours_suppressed += 1;
+
+        let mut metadata = action.metadata.clone();
+        metadata.insert("reason".to_string(), "quiet_hours".to_string());
+        metadata.insert(
+            "quiet_hours_start".to_string(),
+            preferences.quiet_hours_start.clone(),
+        );
+        metadata.insert(
+            "quiet_hours_end".to_string(),
+            preferences.quiet_hours_end.clone(),
+        );
+
+        record_notification_audit(
+            store,
+            job.user_id,
+            "NOTIFICATION_SUPPRESSED",
+            AuditResult::Success,
+            metadata,
+        )
+        .await;
+
+        info!(
+            job_id = %job.id,
+            user_id = %job.user_id,
+            quiet_hours_start = %preferences.quiet_hours_start,
+            quiet_hours_end = %preferences.quiet_hours_end,
+            "notification suppressed by quiet hours"
+        );
+
+        return Ok(());
+    }
+
+    record_notification_audit(
+        store,
+        job.user_id,
+        "JOB_ACTION_GENERATED",
+        AuditResult::Success,
+        action.metadata.clone(),
+    )
+    .await;
+
+    send_notification_to_devices(store, push_sender, job, content, &action.metadata, metrics).await
+}
+
+async fn send_notification_to_devices(
+    store: &Store,
+    push_sender: &PushSender,
+    job: &ClaimedJob,
+    content: &NotificationContent,
+    metadata_base: &HashMap<String, String>,
+    metrics: &mut WorkerTickMetrics,
+) -> Result<(), JobExecutionError> {
+    let devices = store
+        .list_registered_devices(job.user_id)
+        .await
+        .map_err(|err| {
+            JobExecutionError::transient(
+                "DEVICE_LOOKUP_FAILED",
+                format!("failed to fetch registered devices: {err}"),
+            )
+        })?;
+
+    if devices.is_empty() {
+        return Err(JobExecutionError::permanent(
+            "NO_REGISTERED_DEVICE",
+            "no APNs device registered for user",
+        ));
+    }
+
+    let mut delivered = 0_usize;
+    let mut first_transient_error: Option<JobExecutionError> = None;
+    let mut first_permanent_error: Option<JobExecutionError> = None;
+
+    for device in &devices {
+        metrics.push_attempts += 1;
+
+        match push_sender.send(device, content).await {
+            Ok(()) => {
+                delivered += 1;
+                metrics.push_delivered += 1;
+
+                let mut metadata = metadata_base.clone();
+                metadata.insert("device_id".to_string(), device.device_id.clone());
+                metadata.insert(
+                    "environment".to_string(),
+                    apns_environment_label(&device.environment).to_string(),
+                );
+                metadata.insert("outcome".to_string(), "delivered".to_string());
+
+                record_notification_audit(
+                    store,
+                    job.user_id,
+                    "NOTIFICATION_DELIVERY_ATTEMPT",
+                    AuditResult::Success,
+                    metadata,
+                )
+                .await;
+            }
+            Err(err) => {
+                let (error_code, error_message, class) = match &err {
+                    PushSendError::Transient { code, message } => {
+                        metrics.push_transient_failures += 1;
+                        (code.clone(), message.clone(), FailureClass::Transient)
+                    }
+                    PushSendError::Permanent { code, message } => {
+                        metrics.push_permanent_failures += 1;
+                        (code.clone(), message.clone(), FailureClass::Permanent)
+                    }
+                };
+
+                let mut metadata = metadata_base.clone();
+                metadata.insert("device_id".to_string(), device.device_id.clone());
+                metadata.insert(
+                    "environment".to_string(),
+                    apns_environment_label(&device.environment).to_string(),
+                );
+                metadata.insert("outcome".to_string(), "failed".to_string());
+                metadata.insert("error_code".to_string(), error_code.clone());
+
+                record_notification_audit(
+                    store,
+                    job.user_id,
+                    "NOTIFICATION_DELIVERY_ATTEMPT",
+                    AuditResult::Failure,
+                    metadata,
+                )
+                .await;
+
+                match class {
+                    FailureClass::Transient if first_transient_error.is_none() => {
+                        first_transient_error = Some(err.to_job_error())
+                    }
+                    FailureClass::Permanent if first_permanent_error.is_none() => {
+                        first_permanent_error = Some(err.to_job_error())
+                    }
+                    _ => {}
+                }
+
+                warn!(
+                    job_id = %job.id,
+                    user_id = %job.user_id,
+                    device_id = %device.device_id,
+                    error_code = %error_code,
+                    error_message = %error_message,
+                    "push delivery attempt failed"
+                );
+            }
+        }
+    }
+
+    if delivered > 0 {
+        return Ok(());
+    }
+
+    if let Some(err) = first_transient_error {
+        return Err(err);
+    }
+
+    if let Some(err) = first_permanent_error {
+        return Err(err);
+    }
+
+    Err(JobExecutionError::permanent(
+        "PUSH_DELIVERY_FAILED",
+        "push delivery failed without a classified error",
+    ))
+}
+
+async fn record_notification_audit(
+    store: &Store,
+    user_id: uuid::Uuid,
+    event_type: &str,
+    result: AuditResult,
+    metadata: HashMap<String, String>,
+) {
+    if let Err(err) = store
+        .add_audit_event(user_id, event_type, None, result, &metadata)
+        .await
+    {
+        warn!(
+            user_id = %user_id,
+            event_type = %event_type,
+            "failed to persist notification audit event: {err}"
+        );
+    }
+}

--- a/backend/crates/worker/src/main.rs
+++ b/backend/crates/worker/src/main.rs
@@ -1,17 +1,16 @@
-use std::collections::HashMap;
-
-use chrono::{DateTime, Duration as ChronoDuration, NaiveTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use shared::config::WorkerConfig;
 use shared::models::ApnsEnvironment;
-use shared::repos::{AuditResult, ClaimedJob, DeviceRegistration, JobType, Store};
+use shared::repos::{ClaimedJob, DeviceRegistration, Store};
 use shared::security::{KmsDecryptPolicy, SecretRuntime, TeeAttestationPolicy};
 use tokio::signal;
 use tokio::time::{self, Duration};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
+mod job_actions;
 mod privacy_delete;
 mod privacy_delete_revoke;
 
@@ -120,15 +119,12 @@ struct NotificationContent {
     body: String,
 }
 
-#[derive(Debug, Deserialize)]
-struct NotificationJobPayload {
-    notification: Option<NotificationPayloadBody>,
-}
-
-#[derive(Debug, Deserialize)]
-struct NotificationPayloadBody {
-    title: String,
-    body: String,
+struct JobRuntime<'a> {
+    store: &'a Store,
+    config: &'a WorkerConfig,
+    secret_runtime: &'a SecretRuntime,
+    oauth_client: &'a reqwest::Client,
+    push_sender: &'a PushSender,
 }
 
 #[derive(Debug, Serialize)]
@@ -218,7 +214,15 @@ async fn main() {
                     &oauth_client,
                     worker_id,
                 ).await;
-                process_due_jobs(&store, &config, &push_sender, worker_id).await;
+                process_due_jobs(
+                    &store,
+                    &config,
+                    &secret_runtime,
+                    &oauth_client,
+                    &push_sender,
+                    worker_id,
+                )
+                .await;
             }
         }
     }
@@ -299,17 +303,28 @@ impl PushSender {
 async fn process_due_jobs(
     store: &Store,
     config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
     push_sender: &PushSender,
     worker_id: Uuid,
 ) {
+    let runtime = JobRuntime {
+        store,
+        config,
+        secret_runtime,
+        oauth_client,
+        push_sender,
+    };
+
     let now = Utc::now();
-    let claimed_jobs = match store
+    let claimed_jobs = match runtime
+        .store
         .claim_due_jobs(
             now,
             worker_id,
-            i64::from(config.batch_size),
-            i64::try_from(config.lease_seconds).unwrap_or(i64::MAX),
-            i32::try_from(config.per_user_concurrency_limit).unwrap_or(i32::MAX),
+            i64::from(runtime.config.batch_size),
+            i64::try_from(runtime.config.lease_seconds).unwrap_or(i64::MAX),
+            i32::try_from(runtime.config.per_user_concurrency_limit).unwrap_or(i32::MAX),
         )
         .await
     {
@@ -327,10 +342,10 @@ async fn process_due_jobs(
 
     for job in claimed_jobs {
         metrics.record_lag(job.due_at, now);
-        process_claimed_job(store, config, push_sender, worker_id, job, &mut metrics).await;
+        process_claimed_job(&runtime, worker_id, job, &mut metrics).await;
     }
 
-    let due_count = store.count_due_jobs(Utc::now()).await.unwrap_or(-1);
+    let due_count = runtime.store.count_due_jobs(Utc::now()).await.unwrap_or(-1);
 
     info!(
         worker_id = %worker_id,
@@ -354,17 +369,15 @@ async fn process_due_jobs(
 }
 
 async fn process_claimed_job(
-    store: &Store,
-    config: &WorkerConfig,
-    push_sender: &PushSender,
+    runtime: &JobRuntime<'_>,
     worker_id: Uuid,
     job: ClaimedJob,
     metrics: &mut WorkerTickMetrics,
 ) {
     metrics.processed_jobs += 1;
 
-    match execute_job(store, push_sender, &job, metrics).await {
-        Ok(()) => match store.mark_job_done(job.id, worker_id).await {
+    match execute_job(runtime, &job, metrics).await {
+        Ok(()) => match runtime.store.mark_job_done(job.id, worker_id).await {
             Ok(true) => {
                 metrics.successful_jobs += 1;
             }
@@ -392,14 +405,15 @@ async fn process_claimed_job(
 
             if can_retry {
                 let delay_seconds = retry_delay_seconds(
-                    config.retry_base_delay_seconds,
-                    config.retry_max_delay_seconds,
+                    runtime.config.retry_base_delay_seconds,
+                    runtime.config.retry_max_delay_seconds,
                     next_attempt,
                 );
                 let next_due_at = Utc::now()
                     + ChronoDuration::seconds(i64::try_from(delay_seconds).unwrap_or(i64::MAX));
 
-                match store
+                match runtime
+                    .store
                     .schedule_job_retry(
                         job.id,
                         worker_id,
@@ -439,7 +453,8 @@ async fn process_claimed_job(
                     }
                 }
             } else {
-                match store
+                match runtime
+                    .store
                     .mark_job_failed(&job, worker_id, next_attempt, &err.code, &err.message)
                     .await
                 {
@@ -477,12 +492,12 @@ async fn process_claimed_job(
 }
 
 async fn execute_job(
-    store: &Store,
-    push_sender: &PushSender,
+    runtime: &JobRuntime<'_>,
     job: &ClaimedJob,
     metrics: &mut WorkerTickMetrics,
 ) -> Result<(), JobExecutionError> {
-    let has_action_lease = store
+    let has_action_lease = runtime
+        .store
         .record_outbound_action_idempotency(job.user_id, &job.idempotency_key, job.id)
         .await
         .map_err(|err| {
@@ -502,8 +517,19 @@ async fn execute_job(
         return Ok(());
     }
 
-    if let Err(err) = dispatch_job_action(store, push_sender, job, metrics).await {
-        if let Err(release_err) = store
+    if let Err(err) = job_actions::dispatch_job_action(
+        runtime.store,
+        runtime.config,
+        runtime.secret_runtime,
+        runtime.oauth_client,
+        runtime.push_sender,
+        job,
+        metrics,
+    )
+    .await
+    {
+        if let Err(release_err) = runtime
+            .store
             .release_outbound_action_idempotency(job.user_id, &job.idempotency_key, job.id)
             .await
         {
@@ -519,289 +545,11 @@ async fn execute_job(
     Ok(())
 }
 
-async fn dispatch_job_action(
-    store: &Store,
-    push_sender: &PushSender,
-    job: &ClaimedJob,
-    metrics: &mut WorkerTickMetrics,
-) -> Result<(), JobExecutionError> {
-    if let Some(simulated_failure) = parse_simulated_failure(job.payload_ciphertext.as_deref()) {
-        return Err(simulated_failure);
-    }
-
-    let content = resolve_notification_content(job);
-
-    let preferences = store
-        .get_or_create_preferences(job.user_id)
-        .await
-        .map_err(|err| {
-            JobExecutionError::transient(
-                "PREFERENCES_READ_FAILED",
-                format!("failed to read user preferences: {err}"),
-            )
-        })?;
-
-    if is_within_quiet_hours(
-        Utc::now().time(),
-        &preferences.quiet_hours_start,
-        &preferences.quiet_hours_end,
-    )
-    .map_err(|message| JobExecutionError::permanent("INVALID_QUIET_HOURS", message))?
-    {
-        metrics.push_quiet_hours_suppressed += 1;
-
-        let mut metadata = HashMap::new();
-        metadata.insert("job_id".to_string(), job.id.to_string());
-        metadata.insert("job_type".to_string(), job.job_type.as_str().to_string());
-        metadata.insert("reason".to_string(), "quiet_hours".to_string());
-        metadata.insert(
-            "quiet_hours_start".to_string(),
-            preferences.quiet_hours_start.clone(),
-        );
-        metadata.insert(
-            "quiet_hours_end".to_string(),
-            preferences.quiet_hours_end.clone(),
-        );
-
-        record_notification_audit(
-            store,
-            job.user_id,
-            "NOTIFICATION_SUPPRESSED",
-            AuditResult::Success,
-            metadata,
-        )
-        .await;
-
-        info!(
-            job_id = %job.id,
-            user_id = %job.user_id,
-            quiet_hours_start = %preferences.quiet_hours_start,
-            quiet_hours_end = %preferences.quiet_hours_end,
-            "notification suppressed by quiet hours"
-        );
-
-        return Ok(());
-    }
-
-    let devices = store
-        .list_registered_devices(job.user_id)
-        .await
-        .map_err(|err| {
-            JobExecutionError::transient(
-                "DEVICE_LOOKUP_FAILED",
-                format!("failed to fetch registered devices: {err}"),
-            )
-        })?;
-
-    if devices.is_empty() {
-        return Err(JobExecutionError::permanent(
-            "NO_REGISTERED_DEVICE",
-            "no APNs device registered for user",
-        ));
-    }
-
-    let mut delivered = 0_usize;
-    let mut first_transient_error: Option<JobExecutionError> = None;
-    let mut first_permanent_error: Option<JobExecutionError> = None;
-
-    for device in &devices {
-        metrics.push_attempts += 1;
-
-        match push_sender.send(device, &content).await {
-            Ok(()) => {
-                delivered += 1;
-                metrics.push_delivered += 1;
-
-                let mut metadata = HashMap::new();
-                metadata.insert("job_id".to_string(), job.id.to_string());
-                metadata.insert("job_type".to_string(), job.job_type.as_str().to_string());
-                metadata.insert("device_id".to_string(), device.device_id.clone());
-                metadata.insert(
-                    "environment".to_string(),
-                    apns_environment_label(&device.environment).to_string(),
-                );
-                metadata.insert("outcome".to_string(), "delivered".to_string());
-
-                record_notification_audit(
-                    store,
-                    job.user_id,
-                    "NOTIFICATION_DELIVERY_ATTEMPT",
-                    AuditResult::Success,
-                    metadata,
-                )
-                .await;
-            }
-            Err(err) => {
-                let (error_code, error_message, class) = match &err {
-                    PushSendError::Transient { code, message } => {
-                        metrics.push_transient_failures += 1;
-                        (code.clone(), message.clone(), FailureClass::Transient)
-                    }
-                    PushSendError::Permanent { code, message } => {
-                        metrics.push_permanent_failures += 1;
-                        (code.clone(), message.clone(), FailureClass::Permanent)
-                    }
-                };
-
-                let mut metadata = HashMap::new();
-                metadata.insert("job_id".to_string(), job.id.to_string());
-                metadata.insert("job_type".to_string(), job.job_type.as_str().to_string());
-                metadata.insert("device_id".to_string(), device.device_id.clone());
-                metadata.insert(
-                    "environment".to_string(),
-                    apns_environment_label(&device.environment).to_string(),
-                );
-                metadata.insert("outcome".to_string(), "failed".to_string());
-                metadata.insert("error_code".to_string(), error_code.clone());
-
-                record_notification_audit(
-                    store,
-                    job.user_id,
-                    "NOTIFICATION_DELIVERY_ATTEMPT",
-                    AuditResult::Failure,
-                    metadata,
-                )
-                .await;
-
-                match class {
-                    FailureClass::Transient if first_transient_error.is_none() => {
-                        first_transient_error = Some(err.to_job_error())
-                    }
-                    FailureClass::Permanent if first_permanent_error.is_none() => {
-                        first_permanent_error = Some(err.to_job_error())
-                    }
-                    _ => {}
-                }
-
-                warn!(
-                    job_id = %job.id,
-                    user_id = %job.user_id,
-                    device_id = %device.device_id,
-                    error_code = %error_code,
-                    error_message = %error_message,
-                    "push delivery attempt failed"
-                );
-            }
-        }
-    }
-
-    if delivered > 0 {
-        return Ok(());
-    }
-
-    if let Some(err) = first_transient_error {
-        return Err(err);
-    }
-
-    if let Some(err) = first_permanent_error {
-        return Err(err);
-    }
-
-    Err(JobExecutionError::permanent(
-        "PUSH_DELIVERY_FAILED",
-        "push delivery failed without a classified error",
-    ))
-}
-
-async fn record_notification_audit(
-    store: &Store,
-    user_id: Uuid,
-    event_type: &str,
-    result: AuditResult,
-    metadata: HashMap<String, String>,
-) {
-    if let Err(err) = store
-        .add_audit_event(user_id, event_type, None, result, &metadata)
-        .await
-    {
-        warn!(
-            user_id = %user_id,
-            event_type = %event_type,
-            "failed to persist notification audit event: {err}"
-        );
-    }
-}
-
-fn resolve_notification_content(job: &ClaimedJob) -> NotificationContent {
-    if let Some(payload) = parse_notification_payload(job.payload_ciphertext.as_deref()) {
-        let title = payload.title.trim();
-        let body = payload.body.trim();
-
-        if !title.is_empty() && !body.is_empty() {
-            return NotificationContent {
-                title: title.to_string(),
-                body: body.to_string(),
-            };
-        }
-    }
-
-    match job.job_type {
-        JobType::MeetingReminder => NotificationContent {
-            title: "Meeting reminder".to_string(),
-            body: "You have a meeting coming up soon.".to_string(),
-        },
-        JobType::MorningBrief => NotificationContent {
-            title: "Morning brief".to_string(),
-            body: "Your Alfred morning brief is ready.".to_string(),
-        },
-        JobType::UrgentEmailCheck => NotificationContent {
-            title: "Urgent email alert".to_string(),
-            body: "Alfred detected an urgent email that needs attention.".to_string(),
-        },
-    }
-}
-
-fn parse_notification_payload(payload: Option<&[u8]>) -> Option<NotificationPayloadBody> {
-    let payload = payload?;
-    let parsed: NotificationJobPayload = serde_json::from_slice(payload).ok()?;
-    parsed.notification
-}
-
-fn parse_simulated_failure(payload: Option<&[u8]>) -> Option<JobExecutionError> {
-    let payload = payload?;
-    let text = std::str::from_utf8(payload).ok()?;
-
-    let mut parts = text.splitn(4, ':');
-    if parts.next()? != "simulate-failure" {
-        return None;
-    }
-
-    let class = parts.next()?;
-    let code = parts.next()?.trim();
-    let message = parts.next()?.trim();
-
-    match class {
-        "transient" => Some(JobExecutionError::transient(code, message)),
-        "permanent" => Some(JobExecutionError::permanent(code, message)),
-        _ => None,
-    }
-}
-
 fn apns_environment_label(environment: &ApnsEnvironment) -> &'static str {
     match environment {
         ApnsEnvironment::Sandbox => "sandbox",
         ApnsEnvironment::Production => "production",
     }
-}
-
-fn is_within_quiet_hours(now: NaiveTime, start: &str, end: &str) -> Result<bool, String> {
-    let start = parse_hhmm(start)?;
-    let end = parse_hhmm(end)?;
-
-    if start == end {
-        return Ok(true);
-    }
-
-    if start < end {
-        Ok(now >= start && now < end)
-    } else {
-        Ok(now >= start || now < end)
-    }
-}
-
-fn parse_hhmm(value: &str) -> Result<NaiveTime, String> {
-    NaiveTime::parse_from_str(value, "%H:%M")
-        .map_err(|_| format!("time must be in HH:MM format: {value}"))
 }
 
 fn classify_http_failure(status: StatusCode) -> FailureClass {
@@ -825,10 +573,9 @@ fn retry_delay_seconds(base_seconds: u64, max_seconds: u64, attempt: i32) -> u64
 
 #[cfg(test)]
 mod tests {
-    use chrono::NaiveTime;
     use reqwest::StatusCode;
 
-    use super::{FailureClass, classify_http_failure, is_within_quiet_hours, retry_delay_seconds};
+    use super::{FailureClass, classify_http_failure, retry_delay_seconds};
 
     #[test]
     fn retry_backoff_is_exponential_and_capped() {
@@ -836,32 +583,6 @@ mod tests {
         assert_eq!(retry_delay_seconds(30, 900, 2), 60);
         assert_eq!(retry_delay_seconds(30, 900, 3), 120);
         assert_eq!(retry_delay_seconds(30, 900, 10), 900);
-    }
-
-    #[test]
-    fn quiet_hours_supports_wrapped_ranges() {
-        let before_midnight = NaiveTime::from_hms_opt(23, 15, 0).expect("valid time");
-        let after_midnight = NaiveTime::from_hms_opt(6, 45, 0).expect("valid time");
-        let outside = NaiveTime::from_hms_opt(14, 0, 0).expect("valid time");
-
-        assert!(is_within_quiet_hours(before_midnight, "22:00", "07:00").expect("valid range"));
-        assert!(is_within_quiet_hours(after_midnight, "22:00", "07:00").expect("valid range"));
-        assert!(!is_within_quiet_hours(outside, "22:00", "07:00").expect("valid range"));
-    }
-
-    #[test]
-    fn quiet_hours_supports_non_wrapped_ranges() {
-        let in_range = NaiveTime::from_hms_opt(13, 0, 0).expect("valid time");
-        let out_of_range = NaiveTime::from_hms_opt(17, 0, 0).expect("valid time");
-
-        assert!(is_within_quiet_hours(in_range, "12:00", "14:00").expect("valid range"));
-        assert!(!is_within_quiet_hours(out_of_range, "12:00", "14:00").expect("valid range"));
-    }
-
-    #[test]
-    fn quiet_hours_with_equal_bounds_suppresses_all_day() {
-        let now = NaiveTime::from_hms_opt(9, 30, 0).expect("valid time");
-        assert!(is_within_quiet_hours(now, "08:00", "08:00").expect("valid range"));
     }
 
     #[test]

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -106,9 +106,9 @@ Ship a private beta where iOS users can:
 | WRK-001 | P0 | Implement due-job fetch with row leasing | BE | 2026-03-06 | DONE | DB-005 | No duplicate processing on concurrency test |
 | WRK-002 | P0 | Implement retry policy (transient/permanent) | BE | 2026-03-08 | DONE | WRK-001 | Retries respect policy |
 | WRK-003 | P1 | Implement dead-letter writes | BE | 2026-03-09 | DONE | DB-006, WRK-002 | Failed jobs land in DLQ table |
-| WRK-004 | P0 | Implement meeting reminder job | BE | 2026-03-12 | TODO | WRK-001, APNS-001 | Reminder push end-to-end works |
-| WRK-005 | P0 | Implement morning brief job | BE | 2026-03-15 | TODO | WRK-001, APNS-001 | Morning brief push works |
-| WRK-006 | P0 | Implement urgent-email scan job | BE | 2026-03-18 | TODO | BE-006, WRK-001 | Alerts generated via rule engine |
+| WRK-004 | P0 | Implement meeting reminder job | BE | 2026-03-12 | DONE | WRK-001, APNS-001 | Reminder push end-to-end works |
+| WRK-005 | P0 | Implement morning brief job | BE | 2026-03-15 | DONE | WRK-001, APNS-001 | Morning brief push works |
+| WRK-006 | P0 | Implement urgent-email scan job | BE | 2026-03-18 | DONE | BE-006, WRK-001 | Alerts generated via rule engine |
 | WRK-007 | P0 | Add idempotency keys for outbound actions | BE | 2026-03-14 | DONE | WRK-002 | Duplicate sends prevented |
 | WRK-008 | P1 | Add per-user concurrency limits | BE | 2026-03-19 | DONE | WRK-001 | Limits enforced in worker |
 | WRK-009 | P1 | Add worker lag metrics and alerts | SRE | 2026-03-20 | TODO | OBS-001 | Lag dashboard + alert live |


### PR DESCRIPTION
## Summary
Implement real worker execution for `MEETING_REMINDER`, `MORNING_BRIEF`, and `URGENT_EMAIL_CHECK` jobs using Google provider data instead of placeholder/no-op behavior.

## Changes
- Added job action modules under `backend/crates/worker/src/job_actions/*` and moved action dispatch out of `backend/crates/worker/src/main.rs`.
- Implemented Google connector session bootstrap in worker (attestation-gated decrypt + refresh-token exchange).
- Implemented meeting reminder generation from Calendar events, morning brief generation from Calendar + Gmail unread counts, and rule-based urgent email alert detection.
- Preserved retry/idempotency behavior and added action/delivery audit metadata events (`JOB_ACTION_GENERATED`, `JOB_ACTION_SKIPPED`, suppression/delivery attempts).
- Added unit tests for quiet-hours parsing, simulated failures, urgent-email rule matching, and notification truncation.
- Updated worker config/dev commands with required OAuth settings and synced Phase I board statuses for WRK-004/005/006.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just backend-verify`
- `just backend-deep-review`

## Issue
Closes #18

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: `cargo test` passes via `just backend-verify` and `just backend-deep-review`
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: improved by extracting worker job execution into focused modules and keeping DB access in `shared::repos`
- Performance/scalability concerns: no blockers identified for Phase I scope
- Refactor recommendations: none required for this issue

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`
