### PR TITLE
Issue #64: Implement structured server logging and shared iOS logger

### DIFF
--- a/agent/start.md
+++ b/agent/start.md
@@ -46,6 +46,8 @@ The project intentionally avoids smart-home control in v1 to reduce reliability 
    1. `docs/phase1-master-todo.md`
 8. Product context (canonical):
    1. `docs/product-context.md`
+9. Logging conventions:
+   1. `docs/logging.md`
 
 ## Runtime Components
 

--- a/alfred/alfred/AppModel+GoogleOAuthCallback.swift
+++ b/alfred/alfred/AppModel+GoogleOAuthCallback.swift
@@ -6,8 +6,10 @@ extension AppModel {
         _ url: URL,
         completionForTesting: ((CompleteGoogleConnectRequest) async -> Void)? = nil
     ) async {
+        AppLogger.debug("Handling OAuth callback URL.", category: .oauth)
         let normalizedRedirectURI = redirectURI.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedRedirectURI.isEmpty else {
+            AppLogger.warning("OAuth callback rejected because redirect URI is empty.", category: .oauth)
             errorBanner = ErrorBanner(
                 message: "Redirect URI is required.",
                 retryAction: nil,
@@ -22,6 +24,7 @@ extension AppModel {
                 redirectURI: normalizedRedirectURI,
                 expectedState: trimmedOrNil(googleState)
             ) else {
+                AppLogger.debug("Ignored non-matching callback URL.", category: .oauth)
                 return
             }
 
@@ -44,12 +47,17 @@ extension AppModel {
 
             await completeGoogleOAuth()
         } catch let parseError as GoogleOAuthCallbackParsingError {
+            AppLogger.warning("OAuth callback parsing failed: \(parseError.localizedDescription)", category: .oauth)
             errorBanner = ErrorBanner(
                 message: parseError.localizedDescription,
                 retryAction: nil,
                 sourceAction: .completeGoogleOAuth
             )
         } catch {
+            AppLogger.error(
+                "Unexpected OAuth callback handling error of type \(String(describing: type(of: error))).",
+                category: .oauth
+            )
             errorBanner = ErrorBanner(
                 message: Self.errorMessage(from: error),
                 retryAction: nil,

--- a/alfred/alfred/Core/AppLogger.swift
+++ b/alfred/alfred/Core/AppLogger.swift
@@ -1,0 +1,48 @@
+import Foundation
+import OSLog
+
+enum AppLogger {
+    enum Category {
+        case app
+        case auth
+        case network
+        case oauth
+    }
+
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "com.prodata.alfred"
+    private static let appLogger = Logger(subsystem: subsystem, category: "app")
+    private static let authLogger = Logger(subsystem: subsystem, category: "auth")
+    private static let networkLogger = Logger(subsystem: subsystem, category: "network")
+    private static let oauthLogger = Logger(subsystem: subsystem, category: "oauth")
+
+    static func debug(_ message: String, category: Category = .app) {
+        #if DEBUG
+            logger(for: category).debug("\(message, privacy: .public)")
+        #endif
+    }
+
+    static func info(_ message: String, category: Category = .app) {
+        logger(for: category).info("\(message, privacy: .public)")
+    }
+
+    static func warning(_ message: String, category: Category = .app) {
+        logger(for: category).warning("\(message, privacy: .public)")
+    }
+
+    static func error(_ message: String, category: Category = .app) {
+        logger(for: category).error("\(message, privacy: .public)")
+    }
+
+    private static func logger(for category: Category) -> Logger {
+        switch category {
+        case .app:
+            return appLogger
+        case .auth:
+            return authLogger
+        case .network:
+            return networkLogger
+        case .oauth:
+            return oauthLogger
+        }
+    }
+}

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2416,6 +2416,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,12 +2435,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -26,6 +26,6 @@ sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-r
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = "2"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,35 @@
+# Logging Conventions
+
+This project uses structured logs on the backend and a shared logger facade on iOS.
+
+## Backend (API server)
+
+Location:
+- `backend/crates/api-server/src/main.rs`
+- `backend/crates/api-server/src/http/observability.rs`
+
+Rules:
+- Emit JSON logs through `tracing_subscriber`.
+- Include request correlation via `request_id`.
+- For every request completion, include:
+  - `method`
+  - `route`
+  - `path`
+  - `status`
+  - `latency_ms`
+  - `outcome`
+- Never log secrets, OAuth tokens, or raw sensitive payloads.
+
+## iOS app
+
+Location:
+- `alfred/alfred/Core/AppLogger.swift`
+
+Usage:
+- `AppLogger.debug(...)` for debug-only logs (`#if DEBUG` gated).
+- `AppLogger.info(...)`, `AppLogger.warning(...)`, `AppLogger.error(...)` for logs that should also appear in Release builds.
+- Select a category (`.app`, `.auth`, `.network`, `.oauth`) to keep log streams easy to filter.
+
+Guidelines:
+- Prefer event-style messages over verbose prose.
+- Avoid logging user secrets/tokens, callback codes, or other sensitive values.


### PR DESCRIPTION
## Summary
- enable JSON structured logging for API server tracing
- add request completion structured fields (`request_id`, method/route/path/status/latency/outcome)
- add shared `AppLogger` for iOS app-wide logging with debug-only debug level
- adopt `AppLogger` in core app/auth/oauth flows
- add logging conventions doc and link from agent start guide

## Validation
- `just check-tools`
- `just backend-check`
- `just backend-verify`
- `just backend-deep-review`
- `just ios-build`
- `just ios-test`

Closes #64