### PR TITLE
Add UI spec and agent guidance for frontend execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@ This file is intentionally at repository root so coding agents can auto-discover
 2. Read `agent/start.md` before making changes.
 3. If running with minimal context, read `agent/start.empty` first and then `agent/start.md`.
 4. Read `docs/engineering-standards.md` for mandatory security/scalability rules.
-5. Use the `Justfile` at repo root for all common workflows.
-6. Work from GitHub issues first, then keep the Phase I board aligned.
+5. For iOS/front-end issues, read `docs/ui-spec.md` before making changes.
+6. Use the `Justfile` at repo root for all common workflows.
+7. Work from GitHub issues first, then keep the Phase I board aligned.
 
 ## Authentication Direction (Important)
 
@@ -107,6 +108,18 @@ Code must remain modular by default. Do not keep adding logic to a single large 
 1. Add/update Swift tests for core logic changes.
 2. UI tests are optional for now for UI-only changes.
 3. Always run `just ios-build`; run `just ios-test` for core logic test changes.
+
+## Frontend UI Rules (Non-Negotiable)
+
+1. `docs/ui-spec.md` is the front-end source of truth for Phase I UI/UX.
+2. SwiftUI must stay modular and reusable; avoid monolithic screens.
+3. Target `<= 300` lines for handwritten Swift files and treat `500` lines as hard ceiling unless blocked.
+4. If touching a large front-end file, extract components/helpers in the same issue when practical.
+5. For front-end implementation, use relevant SwiftUI skills when applicable:
+   1. `swiftui-ui-patterns`
+   2. `swiftui-view-refactor`
+   3. `swiftui-performance-audit`
+   4. `swift-concurrency-expert` when async behavior changes
 
 ## Planning and Issue Source of Truth
 

--- a/agent/start.empty
+++ b/agent/start.empty
@@ -7,6 +7,7 @@ Use this file when an agent starts with minimal context.
 1. `agent/start.md`
 2. `docs/product-context.md`
 3. `docs/engineering-standards.md`
+4. For iOS/front-end issues: `docs/ui-spec.md`
 
 ## Auth Direction (Current)
 

--- a/agent/start.md
+++ b/agent/start.md
@@ -13,6 +13,10 @@ Read mandatory security/scalability rules:
 
 `docs/engineering-standards.md`
 
+For iOS/front-end issues, read UI source of truth:
+
+`docs/ui-spec.md`
+
 Use this template for required AI review reporting before merge:
 
 `docs/ai-review-template.md`
@@ -48,6 +52,8 @@ The project intentionally avoids smart-home control in v1 to reduce reliability 
    1. `docs/product-context.md`
 9. Logging conventions:
    1. `docs/logging.md`
+10. UI/UX source of truth for iOS:
+   1. `docs/ui-spec.md`
 
 ## Runtime Components
 
@@ -233,6 +239,16 @@ Important:
 3. Minimum iOS completion check:
    1. `just ios-build`
 4. Run `just ios-test` when logic tests were added/changed or when explicitly requested.
+5. Follow `docs/ui-spec.md` for navigation, theme, state UX, and screen responsibilities.
+6. Keep SwiftUI files modular:
+   1. Target `<= 300` lines for handwritten files.
+   2. Hard ceiling `500` lines unless blocked and explicitly documented.
+7. Prefer reusable components and shared patterns over one-off large view files.
+8. Use SwiftUI skills when relevant:
+   1. `swiftui-ui-patterns`
+   2. `swiftui-view-refactor`
+   3. `swiftui-performance-audit`
+   4. `swift-concurrency-expert` for async/concurrency changes
 
 ## Standard Agent Workflow
 

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -1,0 +1,120 @@
+# Alfred UI Specification (Phase I)
+
+- Last Updated: 2026-02-15
+- Scope: iOS front-end design and implementation rules for Phase I
+- Audience: iOS engineers and autonomous coding agents
+
+## 1) Source Of Truth
+
+This document is the source of truth for iOS UI/UX implementation in Phase I.
+
+If a front-end issue conflicts with ad hoc styling choices, follow this spec and update the issue notes.
+
+## 2) Product Direction
+
+1. Dark-mode-only experience for Phase I.
+2. Native iOS bottom-tab navigation as primary app structure.
+3. Home is the primary interaction surface.
+4. Connectors must be first-class and future-extensible (Google now, others later).
+
+## 3) Navigation Architecture
+
+Primary tabs:
+
+1. Home
+2. Activity
+3. Connectors
+4. Profile
+
+Architecture rules:
+
+1. Use `TabView` at app root.
+2. Use one `NavigationStack` per tab (independent history).
+3. Route deep links through centralized router logic, not per-screen ad hoc handlers.
+4. Keep tab identity centralized in one enum.
+
+## 4) Screen Responsibilities
+
+### Home
+
+1. Show actionable summary of the day.
+2. Show reminder/brief/urgent status cards.
+3. Expose quick actions (refresh, retry, open connector state).
+
+### Activity
+
+1. Show chronological timeline of events.
+2. Support filters (reminder, brief, urgent, system).
+3. Support detail view for an event.
+
+### Connectors
+
+1. Show connected providers and connection health.
+2. Show Google connection controls for v1.
+3. Preserve extensible layout for future providers.
+
+### Profile
+
+1. Show account identity state.
+2. Host preferences and notification settings.
+3. Host privacy actions (revoke, delete-all) with explicit confirmations.
+
+## 5) Visual System (Dark-Only)
+
+1. Use near-black base surfaces and elevated dark cards.
+2. Use semantic colors/tokens; avoid hard-coded ad hoc colors in feature views.
+3. Keep one primary accent color for core actions.
+4. Preserve strong text contrast and Dynamic Type support.
+
+## 6) State UX Rules (Required)
+
+Every async surface must support:
+
+1. Loading state (skeleton/redacted placeholders where practical)
+2. Empty state (clear message + next action)
+3. Error state (human-readable message + retry)
+4. Offline or transient failure state (recoverable with retry/backoff messaging)
+
+Do not block the whole app with spinners for local section fetches.
+
+## 7) SwiftUI Engineering Rules (Required)
+
+This section is mandatory for all front-end issues.
+
+1. Build composable views with clear responsibility boundaries.
+2. Reuse shared components for repeated UI patterns (cards, rows, headers, state views).
+3. Prefer modern SwiftUI data flow (`@State`, `@Binding`, `@Environment`, `@Observable`) over large ad hoc view models.
+4. Keep files small and focused:
+   1. Target `<= 300` lines for handwritten Swift files.
+   2. Hard ceiling is `500` lines. If exceeded, split in the same issue unless blocked.
+5. Do not add new logic into already-large files without extracting subviews/helpers first.
+6. Keep routing/state orchestration outside presentational subviews.
+7. Add lightweight comments only where flow is non-obvious.
+
+## 8) Skills Guidance For Agents
+
+When implementing front-end issues, use the repository SwiftUI skills as applicable:
+
+1. `swiftui-ui-patterns` for tab/navigation/sheet composition and general UI structure.
+2. `swiftui-view-refactor` for view decomposition and dependency flow cleanup.
+3. `swiftui-performance-audit` for rendering/performance risk review.
+4. `swift-concurrency-expert` when async state/concurrency behavior is changed.
+
+Agents should explicitly note skill usage in issue updates when a skill guided implementation decisions.
+
+## 9) Acceptance Checklist For Front-End Issues
+
+Before handoff:
+
+1. `just ios-build` passes.
+2. `just ios-test` passes when core logic/state behavior changed.
+3. UI follows tab architecture and dark-theme token usage.
+4. Loading/empty/error states are implemented for touched screens.
+5. Files respect modularity and size constraints from this spec and `AGENTS.md`.
+
+## 10) Relationship To Existing Docs
+
+1. Product intent: `docs/product-context.md`
+2. Engineering constraints: `docs/engineering-standards.md`
+3. Execution board: `docs/phase1-master-todo.md`
+4. Agent runtime protocol: `agent/start.md` and `AGENTS.md`


### PR DESCRIPTION
## Summary
- add a new Phase I UI source-of-truth document at `docs/ui-spec.md`
- require agents to read `docs/ui-spec.md` for iOS/front-end issues
- enforce explicit SwiftUI modularity and file-size guidance in agent start docs
- reference SwiftUI skills to guide autonomous front-end issue execution

## Validation
- docs-only change
- no runtime/build impact
