### PR TITLE
P0-11: replace stub iOS session endpoint with Apple-validated lifecycle auth

### DIFF
--- a/alfred/Packages/AlfredAPIClient/Sources/AlfredAPIClient.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/AlfredAPIClient.swift
@@ -50,6 +50,24 @@ public final class AlfredAPIClient: Sendable {
         )
     }
 
+    public func refreshIOSSession(_ request: RefreshSessionRequest) async throws -> CreateSessionResponse {
+        try await send(
+            method: "POST",
+            path: "/v1/auth/ios/session/refresh",
+            body: request,
+            requiresAuth: false
+        )
+    }
+
+    public func revokeIOSSession(_ request: RevokeSessionRequest) async throws -> OkResponse {
+        try await send(
+            method: "POST",
+            path: "/v1/auth/ios/session/revoke",
+            body: request,
+            requiresAuth: false
+        )
+    }
+
     public func registerAPNSDevice(_ request: RegisterDeviceRequest) async throws -> OkResponse {
         try await send(
             method: "POST",

--- a/alfred/Packages/AlfredAPIClient/Sources/Models.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/Models.swift
@@ -27,6 +27,30 @@ public struct CreateSessionResponse: Codable, Sendable {
     }
 }
 
+public struct RefreshSessionRequest: Codable, Sendable {
+    public let refreshToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case refreshToken = "refresh_token"
+    }
+
+    public init(refreshToken: String) {
+        self.refreshToken = refreshToken
+    }
+}
+
+public struct RevokeSessionRequest: Codable, Sendable {
+    public let refreshToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case refreshToken = "refresh_token"
+    }
+
+    public init(refreshToken: String) {
+        self.refreshToken = refreshToken
+    }
+}
+
 public enum APNSEnvironment: String, Codable, Sendable {
     case sandbox
     case production

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -31,6 +31,58 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CreateSessionResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "502":
+          $ref: "#/components/responses/BadGateway"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /v1/auth/ios/session/refresh:
+    post:
+      tags: [Auth]
+      summary: Refresh iOS session
+      operationId: refreshIOSSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RefreshSessionRequest"
+      responses:
+        "200":
+          description: Session refreshed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateSessionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /v1/auth/ios/session/revoke:
+    post:
+      tags: [Auth]
+      summary: Revoke iOS session
+      operationId: revokeIOSSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RevokeSessionRequest"
+      responses:
+        "200":
+          description: Session revoked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "429":
           $ref: "#/components/responses/TooManyRequests"
   /v1/devices/apns:
@@ -313,6 +365,7 @@ components:
           type: string
         device_id:
           type: string
+          minLength: 1
     CreateSessionResponse:
       type: object
       required: [access_token, refresh_token, expires_in]
@@ -321,10 +374,24 @@ components:
           type: string
         refresh_token:
           type: string
+          minLength: 1
         expires_in:
           type: integer
           format: int32
           minimum: 1
+    RefreshSessionRequest:
+      type: object
+      required: [refresh_token]
+      properties:
+        refresh_token:
+          type: string
+          minLength: 1
+    RevokeSessionRequest:
+      type: object
+      required: [refresh_token]
+      properties:
+        refresh_token:
+          type: string
     RegisterDeviceRequest:
       type: object
       required: [device_id, apns_token, environment]

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,5 +6,6 @@ WORKER_TICK_SECONDS=30
 
 # Shared OAuth vars (used by API + worker job execution)
 # DATABASE_URL=postgres://postgres:postgres@localhost:5432/alfred
+# APPLE_IOS_AUDIENCE=com.prodata.alfred
 # GOOGLE_OAUTH_CLIENT_ID=replace-me
 # GOOGLE_OAUTH_CLIENT_SECRET=replace-me

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -38,6 +38,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "jsonwebtoken",
  "reqwest",
  "serde",
  "serde_json",
@@ -314,6 +315,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -925,6 +935,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1083,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1107,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -1138,6 +1180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1251,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1616,6 +1674,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1738,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -2002,6 +2078,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2367,7 @@ dependencies = [
  "getrandom 0.4.1",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,6 +19,7 @@ ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+jsonwebtoken = "10"
 sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json", "migrate"] }
 thiserror = "2"
@@ -26,4 +27,4 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "tim
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
-uuid = { version = "1", features = ["serde", "v4"] }
+uuid = { version = "1", features = ["serde", "v4", "v5"] }

--- a/backend/crates/api-server/Cargo.toml
+++ b/backend/crates/api-server/Cargo.toml
@@ -9,6 +9,7 @@ chrono.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+jsonwebtoken.workspace = true
 sha2.workspace = true
 sqlx.workspace = true
 tokio.workspace = true

--- a/backend/crates/api-server/src/http/apple_identity.rs
+++ b/backend/crates/api-server/src/http/apple_identity.rs
@@ -1,0 +1,172 @@
+use chrono::Utc;
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use serde::Deserialize;
+
+const APPLE_JWKS_URL: &str = "https://appleid.apple.com/auth/keys";
+const APPLE_ISSUER: &str = "https://appleid.apple.com";
+const MAX_CLOCK_SKEW_SECONDS: i64 = 60;
+
+#[derive(Debug, Clone)]
+pub(super) struct VerifiedAppleIdentity {
+    pub(super) subject: String,
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum AppleIdentityError {
+    InvalidToken {
+        code: &'static str,
+        message: &'static str,
+    },
+    UpstreamUnavailable {
+        code: &'static str,
+        message: &'static str,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct AppleClaims {
+    sub: String,
+    iat: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct AppleJwks {
+    keys: Vec<AppleJwk>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AppleJwk {
+    kid: String,
+    alg: Option<String>,
+    kty: String,
+    n: String,
+    e: String,
+}
+
+pub(super) async fn verify_identity_token(
+    http_client: &reqwest::Client,
+    expected_audience: &str,
+    identity_token: &str,
+) -> Result<VerifiedAppleIdentity, AppleIdentityError> {
+    if identity_token.trim().is_empty() {
+        return Err(AppleIdentityError::InvalidToken {
+            code: "invalid_apple_identity_token",
+            message: "apple_identity_token is required",
+        });
+    }
+
+    let header = decode_header(identity_token).map_err(|_| AppleIdentityError::InvalidToken {
+        code: "invalid_apple_identity_token",
+        message: "Apple identity token is malformed",
+    })?;
+
+    if header.alg != Algorithm::RS256 {
+        return Err(AppleIdentityError::InvalidToken {
+            code: "invalid_apple_identity_token",
+            message: "Apple identity token algorithm is unsupported",
+        });
+    }
+
+    let Some(key_id) = header.kid else {
+        return Err(AppleIdentityError::InvalidToken {
+            code: "invalid_apple_identity_token",
+            message: "Apple identity token key id is missing",
+        });
+    };
+
+    let jwks: AppleJwks = http_client
+        .get(APPLE_JWKS_URL)
+        .send()
+        .await
+        .map_err(|_| AppleIdentityError::UpstreamUnavailable {
+            code: "apple_identity_unavailable",
+            message: "Unable to reach Apple identity validation endpoint",
+        })?
+        .error_for_status()
+        .map_err(|_| AppleIdentityError::UpstreamUnavailable {
+            code: "apple_identity_unavailable",
+            message: "Apple identity validation endpoint returned an error",
+        })?
+        .json()
+        .await
+        .map_err(|_| AppleIdentityError::UpstreamUnavailable {
+            code: "apple_identity_unavailable",
+            message: "Apple identity validation response was invalid",
+        })?;
+
+    let Some(jwk) = jwks
+        .keys
+        .iter()
+        .find(|key| key.kid == key_id && key.kty == "RSA")
+    else {
+        return Err(AppleIdentityError::InvalidToken {
+            code: "invalid_apple_identity_token",
+            message: "Apple identity token key was not recognized",
+        });
+    };
+
+    if jwk.alg.as_deref().unwrap_or("RS256") != "RS256" {
+        return Err(AppleIdentityError::InvalidToken {
+            code: "invalid_apple_identity_token",
+            message: "Apple identity token key algorithm is unsupported",
+        });
+    }
+
+    let decoding_key = DecodingKey::from_rsa_components(&jwk.n, &jwk.e).map_err(|_| {
+        AppleIdentityError::InvalidToken {
+            code: "invalid_apple_identity_token",
+            message: "Apple identity token key was invalid",
+        }
+    })?;
+
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_audience(&[expected_audience]);
+    validation.set_issuer(&[APPLE_ISSUER]);
+    validation.leeway = MAX_CLOCK_SKEW_SECONDS as u64;
+    validation.required_spec_claims = ["exp", "iat", "iss", "aud", "sub"]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+
+    let token_data =
+        decode::<AppleClaims>(identity_token, &decoding_key, &validation).map_err(|err| {
+            let (code, message) = match err.kind() {
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature => (
+                    "expired_apple_identity_token",
+                    "Apple identity token is expired",
+                ),
+                jsonwebtoken::errors::ErrorKind::InvalidAudience => (
+                    "invalid_apple_identity_token",
+                    "Apple identity token audience does not match",
+                ),
+                jsonwebtoken::errors::ErrorKind::InvalidIssuer => (
+                    "invalid_apple_identity_token",
+                    "Apple identity token issuer is invalid",
+                ),
+                _ => (
+                    "invalid_apple_identity_token",
+                    "Apple identity token validation failed",
+                ),
+            };
+            AppleIdentityError::InvalidToken { code, message }
+        })?;
+
+    let now = Utc::now().timestamp();
+    if token_data.claims.iat > now + MAX_CLOCK_SKEW_SECONDS {
+        return Err(AppleIdentityError::InvalidToken {
+            code: "invalid_apple_identity_token",
+            message: "Apple identity token issue time is invalid",
+        });
+    }
+
+    if token_data.claims.sub.trim().is_empty() {
+        return Err(AppleIdentityError::InvalidToken {
+            code: "invalid_apple_identity_token",
+            message: "Apple identity token subject is missing",
+        });
+    }
+
+    Ok(VerifiedAppleIdentity {
+        subject: token_data.claims.sub,
+    })
+}

--- a/backend/crates/api-server/src/http/rate_limit.rs
+++ b/backend/crates/api-server/src/http/rate_limit.rs
@@ -53,6 +53,8 @@ impl SensitiveEndpoint {
 
         match (method, path) {
             (&Method::POST, "/v1/auth/ios/session") => Some(Self::AuthSession),
+            (&Method::POST, "/v1/auth/ios/session/refresh") => Some(Self::AuthSession),
+            (&Method::POST, "/v1/auth/ios/session/revoke") => Some(Self::AuthSession),
             (&Method::POST, "/v1/connectors/google/start") => Some(Self::GoogleConnectStart),
             (&Method::POST, "/v1/connectors/google/callback") => Some(Self::GoogleConnectCallback),
             (&Method::DELETE, path) if path.starts_with("/v1/connectors/") => {

--- a/backend/crates/api-server/src/http/session.rs
+++ b/backend/crates/api-server/src/http/session.rs
@@ -5,29 +5,228 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use chrono::{Duration, Utc};
-use shared::models::{CreateSessionRequest, CreateSessionResponse};
-use shared::repos::AuditResult;
+use shared::models::{
+    CreateSessionRequest, CreateSessionResponse, ErrorBody, ErrorResponse, OkResponse,
+    RefreshSessionRequest, RevokeSessionRequest,
+};
+use shared::repos::{AuditResult, SessionTokenStatus};
+use tracing::warn;
+use uuid::Uuid;
 
 use super::AppState;
-use super::errors::store_error_response;
+use super::apple_identity::{AppleIdentityError, verify_identity_token};
+use super::errors::{bad_gateway_response, bad_request_response, store_error_response};
 use super::tokens::{generate_secure_token, hash_token};
+
+const APPLE_SUBJECT_NAMESPACE: Uuid = Uuid::from_u128(0x6b1e3eecf9d64f3a98611f9922905dc0);
 
 pub(super) async fn create_session(
     State(state): State<AppState>,
-    Json(_req): Json<CreateSessionRequest>,
+    Json(req): Json<CreateSessionRequest>,
 ) -> Response {
-    let user_id = match state.store.create_user().await {
-        Ok(user_id) => user_id,
+    if req.device_id.trim().is_empty() {
+        return bad_request_response("invalid_device_id", "device_id is required");
+    }
+
+    let identity = match verify_identity_token(
+        &state.http_client,
+        &state.apple_ios_audience,
+        req.apple_identity_token.trim(),
+    )
+    .await
+    {
+        Ok(identity) => identity,
+        Err(AppleIdentityError::InvalidToken { code, message }) => {
+            return session_error_response(code, message);
+        }
+        Err(AppleIdentityError::UpstreamUnavailable { code, message }) => {
+            return bad_gateway_response(code, message);
+        }
+    };
+
+    let user_id = user_id_for_apple_subject(&identity.subject);
+
+    if let Err(err) = state.store.ensure_user(user_id).await {
+        return store_error_response(err);
+    }
+
+    let response = match issue_session_tokens(&state, user_id).await {
+        Ok(response) => response,
         Err(err) => return store_error_response(err),
     };
 
+    write_auth_audit_event(
+        &state,
+        user_id,
+        "AUTH_SESSION_CREATED",
+        AuditResult::Success,
+        "session_create",
+        Some("apple_sign_in"),
+    )
+    .await;
+
+    (StatusCode::OK, Json(response)).into_response()
+}
+
+pub(super) async fn refresh_session(
+    State(state): State<AppState>,
+    Json(req): Json<RefreshSessionRequest>,
+) -> Response {
+    let refresh_token = req.refresh_token.trim();
+    if refresh_token.is_empty() {
+        return bad_request_response("invalid_refresh_token", "refresh_token is required");
+    }
+
+    let refresh_hash = hash_token(refresh_token);
+    let access_token = generate_secure_token("at");
+    let refresh_token = generate_secure_token("rt");
+    let access_hash = hash_token(&access_token);
+    let new_refresh_hash = hash_token(&refresh_token);
+    let now = Utc::now();
+    let expires_at = now + Duration::seconds(state.session_ttl_seconds as i64);
+
+    let (status, user_id) = match state
+        .store
+        .rotate_session_by_refresh_token(
+            &refresh_hash,
+            &access_hash,
+            &new_refresh_hash,
+            expires_at,
+            now,
+        )
+        .await
+    {
+        Ok(result) => result,
+        Err(err) => return store_error_response(err),
+    };
+
+    match status {
+        SessionTokenStatus::Active => {
+            if let Some(user_id) = user_id {
+                write_auth_audit_event(
+                    &state,
+                    user_id,
+                    "AUTH_SESSION_REFRESH",
+                    AuditResult::Success,
+                    "session_refresh",
+                    None,
+                )
+                .await;
+            }
+            (
+                StatusCode::OK,
+                Json(CreateSessionResponse {
+                    access_token,
+                    refresh_token,
+                    expires_in: state.session_ttl_seconds as u32,
+                }),
+            )
+                .into_response()
+        }
+        SessionTokenStatus::Expired => {
+            if let Some(user_id) = user_id {
+                write_auth_audit_event(
+                    &state,
+                    user_id,
+                    "AUTH_SESSION_REFRESH",
+                    AuditResult::Failure,
+                    "session_refresh",
+                    Some("expired_refresh_token"),
+                )
+                .await;
+            }
+            session_error_response("expired_refresh_token", "Refresh token is expired")
+        }
+        SessionTokenStatus::Revoked => {
+            if let Some(user_id) = user_id {
+                write_auth_audit_event(
+                    &state,
+                    user_id,
+                    "AUTH_SESSION_REFRESH",
+                    AuditResult::Failure,
+                    "session_refresh",
+                    Some("revoked_refresh_token"),
+                )
+                .await;
+            }
+            session_error_response("revoked_refresh_token", "Refresh token is revoked")
+        }
+        SessionTokenStatus::NotFound => {
+            session_error_response("invalid_refresh_token", "Refresh token is invalid")
+        }
+    }
+}
+
+pub(super) async fn revoke_session(
+    State(state): State<AppState>,
+    Json(req): Json<RevokeSessionRequest>,
+) -> Response {
+    let refresh_token = req.refresh_token.trim();
+    if refresh_token.is_empty() {
+        return bad_request_response("invalid_refresh_token", "refresh_token is required");
+    }
+
+    let now = Utc::now();
+    let (status, user_id) = match state
+        .store
+        .revoke_session_by_refresh_token(&hash_token(refresh_token), now)
+        .await
+    {
+        Ok(result) => result,
+        Err(err) => return store_error_response(err),
+    };
+
+    match status {
+        SessionTokenStatus::Active | SessionTokenStatus::Revoked => {
+            if let Some(user_id) = user_id {
+                let reason = if status == SessionTokenStatus::Revoked {
+                    Some("already_revoked")
+                } else {
+                    None
+                };
+                write_auth_audit_event(
+                    &state,
+                    user_id,
+                    "AUTH_SESSION_REVOKE",
+                    AuditResult::Success,
+                    "session_revoke",
+                    reason,
+                )
+                .await;
+            }
+            (StatusCode::OK, Json(OkResponse { ok: true })).into_response()
+        }
+        SessionTokenStatus::Expired => {
+            if let Some(user_id) = user_id {
+                write_auth_audit_event(
+                    &state,
+                    user_id,
+                    "AUTH_SESSION_REVOKE",
+                    AuditResult::Failure,
+                    "session_revoke",
+                    Some("expired_refresh_token"),
+                )
+                .await;
+            }
+            session_error_response("expired_refresh_token", "Refresh token is expired")
+        }
+        SessionTokenStatus::NotFound => {
+            session_error_response("invalid_refresh_token", "Refresh token is invalid")
+        }
+    }
+}
+
+async fn issue_session_tokens(
+    state: &AppState,
+    user_id: Uuid,
+) -> Result<CreateSessionResponse, shared::repos::StoreError> {
     let access_token = generate_secure_token("at");
     let refresh_token = generate_secure_token("rt");
     let access_hash = hash_token(&access_token);
     let refresh_hash = hash_token(&refresh_token);
     let expires_in = state.session_ttl_seconds;
 
-    if let Err(err) = state
+    state
         .store
         .create_session(
             user_id,
@@ -35,33 +234,55 @@ pub(super) async fn create_session(
             &refresh_hash,
             Utc::now() + Duration::seconds(expires_in as i64),
         )
-        .await
-    {
-        return store_error_response(err);
-    }
+        .await?;
 
-    let mut metadata = HashMap::new();
-    metadata.insert("action".to_string(), "session_created".to_string());
-
-    if let Err(err) = state
-        .store
-        .add_audit_event(
-            user_id,
-            "AUTH_SESSION_CREATED",
-            None,
-            AuditResult::Success,
-            &metadata,
-        )
-        .await
-    {
-        return store_error_response(err);
-    }
-
-    let response = CreateSessionResponse {
+    Ok(CreateSessionResponse {
         access_token,
         refresh_token,
         expires_in: expires_in as u32,
-    };
+    })
+}
 
-    (StatusCode::OK, Json(response)).into_response()
+fn user_id_for_apple_subject(subject: &str) -> Uuid {
+    Uuid::new_v5(&APPLE_SUBJECT_NAMESPACE, subject.as_bytes())
+}
+
+fn session_error_response(code: &str, message: &str) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(ErrorResponse {
+            error: ErrorBody {
+                code: code.to_string(),
+                message: message.to_string(),
+            },
+        }),
+    )
+        .into_response()
+}
+
+async fn write_auth_audit_event(
+    state: &AppState,
+    user_id: Uuid,
+    event_type: &str,
+    result: AuditResult,
+    action: &str,
+    reason: Option<&str>,
+) {
+    let mut metadata = HashMap::new();
+    metadata.insert("action".to_string(), action.to_string());
+    if let Some(reason) = reason {
+        metadata.insert("reason".to_string(), reason.to_string());
+    }
+
+    if let Err(err) = state
+        .store
+        .add_audit_event(user_id, event_type, None, result, &metadata)
+        .await
+    {
+        warn!(
+            user_id = %user_id,
+            event_type,
+            "failed to persist auth audit event: {err}",
+        );
+    }
 }

--- a/backend/crates/api-server/src/main.rs
+++ b/backend/crates/api-server/src/main.rs
@@ -90,6 +90,7 @@ async fn main() {
         trusted_proxy_ips: config.trusted_proxy_ips.into_iter().collect(),
         session_ttl_seconds: config.session_ttl_seconds,
         oauth_state_ttl_seconds: config.oauth_state_ttl_seconds,
+        apple_ios_audience: config.apple_ios_audience,
         http_client: reqwest::Client::new(),
     });
 

--- a/backend/crates/shared/src/config.rs
+++ b/backend/crates/shared/src/config.rs
@@ -13,6 +13,7 @@ pub struct ApiConfig {
     pub data_encryption_key: String,
     pub session_ttl_seconds: u64,
     pub oauth_state_ttl_seconds: u64,
+    pub apple_ios_audience: String,
     pub google_client_id: String,
     pub google_client_secret: String,
     pub google_redirect_uri: String,
@@ -108,6 +109,14 @@ impl ApiConfig {
             ));
         }
 
+        let apple_ios_audience = optional_trimmed_env("APPLE_IOS_AUDIENCE")
+            .unwrap_or_else(|| "com.prodata.alfred".to_string());
+        if apple_ios_audience.is_empty() {
+            return Err(ConfigError::InvalidConfiguration(
+                "APPLE_IOS_AUDIENCE must not be empty".to_string(),
+            ));
+        }
+
         Ok(Self {
             bind_addr: env::var("API_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:8080".to_string()),
             database_url: require_env("DATABASE_URL")?,
@@ -120,6 +129,7 @@ impl ApiConfig {
             data_encryption_key: require_env("DATA_ENCRYPTION_KEY")?,
             session_ttl_seconds: parse_u64_env("SESSION_TTL_SECONDS", 3600)?,
             oauth_state_ttl_seconds: parse_u64_env("OAUTH_STATE_TTL_SECONDS", 600)?,
+            apple_ios_audience,
             google_client_id: require_env("GOOGLE_OAUTH_CLIENT_ID")?,
             google_client_secret: require_env("GOOGLE_OAUTH_CLIENT_SECRET")?,
             google_redirect_uri: require_env("GOOGLE_OAUTH_REDIRECT_URI")?,

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -17,6 +17,16 @@ pub struct CreateSessionResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RefreshSessionRequest {
+    pub refresh_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevokeSessionRequest {
+    pub refresh_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ApnsEnvironment {
     Sandbox,

--- a/backend/crates/shared/src/repos/mod.rs
+++ b/backend/crates/shared/src/repos/mod.rs
@@ -160,3 +160,11 @@ pub struct DeviceRegistration {
     pub apns_token: String,
     pub environment: ApnsEnvironment,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionTokenStatus {
+    Active,
+    Expired,
+    Revoked,
+    NotFound,
+}

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -55,7 +55,7 @@ Ship a private beta where iOS users can:
 
 | ID | Pri | Task | Owner | ETA | Status | Depends On | Exit Criteria |
 |---|---|---|---|---|---|---|---|
-| BE-001 | P0 | Replace stub `/v1/auth/ios/session` with real auth flow | BE | 2026-02-24 | TODO | PROD-001 | Endpoint backed by real session issuance |
+| BE-001 | P0 | Replace stub `/v1/auth/ios/session` with real auth flow | BE | 2026-02-24 | DONE | PROD-001 | Endpoint backed by real session issuance |
 | BE-002 | P0 | Add health/readiness endpoints | BE | 2026-02-20 | TODO | - | `/healthz` and `/readyz` live |
 | BE-003 | P0 | Add structured logging with request_id | BE | 2026-02-21 | TODO | BE-002 | Request logs include trace fields |
 | BE-004 | P0 | Standardize API error envelope/codes | BE | 2026-02-22 | TODO | BE-001 | All endpoints use common error format |


### PR DESCRIPTION
## Summary
Implements issue #17 by replacing the stub iOS auth session flow with Apple identity token validation and full session lifecycle handling.

## Changes
- Added Apple identity token verification against Apple JWKS with enforced issuer/audience/expiry constraints and bounded clock skew checks.
- Added stable Apple subject to Alfred user identity mapping and session persistence for create/refresh/revoke flows.
- Added `POST /v1/auth/ios/session/refresh` and `POST /v1/auth/ios/session/revoke` endpoints with deterministic error responses and redacted auth audit events.
- Updated OpenAPI, shared Rust models, and AlfredAPIClient models/methods for refresh/revoke support.
- Marked board item `BE-001` as DONE in `docs/phase1-master-todo.md`.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just backend-verify`
- `just backend-deep-review`

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: `just backend-verify` and `just backend-deep-review` passed
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no findings
- Performance/scalability concerns: no findings
- Refactor recommendations: none

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #17
