### PR TITLE
Speed up backend CI by caching sqlx-cli install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           - 5432:5432
     env:
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/alfred_ci
+      SQLX_CLI_ROOT: ${{ github.workspace }}/.cargo-sqlx-cli
+      SQLX_CLI_VERSION: 0.8.6
     defaults:
       run:
         working-directory: backend
@@ -43,8 +45,25 @@ jobs:
         with:
           workspaces: backend
 
+      - name: Cache sqlx-cli
+        id: cache-sqlx-cli
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.SQLX_CLI_ROOT }}
+          key: ${{ runner.os }}-sqlx-cli-${{ env.SQLX_CLI_VERSION }}-rustls-postgres
+
       - name: Install sqlx-cli
-        run: cargo install sqlx-cli --no-default-features --features rustls,postgres
+        if: steps.cache-sqlx-cli.outputs.cache-hit != 'true'
+        run: |
+          cargo install sqlx-cli \
+            --version $SQLX_CLI_VERSION \
+            --locked \
+            --no-default-features \
+            --features rustls,postgres \
+            --root $SQLX_CLI_ROOT
+
+      - name: Add sqlx-cli to PATH
+        run: echo "$SQLX_CLI_ROOT/bin" >> "$GITHUB_PATH"
 
       - name: Migration Check
         run: |


### PR DESCRIPTION
## Summary
Cache a pinned `sqlx-cli` install in CI so backend jobs do not spend ~1 minute reinstalling it on every run.

## Changes
- Added `SQLX_CLI_ROOT` and `SQLX_CLI_VERSION` env vars in backend CI job.
- Added `actions/cache@v4` step for the sqlx-cli install root.
- Made install conditional on cache miss.
- Pinned install to `sqlx-cli 0.8.6` with `--locked` for reproducible cache keys.
- Added PATH step so migration commands always use the cached/pinned binary.

## Validation
- `just check-tools` ✅
- `just backend-check` ✅
- `just ios-build` ✅

## Expected impact
On cache hits, the backend CI job should skip the current ~71s `Install sqlx-cli` step almost entirely.
