### PR TITLE
P0-FE03: Redesign home screen command center

### DIFF
--- a/alfred/alfred/Views/HomeView.swift
+++ b/alfred/alfred/Views/HomeView.swift
@@ -1,12 +1,50 @@
+import AlfredAPIClient
 import SwiftUI
 
 struct HomeView: View {
     @ObservedObject var model: AppModel
 
+    private var isHomeLoading: Bool {
+        model.isLoading(.loadPreferences)
+            || model.isLoading(.loadAuditEvents)
+            || model.isLoading(.startGoogleOAuth)
+            || model.isLoading(.completeGoogleOAuth)
+    }
+
+    private var hasConnector: Bool {
+        !model.connectorID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var homeErrorBanner: AppModel.ErrorBanner? {
+        guard let banner = model.errorBanner, let source = banner.sourceAction else { return nil }
+        let homeActions: Set<AppModel.Action> = [
+            .loadPreferences,
+            .loadAuditEvents,
+            .startGoogleOAuth,
+            .completeGoogleOAuth
+        ]
+        return homeActions.contains(source) ? banner : nil
+    }
+
+    private var assistantBadge: (title: String, style: AppStatusBadge.Style) {
+        if homeErrorBanner != nil {
+            return ("Needs attention", .danger)
+        }
+        if isHomeLoading {
+            return ("Syncing", .warning)
+        }
+        return hasConnector ? ("Live", .success) : ("Setup needed", .warning)
+    }
+
+    private var lastActivityTimestamp: String? {
+        model.auditEvents.first?.timestamp.formatted(date: .abbreviated, time: .shortened)
+    }
+
     var body: some View {
         ScrollView {
             LazyVStack(spacing: AppTheme.Layout.sectionSpacing) {
                 summarySection
+                statusCardsSection
                 quickActionsSection
             }
             .padding(.horizontal, AppTheme.Layout.screenPadding)
@@ -17,14 +55,97 @@ struct HomeView: View {
 
     private var summarySection: some View {
         AppCard {
-            AppSectionHeader("Today's Summary", subtitle: "Assistant status at a glance") {
-                AppStatusBadge(title: "Live", style: .success)
+            AppSectionHeader("Today's Command Center", subtitle: "Assistant status at a glance") {
+                AppStatusBadge(title: assistantBadge.title, style: assistantBadge.style)
             }
 
-            StatusRow(title: "Connectors", status: model.googleStatusBadge)
-            StatusRow(title: "Preferences", status: model.preferencesStatusBadge)
-            StatusRow(title: "Privacy", status: model.privacyStatusBadge)
-            StatusRow(title: "Activity", status: model.activityStatusBadge)
+            if isHomeLoading {
+                HomeLoadingStateView()
+            } else if let banner = homeErrorBanner {
+                HomeInlineErrorView(
+                    message: banner.message,
+                    onRetry: banner.retryAction == nil ? nil : {
+                        Task {
+                            await model.retryLastAction()
+                        }
+                    },
+                    onDismiss: {
+                        model.dismissError()
+                    }
+                )
+            } else if !hasConnector {
+                HomeEmptyStateView(
+                    title: "Connect Google to activate Alfred",
+                    subtitle: "Link your account to enable reminders, daily briefs, and urgent alerts.",
+                    actionTitle: "Go to Connectors",
+                    action: { model.selectedTab = .connectors }
+                )
+            } else {
+                HomeSummaryRow(title: "Connectors", status: model.googleStatusBadge)
+                HomeSummaryRow(title: "Preferences", status: model.preferencesStatusBadge)
+                HomeSummaryRow(title: "Privacy", status: model.privacyStatusBadge)
+                HomeSummaryRow(title: "Activity", status: model.activityStatusBadge)
+
+                if let lastActivityTimestamp {
+                    Text("Last activity: \(lastActivityTimestamp)")
+                        .font(.footnote)
+                        .foregroundStyle(AppTheme.Colors.textSecondary)
+                } else {
+                    Text("No activity yet. Alfred will show updates once events begin flowing.")
+                        .font(.footnote)
+                        .foregroundStyle(AppTheme.Colors.textSecondary)
+                }
+            }
+        }
+    }
+
+    private var statusCardsSection: some View {
+        VStack(alignment: .leading, spacing: AppTheme.Layout.sectionSpacing) {
+            AppSectionHeader("Today's Signals", subtitle: "Reminders, briefs, and urgent alerts")
+
+            if isHomeLoading {
+                HomeStatusCardPlaceholder()
+                HomeStatusCardPlaceholder()
+                HomeStatusCardPlaceholder()
+            } else if !hasConnector {
+                AppCard {
+                    HomeEmptyStateView(
+                        title: "Signals are paused",
+                        subtitle: "Connect Google to enable reminders and alerting.",
+                        actionTitle: "Connect Google",
+                        action: { model.selectedTab = .connectors }
+                    )
+                }
+            } else {
+                HomeStatusCard(
+                    title: "Meeting Reminders",
+                    subtitle: "Calendar-driven nudges",
+                    status: ("Scheduled", .success),
+                    detail: "Remind \(model.meetingReminderMinutes) minutes before meetings.",
+                    actionTitle: "Adjust Preferences",
+                    action: { model.selectedTab = .profile }
+                )
+
+                HomeStatusCard(
+                    title: "Morning Brief",
+                    subtitle: "Daily summary delivery",
+                    status: ("Scheduled", .success),
+                    detail: "Arrives at \(model.morningBriefLocalTime) local time.",
+                    actionTitle: "Change Brief Time",
+                    action: { model.selectedTab = .profile }
+                )
+
+                HomeStatusCard(
+                    title: "Urgent Alerts",
+                    subtitle: "High-signal email detection",
+                    status: (model.highRiskRequiresConfirm ? "Confirming" : "Auto-send", .warning),
+                    detail: model.highRiskRequiresConfirm
+                        ? "High-risk alerts require confirmation."
+                        : "Urgent alerts send automatically.",
+                    actionTitle: "Review Settings",
+                    action: { model.selectedTab = .profile }
+                )
+            }
         }
     }
 
@@ -32,33 +153,41 @@ struct HomeView: View {
         AppCard {
             AppSectionHeader("Quick Actions", subtitle: "Jump to the most-used areas")
 
-            Button("Go to Connectors") {
-                model.selectedTab = .connectors
+            if !hasConnector {
+                Button("Connect Google") {
+                    model.selectedTab = .connectors
+                }
+                .buttonStyle(.appPrimary)
+            } else {
+                Button("Refresh Home") {
+                    Task {
+                        await model.loadPreferences()
+                        await model.loadAuditEvents(reset: true)
+                    }
+                }
+                .buttonStyle(.appPrimary)
+                .disabled(isHomeLoading)
             }
-            .buttonStyle(.appPrimary)
 
             Button("View Activity") {
                 model.selectedTab = .activity
             }
             .buttonStyle(.appSecondary)
 
-            Button("Profile Settings") {
+            Button("Profile & Preferences") {
                 model.selectedTab = .profile
             }
             .buttonStyle(.appSecondary)
 
-            Button("Refresh Activity") {
-                Task {
-                    await model.loadAuditEvents(reset: true)
-                }
+            Button("Open Connectors") {
+                model.selectedTab = .connectors
             }
             .buttonStyle(.appSecondary)
-            .disabled(model.isLoading(.loadAuditEvents))
         }
     }
 }
 
-private struct StatusRow: View {
+private struct HomeSummaryRow: View {
     let title: String
     let status: (title: String, style: AppStatusBadge.Style)
 
@@ -73,6 +202,130 @@ private struct StatusRow: View {
             AppStatusBadge(title: status.title, style: status.style)
         }
         .padding(.vertical, 6)
+    }
+}
+
+private struct HomeLoadingStateView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .tint(AppTheme.Colors.accent)
+                Text("Syncing your assistant status…")
+                    .font(.subheadline)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+            }
+
+            Text("Loading connector health, preferences, and activity.")
+                .font(.footnote)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+                .redacted(reason: .placeholder)
+
+            Text("Loading schedule signals.")
+                .font(.footnote)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+                .redacted(reason: .placeholder)
+        }
+    }
+}
+
+private struct HomeInlineErrorView: View {
+    let message: String
+    let onRetry: (() -> Void)?
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            AppStatusBadge(title: "Action needed", style: .danger)
+
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+
+            HStack(spacing: 12) {
+                if let onRetry {
+                    Button("Retry", action: onRetry)
+                        .buttonStyle(.appPrimary)
+                }
+
+                Button("Dismiss", action: onDismiss)
+                    .buttonStyle(.appSecondary)
+            }
+        }
+        .padding(12)
+        .background(AppTheme.Colors.surfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(AppTheme.Colors.danger, lineWidth: 1)
+        )
+    }
+}
+
+private struct HomeEmptyStateView: View {
+    let title: String
+    let subtitle: String
+    let actionTitle: String
+    let action: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+
+            Text(subtitle)
+                .font(.footnote)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+
+            Button(actionTitle, action: action)
+                .buttonStyle(.appSecondary)
+        }
+    }
+}
+
+private struct HomeStatusCard: View {
+    let title: String
+    let subtitle: String
+    let status: (title: String, style: AppStatusBadge.Style)
+    let detail: String
+    let actionTitle: String
+    let action: () -> Void
+
+    var body: some View {
+        AppCard {
+            AppSectionHeader(title, subtitle: subtitle) {
+                AppStatusBadge(title: status.title, style: status.style)
+            }
+
+            Text(detail)
+                .font(.footnote)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+
+            Button(actionTitle, action: action)
+                .buttonStyle(.appSecondary)
+        }
+    }
+}
+
+private struct HomeStatusCardPlaceholder: View {
+    var body: some View {
+        AppCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Loading signal")
+                    .font(.headline)
+                    .foregroundStyle(AppTheme.Colors.textPrimary)
+                    .redacted(reason: .placeholder)
+
+                Text("Loading details…")
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+                    .redacted(reason: .placeholder)
+
+                ProgressView()
+                    .tint(AppTheme.Colors.accent)
+            }
+        }
     }
 }
 

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -144,6 +144,7 @@ Ship a private beta where iOS users can:
 | IOS-003 | P0 | Build Google connect UI flow | IOS | 2026-03-06 | DONE | BE-005 | Google connect completes in app |
 | IOS-013 | P0 | Dark-mode theme tokens + shared UI primitives (FE01) | IOS | 2026-02-16 | DONE | - | App uses dark-only tokens and shared components |
 | IOS-014 | P0 | Build native tabbed app shell (FE02) | IOS | 2026-02-15 | DONE | IOS-013 | TabView + per-tab NavigationStack with centralized tab routing |
+| IOS-015 | P0 | Home screen v1 redesign (FE03) | IOS | 2026-02-15 | DONE | IOS-014 | Home screen shows summary, status cards, quick actions, and loading/empty/error states |
 | IOS-004 | P0 | Build preferences screen | IOS | 2026-03-08 | TODO | BE-008 | Preferences read/write works |
 | IOS-005 | P0 | Build activity log screen | IOS | 2026-03-12 | TODO | BE-009 | Audit entries visible in app |
 | IOS-006 | P0 | Build privacy controls (revoke + delete-all) | IOS | 2026-03-14 | TODO | BE-007, BE-010 | Revoke/delete flows complete |


### PR DESCRIPTION
## Summary
Redesign the Home screen into a command center with summary, signals, and quick actions.

## Changes
- Rebuilt the Home layout with summary and status cards.
- Added loading/empty/error presentation for Home sections.
- Updated the Phase I board with IOS-015 completion.

## Validation
- `just backend-check`
- `just ios-build`

## AI Review Summary

### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: manual review + `just ios-build`
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no findings
- Performance/scalability concerns: no findings
- Refactor recommendations: none

### 4) Final Status
- `just backend-deep-review`: n/a (frontend-only)
- Merge recommendation: APPROVE

## Issue
Closes #69
