### PR TITLE
Update Phase I board for FE02 mapping

### DIFF
--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -140,7 +140,7 @@ Ship a private beta where iOS users can:
 | ID | Pri | Task | Owner | ETA | Status | Depends On | Exit Criteria |
 |---|---|---|---|---|---|---|---|
 | IOS-001 | P0 | Integrate Clerk iOS auth and API token provider wiring | IOS | 2026-02-27 | TODO | BE-001 | App obtains Clerk token and authenticated API calls succeed |
-| IOS-002 | P0 | Build onboarding + sign-in flow using Clerk | IOS | 2026-03-02 | TODO | IOS-001 | User signs in with Clerk and reaches connected home screen |
+| IOS-002 | P0 | Native bottom-tab app shell with per-tab navigation stacks (FE02) | IOS | 2026-02-16 | DONE | IOS-013 | Four-tab shell with independent NavigationStack + centralized tab routing |
 | IOS-003 | P0 | Build Google connect UI flow | IOS | 2026-03-06 | DONE | BE-005 | Google connect completes in app |
 | IOS-013 | P0 | Dark-mode theme tokens + shared UI primitives (FE01) | IOS | 2026-02-16 | DONE | - | App uses dark-only tokens and shared components |
 | IOS-014 | P0 | Build native tabbed app shell (FE02) | IOS | 2026-02-15 | DONE | IOS-013 | TabView + per-tab NavigationStack with centralized tab routing |


### PR DESCRIPTION
## Summary
- Align Phase I board mapping for FE02 tab shell to IOS-002

## Changes
- Update IOS-002 row to reflect tab shell completion and dependencies

## Validation
- `just backend-check` (pre-pull) => pass
- `just ios-build` => failed (SwiftPM manifest diagnostics permission + CoreSimulator runtime unavailable)

## Issue
Relates to #68
