### PR TITLE
Follow-up: address Gemini feedback from PR #31

### DIFF
--- a/backend/crates/api-server/src/http/mod.rs
+++ b/backend/crates/api-server/src/http/mod.rs
@@ -69,30 +69,41 @@ pub fn build_router(app_state: AppState) -> Router {
         )
         .route(
             "/v1/connectors/google/start",
-            post(connectors::start_google_connect),
+            post(connectors::start_google_connect).layer(middleware::from_fn_with_state(
+                protected_rate_limit_layer_state.clone(),
+                rate_limit::sensitive_rate_limit_middleware,
+            )),
         )
         .route(
             "/v1/connectors/google/callback",
-            post(connectors::complete_google_connect),
+            post(connectors::complete_google_connect).layer(middleware::from_fn_with_state(
+                protected_rate_limit_layer_state.clone(),
+                rate_limit::sensitive_rate_limit_middleware,
+            )),
         )
         .route(
             "/v1/connectors/{connector_id}",
-            delete(connectors::revoke_connector),
+            delete(connectors::revoke_connector).layer(middleware::from_fn_with_state(
+                protected_rate_limit_layer_state.clone(),
+                rate_limit::sensitive_rate_limit_middleware,
+            )),
         )
         .route(
             "/v1/preferences",
             get(preferences::get_preferences).put(preferences::update_preferences),
         )
         .route("/v1/audit-events", get(audit::list_audit_events))
-        .route("/v1/privacy/delete-all", post(privacy::delete_all))
+        .route(
+            "/v1/privacy/delete-all",
+            post(privacy::delete_all).layer(middleware::from_fn_with_state(
+                protected_rate_limit_layer_state,
+                rate_limit::sensitive_rate_limit_middleware,
+            )),
+        )
         .route(
             "/v1/privacy/delete-all/{request_id}",
             get(privacy::get_delete_all_status),
         )
-        .layer(middleware::from_fn_with_state(
-            protected_rate_limit_layer_state,
-            rate_limit::sensitive_rate_limit_middleware,
-        ))
         .layer(middleware::from_fn_with_state(
             auth_layer_state,
             authn::auth_middleware,


### PR DESCRIPTION
## Summary
Follow-up to PR #31 to address Gemini review feedback that is valid and security-impacting.

## Gemini Feedback Validation
- Valid: Global `entries.retain` pruning inside request hot path can be abused for lock contention and O(N) per-request cost.
- Valid: Trusting `X-Forwarded-For` / `X-Real-IP` for unauthenticated rate-limit subjects is spoofable.
- Valid: Applying rate-limit middleware to all protected routes is unnecessarily broad.
- Not valid as written: suggestion to use `HeaderValue::from(u64)` for `Retry-After` (this conversion is not available in the current `http` API used by this project).

## Changes
- Moved stale-bucket pruning out of request-path checks into a background pruner task (`RateLimiter::spawn_pruner`).
- Updated API server bootstrap to:
  - start the rate-limit pruner task
  - serve router with `into_make_service_with_connect_info::<SocketAddr>()`
- Switched unauthenticated rate-limit subject derivation to trusted socket `ConnectInfo<SocketAddr>` (no forwarded header trust).
- Applied sensitive rate-limit middleware only on protected routes that actually require rate limiting:
  - `POST /v1/connectors/google/start`
  - `POST /v1/connectors/google/callback`
  - `DELETE /v1/connectors/{connector_id}`
  - `POST /v1/privacy/delete-all`
- Added tests for:
  - stale-bucket pruning behavior
  - subject derivation preferring trusted connect info over spoofable forwarded headers

## Validation
- `just backend-check` => pass
- `just backend-verify` => pass
- `just ios-build` => pass
- `just backend-deep-review` => pass
