### PR TITLE
P0-FE04: Activity timeline screen

### DIFF
--- a/alfred/alfred/Views/ActivityComponents.swift
+++ b/alfred/alfred/Views/ActivityComponents.swift
@@ -1,0 +1,269 @@
+import AlfredAPIClient
+import SwiftUI
+enum ActivityFilter: String, CaseIterable {
+    case all
+    case reminder
+    case brief
+    case urgent
+    case system
+    var title: String {
+        switch self {
+        case .all: return "All"
+        case .reminder: return "Reminder"
+        case .brief: return "Brief"
+        case .urgent: return "Urgent"
+        case .system: return "System"
+        }
+    }
+    var color: Color {
+        switch self {
+        case .all:
+            return AppTheme.Colors.textSecondary
+        case .reminder:
+            return AppTheme.Colors.accent
+        case .brief:
+            return AppTheme.Colors.success
+        case .urgent:
+            return AppTheme.Colors.danger
+        case .system:
+            return AppTheme.Colors.warning
+        }
+    }
+    func matches(event: AuditEvent) -> Bool {
+        guard self != .all else { return true }
+        return ActivityFilter.category(for: event) == self
+    }
+    static func category(for event: AuditEvent) -> ActivityFilter {
+        let type = event.eventType.lowercased()
+        if type.contains("reminder") {
+            return .reminder
+        }
+        if type.contains("brief") {
+            return .brief
+        }
+        if type.contains("urgent") {
+            return .urgent
+        }
+        if type.contains("system") {
+            return .system
+        }
+        return .system
+    }
+}
+struct ActivityFilterPicker: View {
+    @Binding var selectedFilter: ActivityFilter
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(ActivityFilter.allCases, id: \.self) { filter in
+                    ActivityFilterChip(
+                        title: filter.title,
+                        isSelected: selectedFilter == filter,
+                        tint: filter.color
+                    )
+                    .onTapGesture {
+                        selectedFilter = filter
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+}
+struct ActivityFilterChip: View {
+    let title: String
+    let isSelected: Bool
+    let tint: Color
+    var body: some View {
+        Text(title)
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(isSelected ? AppTheme.Colors.textPrimary : AppTheme.Colors.textSecondary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(isSelected ? tint.opacity(0.2) : AppTheme.Colors.surfaceElevated)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(isSelected ? tint : AppTheme.Colors.outline, lineWidth: 1)
+            )
+            .accessibilityLabel("Filter \(title)")
+    }
+}
+struct ActivityTimeline: View {
+    let events: [AuditEvent]
+    var body: some View {
+        VStack(spacing: 12) {
+            ForEach(events.indices, id: \.self) { index in
+                let event = events[index]
+                let isLast = index == events.count - 1
+                let category = ActivityFilter.category(for: event)
+                NavigationLink {
+                    ActivityEventDetailView(event: event, category: category)
+                } label: {
+                    ActivityTimelineRow(event: event, category: category, isLast: isLast)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+struct ActivityTimelineRow: View {
+    let event: AuditEvent
+    let category: ActivityFilter
+    let isLast: Bool
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ActivityTimelineMarker(isLast: isLast, tint: category.color)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .center, spacing: 8) {
+                    Text(event.eventType)
+                        .font(.headline)
+                        .foregroundStyle(AppTheme.Colors.textPrimary)
+                    ActivityCategoryPill(title: category.title, tint: category.color)
+                }
+                Text(event.timestamp.formatted(date: .abbreviated, time: .shortened))
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+                if let connector = event.connector, !connector.isEmpty {
+                    Text("Connector: \(connector)")
+                        .font(.footnote)
+                        .foregroundStyle(AppTheme.Colors.textSecondary)
+                }
+                Text("Result: \(event.result)")
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+            }
+            .padding(.vertical, 2)
+            Spacer(minLength: 0)
+        }
+    }
+}
+struct ActivityTimelineMarker: View {
+    let isLast: Bool
+    let tint: Color
+    var body: some View {
+        VStack(spacing: 0) {
+            Circle()
+                .fill(tint)
+                .frame(width: 10, height: 10)
+                .padding(.top, 4)
+            Rectangle()
+                .fill(AppTheme.Colors.outline)
+                .frame(width: 2)
+                .opacity(isLast ? 0 : 1)
+                .padding(.top, 4)
+                .frame(maxHeight: .infinity)
+        }
+        .frame(width: 16)
+    }
+}
+struct ActivityCategoryPill: View {
+    let title: String
+    let tint: Color
+    var body: some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(tint.opacity(0.2))
+            )
+    }
+}
+struct ActivityInlineButton: View {
+    let title: String
+    let action: () -> Void
+    var body: some View {
+        Button(title, action: action)
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(AppTheme.Colors.textPrimary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(AppTheme.Colors.surfaceElevated)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(AppTheme.Colors.outline, lineWidth: 1)
+            )
+            .accessibilityLabel(title)
+    }
+}
+struct ActivityCallout: View {
+    let title: String
+    let message: String
+    let buttonTitle: String
+    let action: () -> Void
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+            ActivityInlineButton(title: buttonTitle, action: action)
+        }
+        .padding(12)
+        .background(AppTheme.Colors.surfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(AppTheme.Colors.outline, lineWidth: 1)
+        )
+    }
+}
+struct ActivityEmptyState: View {
+    let title: String
+    let message: String
+    let buttonTitle: String
+    let action: () -> Void
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+            ActivityInlineButton(title: buttonTitle, action: action)
+        }
+        .padding(.vertical, 8)
+    }
+}
+struct ActivityLoadingState: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            ForEach(0..<3, id: \.self) { _ in
+                ActivityLoadingRow()
+            }
+        }
+        .redacted(reason: .placeholder)
+    }
+}
+struct ActivityLoadingRow: View {
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ActivityTimelineMarker(isLast: false, tint: AppTheme.Colors.outline)
+            VStack(alignment: .leading, spacing: 6) {
+                Rectangle()
+                    .fill(AppTheme.Colors.surfaceElevated)
+                    .frame(height: 16)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                Rectangle()
+                    .fill(AppTheme.Colors.surfaceElevated)
+                    .frame(height: 12)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                Rectangle()
+                    .fill(AppTheme.Colors.surfaceElevated)
+                    .frame(height: 12)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
+        }
+    }
+}

--- a/alfred/alfred/Views/ActivityDetailView.swift
+++ b/alfred/alfred/Views/ActivityDetailView.swift
@@ -1,0 +1,79 @@
+import AlfredAPIClient
+import SwiftUI
+
+struct ActivityEventDetailView: View {
+    let event: AuditEvent
+    let category: ActivityFilter
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: AppTheme.Layout.sectionSpacing) {
+                AppCard {
+                    AppSectionHeader("Event Detail", subtitle: event.eventType) {
+                        ActivityCategoryPill(title: category.title, tint: category.color)
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        ActivityDetailRow(label: "Timestamp", value: event.timestamp.formatted(date: .abbreviated, time: .shortened))
+                        ActivityDetailRow(label: "Result", value: event.result)
+
+                        if let connector = event.connector, !connector.isEmpty {
+                            ActivityDetailRow(label: "Connector", value: connector)
+                        }
+                    }
+                }
+
+                AppCard {
+                    AppSectionHeader("Metadata", subtitle: event.metadata.isEmpty ? "No metadata attached" : nil)
+
+                    if event.metadata.isEmpty {
+                        Text("Metadata will appear here when events include additional context.")
+                            .font(.footnote)
+                            .foregroundStyle(AppTheme.Colors.textSecondary)
+                    } else {
+                        VStack(alignment: .leading, spacing: 10) {
+                            ForEach(event.metadata.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
+                                ActivityDetailRow(label: key, value: value.displayValue)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, AppTheme.Layout.screenPadding)
+            .padding(.vertical, AppTheme.Layout.sectionSpacing)
+        }
+        .appScreenBackground()
+        .navigationTitle("Activity")
+    }
+}
+
+struct ActivityDetailRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+            Text(value)
+                .font(.footnote)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+        }
+    }
+}
+
+extension StringOrNumberOrBool {
+    var displayValue: String {
+        switch self {
+        case .string(let value):
+            return value
+        case .int(let value):
+            return String(value)
+        case .double(let value):
+            return String(format: "%.2f", value)
+        case .bool(let value):
+            return value ? "true" : "false"
+        }
+    }
+}

--- a/alfred/alfred/Views/ActivityView.swift
+++ b/alfred/alfred/Views/ActivityView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ActivityView: View {
     @ObservedObject var model: AppModel
+    @State private var selectedFilter: ActivityFilter = .all
 
     var body: some View {
         ScrollView {
@@ -18,53 +19,96 @@ struct ActivityView: View {
     private var activitySection: some View {
         AppCard {
             AppSectionHeader("Activity Log", subtitle: "Recent events and outcomes") {
-                AppStatusBadge(title: model.activityStatusBadge.title, style: model.activityStatusBadge.style)
-            }
+                HStack(spacing: 8) {
+                    AppStatusBadge(title: model.activityStatusBadge.title, style: model.activityStatusBadge.style)
 
-            Button("Refresh Activity") {
-                Task {
-                    await model.loadAuditEvents(reset: true)
-                }
-            }
-            .buttonStyle(.appSecondary)
-            .disabled(model.isLoading(.loadAuditEvents))
-
-            if model.auditEvents.isEmpty {
-                Text("No events yet.")
-                    .font(.footnote)
-                    .foregroundStyle(AppTheme.Colors.textSecondary)
-            } else {
-                ForEach(model.auditEvents, id: \.id) { event in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(event.eventType)
-                            .font(.headline)
-                            .foregroundStyle(AppTheme.Colors.textPrimary)
-                        Text(event.timestamp.formatted(date: .abbreviated, time: .shortened))
-                            .font(.footnote)
-                            .foregroundStyle(AppTheme.Colors.textSecondary)
-                        Text("Result: \(event.result)")
-                            .font(.footnote)
-                            .foregroundStyle(AppTheme.Colors.textSecondary)
+                    ActivityInlineButton(title: "Refresh") {
+                        Task { await model.loadAuditEvents(reset: true) }
                     }
-                    .padding(.vertical, 6)
+                    .disabled(model.isLoading(.loadAuditEvents))
                 }
+            }
+
+            ActivityFilterPicker(selectedFilter: $selectedFilter)
+
+            if showErrorCallout, let errorBanner = activityErrorBanner {
+                ActivityCallout(
+                    title: "Activity feed error",
+                    message: errorBanner.message,
+                    buttonTitle: "Retry"
+                ) {
+                    Task { await model.loadAuditEvents(reset: true) }
+                }
+            }
+
+            if isInitialLoading {
+                ActivityLoadingState()
+            } else if filteredEvents.isEmpty {
+                ActivityEmptyState(
+                    title: emptyStateTitle,
+                    message: emptyStateMessage,
+                    buttonTitle: emptyStateButtonTitle
+                ) {
+                    Task { await model.loadAuditEvents(reset: true) }
+                }
+            } else {
+                ActivityTimeline(events: filteredEvents)
             }
 
             if model.canLoadMoreAuditEvents {
-                Button("Load More") {
-                    Task {
-                        await model.loadAuditEvents(reset: false)
-                    }
+                ActivityInlineButton(title: model.isLoading(.loadAuditEvents) ? "Loading…" : "Load More") {
+                    Task { await model.loadAuditEvents(reset: false) }
                 }
-                .buttonStyle(.appSecondary)
                 .disabled(model.isLoading(.loadAuditEvents))
             }
-
-            if model.isLoading(.loadAuditEvents) {
-                ProgressView()
-                    .tint(AppTheme.Colors.accent)
-            }
         }
+    }
+
+    private var isInitialLoading: Bool {
+        model.isLoading(.loadAuditEvents) && model.auditEvents.isEmpty
+    }
+
+    private var activityErrorBanner: AppModel.ErrorBanner? {
+        guard let banner = model.errorBanner, banner.sourceAction == .loadAuditEvents else { return nil }
+        return banner
+    }
+
+    private var showErrorCallout: Bool {
+        activityErrorBanner != nil && !model.auditEvents.isEmpty
+    }
+
+    private var filteredEvents: [AuditEvent] {
+        model.auditEvents.filter { selectedFilter.matches(event: $0) }
+    }
+
+    private var emptyStateTitle: String {
+        if activityErrorBanner != nil && model.auditEvents.isEmpty {
+            return "Unable to load activity"
+        }
+
+        switch selectedFilter {
+        case .all:
+            return "No activity yet"
+        default:
+            return "No \(selectedFilter.title.lowercased()) events"
+        }
+    }
+
+    private var emptyStateMessage: String {
+        if let errorBanner = activityErrorBanner, model.auditEvents.isEmpty {
+            return errorBanner.message
+        }
+
+        switch selectedFilter {
+        case .all:
+            return "Alfred will show updates once events begin flowing."
+        default:
+            return "Try another filter or refresh to check for new events."
+        }
+    }
+
+    private var emptyStateButtonTitle: String {
+        activityErrorBanner != nil && model.auditEvents.isEmpty ? "Retry" : "Refresh Activity"
     }
 }
 

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -146,7 +146,7 @@ Ship a private beta where iOS users can:
 | IOS-014 | P0 | Build native tabbed app shell (FE02) | IOS | 2026-02-15 | DONE | IOS-013 | TabView + per-tab NavigationStack with centralized tab routing |
 | IOS-015 | P0 | Home screen v1 redesign (FE03) | IOS | 2026-02-15 | DONE | IOS-014 | Home screen shows summary, status cards, quick actions, and loading/empty/error states |
 | IOS-004 | P0 | Build preferences screen | IOS | 2026-03-08 | TODO | BE-008 | Preferences read/write works |
-| IOS-005 | P0 | Build activity log screen | IOS | 2026-03-12 | TODO | BE-009 | Audit entries visible in app |
+| IOS-005 | P0 | Build activity log screen | IOS | 2026-03-12 | DONE | BE-009 | Audit entries visible in app |
 | IOS-006 | P0 | Build privacy controls (revoke + delete-all) | IOS | 2026-03-14 | TODO | BE-007, BE-010 | Revoke/delete flows complete |
 | IOS-007 | P1 | Add offline/error state UI patterns | IOS | 2026-03-16 | TODO | IOS-003 | UX handles API failures cleanly |
 | IOS-008 | P1 | Add analytics events (privacy-safe) | IOS | 2026-03-18 | TODO | PROD-003 | KPI events emitting |


### PR DESCRIPTION
## Summary
- build the Activity timeline screen with filters, pagination, and detail drill-in
- add reusable Activity UI components and detail view
- mark IOS-005 as done on the Phase I board

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`

## Issue
Closes #70
