### PR TITLE
Combine ngrok with just dev

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -156,6 +156,7 @@ dev:
     @trap 'kill 0' INT TERM EXIT; \
       (cd {{ backend_dir }} && cargo run -p api-server) & \
       (cd {{ backend_dir }} && cargo run -p worker) & \
+      (just ngrok) & \
       wait
 
 # Show key project docs.
@@ -173,4 +174,8 @@ sync-master:
 
 # Start ngrok tunnel to localhost:8080
 ngrok:
-    ngrok http 8080 --domain $(cat .ngrok-domain)
+    @if [ -f .ngrok-domain ] && [ -n "$$(cat .ngrok-domain)" ]; then \
+      ngrok http 8080 --domain "$$(cat .ngrok-domain)"; \
+    else \
+      ngrok http 8080; \
+    fi


### PR DESCRIPTION
## Summary
- run `ngrok` in the same process group as `just dev` so one command starts API, worker, and tunnel
- keep `just ngrok` usable directly
- add fallback behavior so `just ngrok` works even when `.ngrok-domain` is missing

## Validation
- `just --dry-run dev`
- `just --dry-run ngrok`
