### PR TITLE
Fix trusted-proxy client IP derivation for unauthenticated rate limits

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -60,6 +60,7 @@ These vars control TEE/KMS-bound decrypt policy for connector refresh tokens:
 10. `KMS_KEY_ID` (default: `kms/local/alfred-refresh-token`)
 11. `KMS_KEY_VERSION` (default: `1`)
 12. `KMS_ALLOWED_MEASUREMENTS` (CSV; defaults to `TEE_ALLOWED_MEASUREMENTS`)
+13. `TRUSTED_PROXY_IPS` (CSV of proxy/LB source IPs; only these peers are allowed to supply forwarded client IP headers for unauthenticated rate limiting)
 
 ## Push Delivery Environment (Worker)
 

--- a/backend/crates/api-server/src/http/mod.rs
+++ b/backend/crates/api-server/src/http/mod.rs
@@ -2,6 +2,8 @@ use axum::routing::{delete, get, post};
 use axum::{Router, middleware};
 use shared::repos::Store;
 use shared::security::SecretRuntime;
+use std::collections::HashSet;
+use std::net::IpAddr;
 use uuid::Uuid;
 
 mod audit;
@@ -34,6 +36,7 @@ pub struct AppState {
     pub oauth: OAuthConfig,
     pub secret_runtime: SecretRuntime,
     pub rate_limiter: RateLimiter,
+    pub trusted_proxy_ips: HashSet<IpAddr>,
     pub session_ttl_seconds: u64,
     pub oauth_state_ttl_seconds: u64,
     pub http_client: reqwest::Client,

--- a/backend/crates/api-server/src/main.rs
+++ b/backend/crates/api-server/src/main.rs
@@ -87,6 +87,7 @@ async fn main() {
             config.tee_attestation_document_path,
         ),
         rate_limiter,
+        trusted_proxy_ips: config.trusted_proxy_ips.into_iter().collect(),
         session_ttl_seconds: config.session_ttl_seconds,
         oauth_state_ttl_seconds: config.oauth_state_ttl_seconds,
         http_client: reqwest::Client::new(),


### PR DESCRIPTION
## Summary
Fix unauthenticated rate-limit subject IP resolution for reverse-proxy/load-balancer deployments.

## Why
The current implementation only uses the direct socket peer (`ConnectInfo<SocketAddr>`). Behind a proxy/LB, that can collapse all unauthenticated requests into one bucket and let one abusive client deny service for others.

## Changes
- Added `TRUSTED_PROXY_IPS` API config env var (CSV of proxy/LB source IPs).
- Added `trusted_proxy_ips` to API app state.
- Updated rate-limit subject resolution:
  - If peer IP is **not** trusted: use peer IP directly.
  - If peer IP **is** trusted: derive client IP from forwarded chain (`X-Forwarded-For`) using right-to-left untrusted selection; fallback to `X-Real-IP`, then peer IP.
- Kept spoofing resistance: forwarded headers are ignored unless the direct peer is trusted.
- Added tests for untrusted-peer spoofing resistance and trusted-proxy forwarded chain extraction.
- Documented `TRUSTED_PROXY_IPS` in backend README.

## Validation
- `just backend-check` => pass
- `just backend-verify` => pass
- `just ios-build` => pass
- `just backend-deep-review` => pass
