### PR TITLE
FE05: Connectors hub v1 with stateful Google actions

### DIFF
--- a/alfred/alfred/AppModel.swift
+++ b/alfred/alfred/AppModel.swift
@@ -195,6 +195,11 @@ final class AppModel: ObservableObject {
 
         await run(action: .revokeConnector, retryAction: .revokeConnector(connectorID: id)) { [self] in
             let response = try await apiClient.revokeConnector(connectorID: id)
+            if response.status == .revoked {
+                connectorID = ""
+                googleAuthURL = ""
+                googleState = ""
+            }
             revokeStatus = "Connector status: \(response.status.rawValue)."
         }
     }

--- a/alfred/alfred/Views/ConnectorsView.swift
+++ b/alfred/alfred/Views/ConnectorsView.swift
@@ -3,9 +3,87 @@ import SwiftUI
 struct ConnectorsView: View {
     @ObservedObject var model: AppModel
 
+    private struct FutureConnector: Identifiable {
+        let id: String
+        let title: String
+        let subtitle: String
+    }
+
+    private var hasConnector: Bool {
+        !model.connectorID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var hasPendingConsent: Bool {
+        !model.googleState.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var hasConsentURL: Bool {
+        !model.googleAuthURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var isGoogleActionInFlight: Bool {
+        model.isLoading(.startGoogleOAuth)
+            || model.isLoading(.completeGoogleOAuth)
+            || model.isLoading(.revokeConnector)
+    }
+
+    private var connectorsErrorBanner: AppModel.ErrorBanner? {
+        guard let banner = model.errorBanner, let source = banner.sourceAction else {
+            return nil
+        }
+        let connectorActions: Set<AppModel.Action> = [
+            .startGoogleOAuth,
+            .completeGoogleOAuth,
+            .revokeConnector
+        ]
+        return connectorActions.contains(source) ? banner : nil
+    }
+
+    private var hubStatusBadge: (title: String, style: AppStatusBadge.Style) {
+        if connectorsErrorBanner != nil {
+            return ("Action needed", .danger)
+        }
+        if isGoogleActionInFlight {
+            return ("Syncing", .warning)
+        }
+        return hasConnector ? ("Operational", .success) : ("Setup pending", .warning)
+    }
+
+    private var googleHealthBadge: (title: String, style: AppStatusBadge.Style) {
+        if connectorsErrorBanner != nil {
+            return ("Issue", .danger)
+        }
+        if isGoogleActionInFlight {
+            return ("Syncing", .warning)
+        }
+        if hasConnector {
+            return ("Healthy", .success)
+        }
+        if hasPendingConsent {
+            return ("Awaiting consent", .warning)
+        }
+        return ("Not configured", .neutral)
+    }
+
+    private var googleActionTitle: String {
+        hasConnector ? "Reconnect Google" : "Connect Google"
+    }
+
+    private var futureConnectors: [FutureConnector] {
+        [
+            FutureConnector(id: "microsoft", title: "Microsoft 365", subtitle: "Calendar + Outlook"),
+            FutureConnector(id: "slack", title: "Slack", subtitle: "Priority message alerts"),
+            FutureConnector(id: "notion", title: "Notion", subtitle: "Tasks and project status")
+        ]
+    }
+
     var body: some View {
         ScrollView {
             LazyVStack(spacing: AppTheme.Layout.sectionSpacing) {
+                summarySection
+                if let banner = connectorsErrorBanner {
+                    errorSection(banner: banner)
+                }
                 googleSection
                 futureSection
             }
@@ -15,43 +93,127 @@ struct ConnectorsView: View {
         .appScreenBackground()
     }
 
+    private var summarySection: some View {
+        AppCard {
+            AppSectionHeader("Connectors Hub", subtitle: "Connection health and provider controls") {
+                AppStatusBadge(title: hubStatusBadge.title, style: hubStatusBadge.style)
+            }
+
+            ConnectorSignalRow(title: "Connected providers", value: hasConnector ? "1 of 1 live" : "0 of 1 live")
+            ConnectorSignalRow(
+                title: "Google health",
+                value: googleHealthBadge.title,
+                valueStyle: googleHealthBadge.style
+            )
+            ConnectorSignalRow(
+                title: "Expansion readiness",
+                value: "Future providers can be added without redesign"
+            )
+        }
+    }
+
+    private func errorSection(banner: AppModel.ErrorBanner) -> some View {
+        AppCard {
+            AppSectionHeader("Connector issue", subtitle: "Review and retry") {
+                AppStatusBadge(title: "Needs attention", style: .danger)
+            }
+
+            Text(banner.message)
+                .font(.subheadline)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+
+            Text("If this looks transient or network-related, retry first. If it persists, reconnect Google.")
+                .font(.footnote)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+
+            HStack(spacing: 12) {
+                if banner.retryAction != nil {
+                    Button("Retry") {
+                        Task {
+                            await model.retryLastAction()
+                        }
+                    }
+                    .buttonStyle(.appPrimary)
+                }
+
+                Button("Dismiss") {
+                    model.dismissError()
+                }
+                .buttonStyle(.appSecondary)
+            }
+        }
+    }
+
     private var googleSection: some View {
         AppCard {
             AppSectionHeader("Google Connect", subtitle: "Calendar + Gmail permissions") {
                 AppStatusBadge(title: model.googleStatusBadge.title, style: model.googleStatusBadge.style)
             }
 
-            TextField("Redirect URI", text: $model.redirectURI)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .appFieldStyle()
+            ConnectorSignalRow(
+                title: "Connector health",
+                value: googleHealthBadge.title,
+                valueStyle: googleHealthBadge.style
+            )
 
-            Button("Start Google OAuth") {
+            Button(googleActionTitle) {
                 Task {
                     await model.startGoogleOAuth()
                 }
             }
             .buttonStyle(.appPrimary)
-            .disabled(model.isLoading(.startGoogleOAuth))
+            .disabled(isGoogleActionInFlight)
 
-            if let authURL = URL(string: model.googleAuthURL), !model.googleAuthURL.isEmpty {
-                Link("Open Google Consent", destination: authURL)
-                    .font(.footnote)
+            if let authURL = URL(string: model.googleAuthURL), hasConsentURL {
+                Link("Open Google Consent Screen", destination: authURL)
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(AppTheme.Colors.accent)
             }
 
-            if !model.googleState.isEmpty {
-                Text("State: \(model.googleState)")
+            if hasPendingConsent {
+                Text("Consent is pending. Return here after Google approval and Alfred will finish setup automatically.")
                     .font(.footnote)
                     .foregroundStyle(AppTheme.Colors.textSecondary)
-                    .textSelection(.enabled)
+            } else if !hasConnector {
+                Text("No active Google connector yet. Connect to enable reminders, briefs, and urgent alerts.")
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
             }
 
-            Text("After consent, Alfred completes OAuth automatically when you return to the app.")
+            if hasConnector {
+                Button("Revoke Google Access") {
+                    Task {
+                        await model.revokeConnector()
+                    }
+                }
+                .buttonStyle(.appSecondary)
+                .disabled(isGoogleActionInFlight)
+            }
+
+            if !model.connectorID.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Connector ID")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(AppTheme.Colors.textSecondary)
+
+                    Text(model.connectorID)
+                        .font(.footnote.monospaced())
+                        .foregroundStyle(AppTheme.Colors.textPrimary)
+                        .textSelection(.enabled)
+                }
+            }
+
+            if !model.revokeStatus.isEmpty {
+                Text(model.revokeStatus)
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+            }
+
+            Text("Redirect URI: \(model.redirectURI)")
                 .font(.footnote)
                 .foregroundStyle(AppTheme.Colors.textSecondary)
 
-            if model.isLoading(.startGoogleOAuth) || model.isLoading(.completeGoogleOAuth) {
+            if isGoogleActionInFlight {
                 ProgressView()
                     .tint(AppTheme.Colors.accent)
             }
@@ -62,10 +224,66 @@ struct ConnectorsView: View {
         AppCard {
             AppSectionHeader("More Connectors", subtitle: "Additional providers are coming soon")
 
-            Text("We’ll add new integrations here without changing the layout.")
-                .font(.footnote)
-                .foregroundStyle(AppTheme.Colors.textSecondary)
+            ForEach(futureConnectors) { connector in
+                FutureConnectorRow(title: connector.title, subtitle: connector.subtitle)
+            }
         }
+    }
+}
+
+private struct ConnectorSignalRow: View {
+    let title: String
+    let value: String
+    var valueStyle: AppStatusBadge.Style?
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+
+            Spacer(minLength: 12)
+
+            if let valueStyle {
+                AppStatusBadge(title: value, style: valueStyle)
+            } else {
+                Text(value)
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+                    .multilineTextAlignment(.trailing)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct FutureConnectorRow: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(AppTheme.Colors.textPrimary)
+
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+            }
+
+            Spacer(minLength: 12)
+
+            AppStatusBadge(title: "Planned", style: .neutral)
+        }
+        .padding(12)
+        .background(AppTheme.Colors.surfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(AppTheme.Colors.outline, lineWidth: 1)
+        )
     }
 }
 

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -141,7 +141,7 @@ Ship a private beta where iOS users can:
 |---|---|---|---|---|---|---|---|
 | IOS-001 | P0 | Integrate Clerk iOS auth and API token provider wiring | IOS | 2026-02-27 | TODO | BE-001 | App obtains Clerk token and authenticated API calls succeed |
 | IOS-002 | P0 | Native bottom-tab app shell with per-tab navigation stacks (FE02) | IOS | 2026-02-16 | DONE | IOS-013 | Four-tab shell with independent NavigationStack + centralized tab routing |
-| IOS-003 | P0 | Build Google connect UI flow | IOS | 2026-03-06 | DONE | BE-005 | Google connect completes in app |
+| IOS-003 | P0 | Build Google connect UI flow + Connectors hub v1 (FE05) | IOS | 2026-03-06 | DONE | BE-005 | Connectors tab shows Google state/actions, error+retry UX, and extensible future-provider layout |
 | IOS-013 | P0 | Dark-mode theme tokens + shared UI primitives (FE01) | IOS | 2026-02-16 | DONE | - | App uses dark-only tokens and shared components |
 | IOS-014 | P0 | Build native tabbed app shell (FE02) | IOS | 2026-02-15 | DONE | IOS-013 | TabView + per-tab NavigationStack with centralized tab routing |
 | IOS-015 | P0 | Home screen v1 redesign (FE03) | IOS | 2026-02-15 | DONE | IOS-014 | Home screen shows summary, status cards, quick actions, and loading/empty/error states |


### PR DESCRIPTION
## Summary
Implements issue #71 by redesigning the Connectors tab into a dedicated hub for Google now and future providers.

## Changes
- Reworked `ConnectorsView` into a modular Connectors hub with:
  - at-a-glance health/status summary
  - Google connect/reconnect/revoke action paths
  - loading/empty/error/retry UX states
  - future-provider placeholders to preserve extensible layout
- Hardened connector lifecycle behavior in `AppModel` so successful revoke clears local connector/OAuth state.
- Updated Phase I board mapping in `docs/phase1-master-todo.md` to explicitly include FE05 scope under `IOS-003`.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just ios-test`

## AI Review Summary
### 1) Security Audit
- Findings: Removed UI exposure of raw OAuth `state` token; no new secret handling regressions found.
- Risk level: Low
- Required fixes: None

### 2) Bug Check
- Findings: Fixed connector-state regression where revoke could leave UI as connected by clearing connector/OAuth state on `REVOKED`.
- Repro or test evidence: Local `just ios-build` and `just ios-test` both pass.
- Required fixes: None remaining

### 3) Scalability / Code Quality Review
- Findings: Connectors screen refactored into modular subviews (`ConnectorSignalRow`, `FutureConnectorRow`) with clear state derivation.
- Performance/scalability concerns: None observed for current scope.
- Refactor recommendations: None required for this issue.

### 4) Final Status
- `just backend-deep-review`: N/A (no backend code changes)
- Merge recommendation: `APPROVE`

Closes #71
