### PR TITLE
Fix SQLX CLI cache persistence in CI and post-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
         with:
           workspaces: backend
 
-      - name: Cache sqlx-cli
+      - name: Restore sqlx-cli cache
         id: cache-sqlx-cli
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.SQLX_CLI_ROOT }}
           key: ${{ runner.os }}-sqlx-cli-${{ env.SQLX_CLI_VERSION }}-rustls-postgres
@@ -75,6 +75,13 @@ jobs:
             --no-default-features \
             --features rustls,postgres \
             --root $SQLX_CLI_ROOT
+
+      - name: Save sqlx-cli cache
+        if: steps.cache-sqlx-cli.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SQLX_CLI_ROOT }}
+          key: ${{ steps.cache-sqlx-cli.outputs.cache-primary-key }}
 
       - name: Add sqlx-cli to PATH
         run: echo "$SQLX_CLI_ROOT/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -12,6 +12,9 @@ jobs:
   backend:
     name: Backend Checks (master)
     runs-on: ubuntu-latest
+    env:
+      SQLX_CLI_ROOT: ${{ github.workspace }}/.cargo-sqlx-cli
+      SQLX_CLI_VERSION: 0.8.6
     defaults:
       run:
         working-directory: backend
@@ -26,6 +29,30 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: backend
+
+      - name: Restore sqlx-cli cache
+        id: cache-sqlx-cli
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.SQLX_CLI_ROOT }}
+          key: ${{ runner.os }}-sqlx-cli-${{ env.SQLX_CLI_VERSION }}-rustls-postgres
+
+      - name: Install sqlx-cli
+        if: steps.cache-sqlx-cli.outputs.cache-hit != 'true'
+        run: |
+          cargo install sqlx-cli \
+            --version $SQLX_CLI_VERSION \
+            --locked \
+            --no-default-features \
+            --features rustls,postgres \
+            --root $SQLX_CLI_ROOT
+
+      - name: Save sqlx-cli cache
+        if: steps.cache-sqlx-cli.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.SQLX_CLI_ROOT }}
+          key: ${{ steps.cache-sqlx-cli.outputs.cache-primary-key }}
 
       - name: Fmt (check)
         run: cargo fmt --all --check


### PR DESCRIPTION
## Summary
- switch PR CI sqlx-cli cache from monolithic `actions/cache` to explicit `restore` + immediate `save`
- keep installation gated on cache miss, but save cache right after install so later failures/cancellations do not prevent persistence
- add identical sqlx-cli cache restore/install/save flow to post-merge backend workflow to keep default-branch cache warm

## Root Cause
`actions/cache@v4` only saves during post-job with `success()`; when later backend checks fail or job is cancelled, sqlx-cli cache never gets saved and the next run installs from scratch.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`