### PR TITLE
Fix ngrok domain substitution in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -174,8 +174,8 @@ sync-master:
 
 # Start ngrok tunnel to localhost:8080
 ngrok:
-    @if [ -f .ngrok-domain ] && [ -n "$$(cat .ngrok-domain)" ]; then \
-      ngrok http 8080 --domain "$$(cat .ngrok-domain)"; \
+    @if [ -f .ngrok-domain ] && [ -n "$(cat .ngrok-domain)" ]; then \
+      ngrok http 8080 --domain "$(cat .ngrok-domain)"; \
     else \
       ngrok http 8080; \
     fi


### PR DESCRIPTION
## Summary
- fix `ngrok` recipe command substitution in `Justfile`
- replace `$$(` with `$(` so shell runs `cat .ngrok-domain` instead of expanding `$$` to PID

## Validation
- `just --dry-run ngrok`
- `just --dry-run dev`
