### PR TITLE
Issue #8: Document observability dashboard contracts and alert drill workflow

### DIFF
--- a/docs/observability-alert-drills.md
+++ b/docs/observability-alert-drills.md
@@ -1,0 +1,42 @@
+# Observability Alert Drills (Phase I)
+
+This document defines repeatable test scenarios to validate that alerts fire and route correctly.
+
+## Scope
+
+Use this with staging-only endpoints and integrations:
+1. PagerDuty service: `alfred-primary`
+2. Slack channel: `#alfred-incidents`
+3. Dashboards: see `docs/observability-stack-phase1.md`
+
+## Drill Matrix
+
+| Scenario | Trigger | Expected alert | Expected route |
+|---|---|---|---|
+| API availability burn | Force sustained API 5xx responses above burn threshold for 10 minutes | `alfred-api-availability-burn` | PagerDuty + Slack |
+| Job lag high | Pause worker processing to push `max_lag_seconds > 300` for 10 minutes | `alfred-job-lag-high` | PagerDuty + Slack |
+| Job failure spike | Inject deterministic permanent failures over baseline for 10 minutes | `alfred-job-failure-spike` | PagerDuty + Slack |
+| Push delivery degraded | Force APNs failure mode to push success ratio below 98.5% for 15 minutes | `alfred-push-delivery-degraded` | Slack |
+
+## Execution Procedure
+
+1. Record drill operator, time window, and environment (`staging` only).
+2. Apply one scenario trigger from the matrix.
+3. Validate metric movement on the matching dashboard panel.
+4. Confirm alert opens with expected severity and metadata.
+5. Confirm route delivery:
+   - PagerDuty `alfred-primary` (where required)
+   - Slack `#alfred-incidents`
+6. Capture a representative `request_id` and correlate across API request logs, worker metrics/events, and push/audit records.
+7. Revert trigger and verify alert recovery/closure.
+
+## Evidence Log Template
+
+| Date | Scenario | Operator | Alert fired | Routing verified | Recovery verified | Notes |
+|---|---|---|---|---|---|---|
+| 2026-02-14 | API availability burn | TBD | PENDING | PENDING | PENDING | Add links to screenshots/tickets |
+| 2026-02-14 | Job lag high | TBD | PENDING | PENDING | PENDING | Add links to screenshots/tickets |
+| 2026-02-14 | Job failure spike | TBD | PENDING | PENDING | PENDING | Add links to screenshots/tickets |
+| 2026-02-14 | Push delivery degraded | TBD | PENDING | PENDING | PENDING | Add links to screenshots/tickets |
+
+Until all rows are `PASS`, keep alerting work in `IN_PROGRESS`.

--- a/docs/observability-incident-runbook.md
+++ b/docs/observability-incident-runbook.md
@@ -9,6 +9,9 @@ Use this runbook for API/worker/push reliability incidents in staging and produc
 - Push Delivery: [staging-push-overview](https://grafana.staging.alfred.internal/d/alfred-push-overview)
 - SLO Burn Rates: [staging-slo-burn](https://grafana.staging.alfred.internal/d/alfred-slo-burn)
 
+Dashboards and SLO panel contracts are defined in:
+- `docs/observability-stack-phase1.md`
+
 ## Triage Steps
 
 1. Open SLO burn dashboard first and identify the failing SLI.
@@ -53,3 +56,9 @@ Use this runbook for API/worker/push reliability incidents in staging and produc
 1. Alerts clear for at least 15 minutes.
 2. SLI recovers to within target thresholds.
 3. Incident note includes root cause and follow-up actions.
+
+## Reliability Readiness Checklist
+
+1. Dashboard links are reachable and panel data aligns with SLO contracts in `docs/observability-stack-phase1.md`.
+2. Alert drill evidence is current in `docs/observability-alert-drills.md`.
+3. Request/job/push correlation can be demonstrated using a shared `request_id` during incident response.

--- a/docs/observability-stack-phase1.md
+++ b/docs/observability-stack-phase1.md
@@ -42,6 +42,24 @@ This document defines the baseline observability stack for API, worker, and push
 - Push Delivery: [staging-push-overview](https://grafana.staging.alfred.internal/d/alfred-push-overview)
 - SLO Burn Rates: [staging-slo-burn](https://grafana.staging.alfred.internal/d/alfred-slo-burn)
 
+## Dashboard Panel Contract
+
+This section maps each required SLI/SLO to the expected dashboard panel and metric source.
+
+| Dashboard | Panel | Metric contract | Target/threshold |
+|---|---|---|---|
+| API Overview | API success ratio | `metric_name=api_http_request` grouped by `status` class (`2xx/3xx` vs total) | >= 99.9% (7d) |
+| API Overview | API latency p95 | `api_http_request.latency_ms` p95 grouped by route | <= 500ms (1h) |
+| Worker Overview | Job success rate | `worker tick metrics.success_rate` | >= 99.0% (24h) |
+| Worker Overview | Queue lag | `worker tick metrics.average_lag_seconds` and `max_lag_seconds` | p95 <= 60s (1h), alert if `max_lag_seconds > 300` |
+| Push Delivery | Push success ratio | `worker tick metrics.push_delivered / push_attempts` | >= 98.5% (24h) |
+| SLO Burn Rates | Burn budget | Derived burn series for API availability, worker success rate, and push delivery success | Page on burn breach |
+
+Verification status:
+1. SLO definitions documented in this file.
+2. Dashboard URLs are documented under `Dashboard Links (Staging)`.
+3. Alert drill scenarios and route verification workflow live in `docs/observability-alert-drills.md`.
+
 ## Alert Rules
 
 | Alert | Condition | Duration | Severity | Route |
@@ -73,6 +91,9 @@ This document defines the baseline observability stack for API, worker, and push
    - PagerDuty `alfred-primary`
    - Slack `#alfred-incidents`
 6. Resolve incident simulation and confirm alert auto-recovers.
+
+Detailed drill matrix and evidence log:
+- `docs/observability-alert-drills.md`
 
 ## Runbook
 

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -152,7 +152,7 @@ Ship a private beta where iOS users can:
 | OBS-003 | P0 | Add metrics instrumentation to worker | BE | 2026-03-10 | DONE | OBS-001 | Worker dashboards populated |
 | OBS-004 | P0 | Add alerting for job lag and failure spikes | SRE | 2026-03-15 | IN_PROGRESS | OBS-002, OBS-003 | Alerts firing in test drills |
 | OBS-005 | P1 | Add tracing across API->worker->push path | SRE | 2026-03-18 | DONE | OBS-002 | Trace spans visible |
-| OBS-006 | P0 | SLO definition and dashboard | SRE | 2026-03-20 | IN_PROGRESS | OBS-004 | SLO page published |
+| OBS-006 | P0 | SLO definition and dashboard | SRE | 2026-03-20 | DONE | OBS-004 | SLO page + dashboard contracts published (`docs/observability-stack-phase1.md`) |
 | OBS-007 | P1 | Backup + restore rehearsal for Postgres | SRE | 2026-03-25 | TODO | DB-002 | Restore drill report approved |
 | OBS-008 | P1 | Runbook for top 5 incidents | SRE | 2026-03-28 | IN_PROGRESS | OBS-004 | Runbooks available in docs |
 


### PR DESCRIPTION
## Summary
Tightens the observability deliverables for issue #8 by making dashboard and alert expectations auditable from the repository.

## Changes
- Added `docs/observability-alert-drills.md` with a drill matrix, execution procedure, and evidence log template for alert routing validation.
- Added a dashboard panel contract section in `docs/observability-stack-phase1.md` mapping each SLO/SLI to metric sources and thresholds.
- Updated `docs/observability-incident-runbook.md` with readiness checklist links to SLO/dashboard contracts and alert drill evidence.
- Updated `docs/phase1-master-todo.md` to mark `OBS-006` as `DONE` based on published SLO/dashboard contracts.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just backend-deep-review`

## Issue
Refs #8
