### PR TITLE
Docs: align project direction to LLM-first backend and AI migration backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,18 @@ This file is intentionally at repository root so coding agents can auto-discover
 3. Breaking changes are acceptable for auth migration at this phase.
 4. Custom `/v1/auth/ios/session*` paths should be removed or hard-disabled once Clerk path is complete.
 
+## LLM Backend Direction (Important)
+
+1. Backend assistant direction is LLM-first with OpenRouter provider routing (GitHub issues `#91` through `#103`).
+2. New AI backend work must use label `ai-backend` and align to the execution tracker issue `#103`.
+3. Existing rule-based assistant logic is deprecated and tracked for removal in issue `#91`.
+4. Do not remove core infrastructure required by LLM workflows:
+   1. OAuth/connector lifecycle
+   2. enclave/attestation token path
+   3. worker lease/retry/idempotency engine
+   4. push pipeline
+   5. privacy + audit controls
+
 ## Required Workflow
 
 1. Run `just check-tools`.
@@ -126,6 +138,7 @@ Code must remain modular by default. Do not keep adding logic to a single large 
 1. Execution queue: GitHub issues in `niteshbalusu11/alfred` with labels:
    1. `phase-1`
    2. `P0` or `P1`
+   3. `ai-backend` for LLM backend migration work
 2. Planning board: `docs/phase1-master-todo.md`
 3. Rule:
    1. If a GitHub issue and board item conflict, treat GitHub issue as immediate execution source and update docs in the same change.
@@ -189,3 +202,4 @@ Code must remain modular by default. Do not keep adding logic to a single large 
 2. Use migrations for any schema changes.
 3. Do not weaken privacy constraints (token/data handling) without explicit approval.
 4. Do not implement work outside an active GitHub issue unless explicitly requested.
+5. For LLM features, enforce schema-validated outputs and deterministic safety fallback behavior.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ In Phase I, Alfred helps users by:
 1. Sending meeting reminders from Google Calendar.
 2. Sending a daily morning brief.
 3. Sending urgent Gmail alerts.
+4. Answering natural-language assistant questions using connected Google context.
 
 ## What This Project Is
 
@@ -20,14 +21,16 @@ This repository contains the iOS app, backend services, API contract, and securi
 
 ## Architecture Overview
 
-At a high level, Alfred has six core parts:
+At a high level, Alfred has eight core parts:
 
 1. iOS app (`SwiftUI`) for sign-in, settings, and notification UX.
 2. Rust API server (`axum`) for auth, connector, preferences, audit, and privacy APIs.
-3. Rust worker (`tokio`) for scheduled/proactive processing.
-4. Encrypted Postgres for operational state.
-5. TEE-backed path for sensitive decrypt + provider fetch work.
-6. APNs delivery pipeline for user notifications.
+3. LLM orchestration layer for assistant query and proactive summaries.
+4. OpenRouter provider gateway for model routing/fallback.
+5. Rust worker (`tokio`) for scheduled/proactive processing.
+6. Encrypted Postgres for operational state.
+7. TEE-backed path for sensitive decrypt + provider fetch work.
+8. APNs delivery pipeline for user notifications.
 
 ```mermaid
 flowchart LR
@@ -62,8 +65,8 @@ Alfred is intentionally opinionated about privacy:
 ## How Alfred Delivers Value (Phase I)
 
 1. User signs in and connects Google.
-2. Alfred schedules checks for upcoming meetings and urgent inbox signals.
-3. Worker evaluates events and creates actionable nudges.
+2. Alfred assembles normalized calendar/email context for assistant capabilities.
+3. API/worker call LLM workflows (via OpenRouter) to generate summaries/prioritized actions.
 4. APNs delivers timely notifications to iOS.
 5. User can inspect activity and revoke/delete at any time.
 

--- a/agent/start.empty
+++ b/agent/start.empty
@@ -16,6 +16,12 @@ Use this file when an agent starts with minimal context.
 3. Breaking auth changes are acceptable at this phase.
 4. Remove or hard-disable legacy custom `/v1/auth/ios/session*` flow.
 
+## LLM Backend Direction (Current)
+
+1. Backend assistant direction is LLM-first with OpenRouter provider routing.
+2. Migration execution queue is GitHub issues `#91` through `#103` (`ai-backend` label).
+3. Legacy rule-based assistant logic is deprecated and tracked for removal in issue `#91`.
+
 ## Execution Rule
 
 1. GitHub issues with `phase-1` are the execution source of truth (`P0` before `P1`).

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -1,6 +1,6 @@
 # Engineering Standards (Scalability + Security)
 
-- Last Updated: 2026-02-14
+- Last Updated: 2026-02-15
 - Priority: Mandatory for all issue execution
 
 ## 1) Post-Issue Deep Review (Required)
@@ -75,3 +75,23 @@ All new code should be designed for growth:
 2. No secret values in logs, traces, or errors.
 3. Keep least-privilege behavior by default.
 4. Fail closed for invalid auth or invalid security state.
+
+## 6) LLM Integration Standards (Required)
+
+All LLM-backed backend behavior must follow these controls:
+
+1. Provider isolation:
+   1. LLM provider code must stay behind a shared gateway abstraction.
+   2. HTTP handlers and worker actions must not call provider APIs directly.
+2. Output safety:
+   1. Enforce strict schema validation for every LLM response before use.
+   2. Reject non-conforming output and return deterministic fallback content.
+3. Prompt and context hygiene:
+   1. Treat connector content as untrusted input (prompt-injection aware).
+   2. Keep context minimal and redacted; do not include raw secrets/tokens.
+4. Reliability and cost controls:
+   1. Timeouts, retries, and fallback model routing must be explicit and tested.
+   2. Add rate limits/circuit-breaker behavior for provider degradation.
+5. Observability:
+   1. Emit model, latency, usage, and cost telemetry in redacted form.
+   2. Never persist or log sensitive raw prompt/completion payloads.

--- a/docs/product-context.md
+++ b/docs/product-context.md
@@ -1,6 +1,6 @@
 # Alfred Product Context (Canonical)
 
-- Last Updated: 2026-02-14
+- Last Updated: 2026-02-15
 - Audience: Engineers, coding agents, product collaborators
 - Purpose: Provide shared context on what Alfred is, why it exists, and how to build it safely.
 
@@ -8,11 +8,12 @@
 
 Alfred is a hosted, privacy-first AI life assistant.
 
-Phase I (v1) focuses on iOS and Google integrations only:
+Phase I (v1) focuses on iOS and Google integrations with LLM-backed assistant behavior:
 
 1. Meeting reminders from Google Calendar
 2. Daily morning brief
 3. Urgent email alerts from Gmail
+4. Natural-language assistant queries over connected Google context
 
 Alfred is not trying to be a generic chatbot. It is a proactive assistant that takes useful actions and sends timely nudges with high reliability and explicit privacy controls.
 
@@ -70,10 +71,12 @@ Core components:
 
 1. iOS app (`SwiftUI`) for onboarding, settings, and notifications.
 2. Rust API server (`axum`) for Clerk-authenticated connector/preferences/privacy APIs.
-3. Rust worker (`tokio`) for scheduled and proactive jobs.
-4. Encrypted Postgres for operational state.
-5. TEE-backed sensitive execution path for token/data decryption and provider fetches.
-6. APNs pipeline for user notifications.
+3. LLM orchestration layer for assistant query + proactive summary generation.
+4. OpenRouter provider gateway with backend-controlled model routing/fallback.
+5. Rust worker (`tokio`) for scheduled and proactive jobs.
+6. Encrypted Postgres for operational state.
+7. TEE-backed sensitive execution path for token/data decryption and provider fetches.
+8. APNs pipeline for user notifications.
 
 Reference docs:
 
@@ -94,6 +97,8 @@ Required controls:
 5. Redacted logs and auditability.
 6. User controls for revoke and delete-all.
 7. No silent broadening of data access.
+8. LLM prompt-injection safeguards and output schema validation before user-visible actions.
+9. Redacted LLM telemetry (model/latency/usage) without raw sensitive payload logging.
 
 Operating rule:
 
@@ -104,8 +109,9 @@ Operating rule:
 Functional success:
 
 1. Users can connect Google reliably.
-2. Reminder/brief/urgent-email flows work end-to-end.
+2. Reminder/brief/urgent-email flows work end-to-end with LLM-backed summarization/prioritization.
 3. Revoke and delete-all are real and verifiable.
+4. Users can ask assistant questions (for example, meetings today) and receive accurate, concise answers.
 
 Quality success:
 
@@ -123,6 +129,7 @@ Execution queue:
 
 1. GitHub issues labeled `phase-1`.
 2. Priority order: `P0` first, then `P1`.
+3. LLM backend migration issues use label `ai-backend`.
 
 Planning control board:
 

--- a/docs/threat-model-phase1.md
+++ b/docs/threat-model-phase1.md
@@ -1,8 +1,8 @@
 # Phase I STRIDE Threat Model
 
-- Last Updated: 2026-02-14
+- Last Updated: 2026-02-15
 - Reviewed For Issue: `#19`
-- Scope: iOS session auth, OAuth connector lifecycle, TEE decrypt path, worker processing, privacy delete flow
+- Scope: iOS session auth, OAuth connector lifecycle, TEE decrypt path, worker processing, LLM/OpenRouter orchestration, privacy delete flow
 
 ## 1) System Boundaries
 
@@ -19,6 +19,7 @@
 3. User PII and preferences persisted in backend tables.
 4. Audit event stream proving security-sensitive actions.
 5. Attestation documents, allowed measurements, and KMS key policy bindings.
+6. LLM provider credentials, model-routing policy, and assistant output safety controls.
 
 ## 3) STRIDE Analysis
 
@@ -28,7 +29,7 @@
 | Tampering | DB row mutation of connector key metadata or status | Incorrect decrypt policy path, revoke bypass | Strict key-id/key-version checks, ACTIVE status checks, migration-backed schema | Medium: requires tight DB IAM + change auditing |
 | Repudiation | Actor denies issuing revoke/delete-all/security-sensitive actions | Weak incident forensics and support evidence | Audit events for session/connect/revoke/delete lifecycle; deterministic API outcomes | Low: enrich actor metadata over time |
 | Information Disclosure | Token/plaintext leakage via logs/errors or host decrypt path | Credential compromise and privacy breach | Redacted errors, no plaintext token logs, enclave RPC-only decrypt/refresh/revoke path, attestation/KMS gating | Low-Medium: guardrails must remain tested in CI |
-| Denial of Service | Endpoint abuse (auth/connect/delete) and retry storms | Service instability or user lockouts | Endpoint rate limiting for sensitive routes; deterministic 429 + Retry-After; worker lease/retry controls | Medium: distributed abuse needs upstream WAF controls too |
+| Denial of Service | Endpoint abuse (auth/connect/delete) and retry storms; LLM provider degradation | Service instability or user lockouts | Endpoint rate limiting for sensitive routes; deterministic 429 + Retry-After; worker lease/retry controls; provider fallback + deterministic assistant fallback | Medium: distributed abuse needs upstream WAF controls too |
 | Elevation of Privilege | Host process or compromised runtime bypasses enclave constraints | Decrypt outside trusted boundary | Compile-time host decrypt removal, enclave RPC contract, attestation verification + measurement allow-lists + KMS-bound policy; fail-closed checks | Medium: depends on secure key and attestation ops |
 
 ## 4) Threat-Specific Controls Added in This Pass


### PR DESCRIPTION
## Summary
- update core docs to establish LLM-first backend direction
- add AI backend migration queue to Phase I board mapped to issues #91-#103
- update AGENTS/start docs with `ai-backend` workflow guidance
- update RFC/product/engineering/threat docs for OpenRouter + LLM safety and observability expectations

## Files Updated
- AGENTS.md
- README.md
- agent/start.md
- agent/start.empty
- docs/phase1-master-todo.md
- docs/product-context.md
- docs/engineering-standards.md
- docs/rfc-0001-alfred-ios-v1.md
- docs/threat-model-phase1.md

## Validation
- documentation-only change
- no runtime code changes
- no tests run