### PR TITLE
Fix Clerk publishable key enforcement in app startup

### DIFF
--- a/alfred/alfred/Core/AppConfiguration.swift
+++ b/alfred/alfred/Core/AppConfiguration.swift
@@ -13,4 +13,10 @@ enum AppConfiguration {
             .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
             .first(where: { !$0.isEmpty }) ?? ""
     }
+
+    static var requiredClerkPublishableKey: String {
+        let key = clerkPublishableKey
+        precondition(!key.isEmpty, "CLERK_PUBLISHABLE_KEY is required to initialize Clerk.")
+        return key
+    }
 }

--- a/alfred/alfred/alfredApp.swift
+++ b/alfred/alfred/alfredApp.swift
@@ -15,8 +15,7 @@ struct alfredApp: App {
     @StateObject private var model: AppModel
 
     init() {
-        let publishableKey = AppConfiguration.clerkPublishableKey
-        assert(!publishableKey.isEmpty, "CLERK_PUBLISHABLE_KEY is required to initialize Clerk.")
+        let publishableKey = AppConfiguration.requiredClerkPublishableKey
         let configuredClerk = Clerk.configure(publishableKey: publishableKey)
         self.clerk = configuredClerk
         _model = StateObject(wrappedValue: AppModel(clerk: configuredClerk))


### PR DESCRIPTION
## Summary
- address Codex review feedback about Clerk key validation in optimized builds
- replace debug-only `assert` path with a required runtime guard via `precondition`
- keep hardcoded API URL unchanged as requested

## Changes
- add `AppConfiguration.requiredClerkPublishableKey`
- use required key in `alfredApp` startup before `Clerk.configure(...)`

## Verification
- `just ios-build`

Follow-up to #60
