### PR TITLE
P0-FE02: Tab shell routing refactor

### DIFF
--- a/alfred/alfred/Views/AppTabShellView.swift
+++ b/alfred/alfred/Views/AppTabShellView.swift
@@ -5,65 +5,55 @@ import SwiftUI
 struct AppTabShellView: View {
     @Environment(Clerk.self) private var clerk
     @ObservedObject var model: AppModel
-    @State private var homePath = NavigationPath()
-    @State private var activityPath = NavigationPath()
-    @State private var connectorsPath = NavigationPath()
-    @State private var profilePath = NavigationPath()
+    @State private var tabPaths: [AppTab: NavigationPath] = AppTabShellView.defaultPaths()
 
     var body: some View {
         TabView(selection: $model.selectedTab) {
-            tabRoot(title: AppTab.home.title, path: $homePath) {
-                HomeView(model: model)
+            ForEach(AppTab.allCases, id: \.self) { tab in
+                NavigationStack(path: binding(for: tab)) {
+                    tabContent(for: tab)
+                        .navigationTitle(tab.title)
+                        .toolbarBackground(AppTheme.Colors.background, for: .navigationBar)
+                        .toolbarBackground(.visible, for: .navigationBar)
+                        .toolbar {
+                            ToolbarItem(placement: .topBarTrailing) {
+                                if clerk.user != nil {
+                                    UserButton()
+                                        .frame(width: 36, height: 36)
+                                }
+                            }
+                        }
+                }
+                .tabItem {
+                    Label(tab.title, systemImage: tab.systemImage)
+                }
+                .tag(tab)
             }
-            .tabItem {
-                Label(AppTab.home.title, systemImage: AppTab.home.systemImage)
-            }
-            .tag(AppTab.home)
-
-            tabRoot(title: AppTab.activity.title, path: $activityPath) {
-                ActivityView(model: model)
-            }
-            .tabItem {
-                Label(AppTab.activity.title, systemImage: AppTab.activity.systemImage)
-            }
-            .tag(AppTab.activity)
-
-            tabRoot(title: AppTab.connectors.title, path: $connectorsPath) {
-                ConnectorsView(model: model)
-            }
-            .tabItem {
-                Label(AppTab.connectors.title, systemImage: AppTab.connectors.systemImage)
-            }
-            .tag(AppTab.connectors)
-
-            tabRoot(title: AppTab.profile.title, path: $profilePath) {
-                ProfileView(model: model)
-            }
-            .tabItem {
-                Label(AppTab.profile.title, systemImage: AppTab.profile.systemImage)
-            }
-            .tag(AppTab.profile)
         }
     }
 
-    private func tabRoot<Content: View>(
-        title: String,
-        path: Binding<NavigationPath>,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        NavigationStack(path: path) {
-            content()
-                .navigationTitle(title)
-                .toolbarBackground(AppTheme.Colors.background, for: .navigationBar)
-                .toolbarBackground(.visible, for: .navigationBar)
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        if clerk.user != nil {
-                            UserButton()
-                                .frame(width: 36, height: 36)
-                        }
-                    }
-                }
+    private static func defaultPaths() -> [AppTab: NavigationPath] {
+        Dictionary(uniqueKeysWithValues: AppTab.allCases.map { ($0, NavigationPath()) })
+    }
+
+    private func binding(for tab: AppTab) -> Binding<NavigationPath> {
+        Binding(
+            get: { tabPaths[tab] ?? NavigationPath() },
+            set: { tabPaths[tab] = $0 }
+        )
+    }
+
+    @ViewBuilder
+    private func tabContent(for tab: AppTab) -> some View {
+        switch tab {
+        case .home:
+            HomeView(model: model)
+        case .activity:
+            ActivityView(model: model)
+        case .connectors:
+            ConnectorsView(model: model)
+        case .profile:
+            ProfileView(model: model)
         }
     }
 }


### PR DESCRIPTION
## Summary
Refactor the tab shell to build tabs from the centralized AppTab list and keep per-tab navigation paths in a shared map.

## Changes
- Build the TabView from AppTab.allCases.
- Consolidate per-tab NavigationStack bindings in AppTabShellView.
- Keep toolbar/tab labels aligned with AppTab metadata.

## Validation
- `just backend-check`
- `just ios-build`

## AI Review Summary

### 1) Security Audit
- Findings: none
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: none
- Repro or test evidence: `just ios-build`
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: none
- Performance/scalability concerns: none
- Refactor recommendations: none

### 4) Final Status
- `just backend-deep-review`: n/a (no backend changes)
- Merge recommendation: APPROVE

## Issue
Closes #68
