### PR TITLE
P0-AI03: Build deterministic Google context assembler for LLM prompts

### DIFF
--- a/backend/crates/shared/src/llm/context.rs
+++ b/backend/crates/shared/src/llm/context.rs
@@ -1,0 +1,344 @@
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+
+use chrono::{DateTime, NaiveDate, SecondsFormat, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub const CONTEXT_CONTRACT_VERSION_V1: &str = "2026-02-15";
+
+const DEFAULT_MORNING_BRIEF_LOCAL_TIME: &str = "08:00";
+const MAX_MEETINGS: usize = 20;
+const MAX_EMAIL_CANDIDATES: usize = 20;
+const MAX_ATTENDEE_COUNT: usize = 50;
+const MAX_LABELS: usize = 8;
+const MAX_REF_CHARS: usize = 80;
+const MAX_TITLE_CHARS: usize = 120;
+const MAX_SUBJECT_CHARS: usize = 120;
+const MAX_SENDER_CHARS: usize = 120;
+const MAX_SNIPPET_CHARS: usize = 280;
+const MAX_LABEL_CHARS: usize = 32;
+const MAX_LOCAL_TIME_CHARS: usize = 16;
+
+#[derive(Debug, Clone, Default)]
+pub struct GoogleCalendarMeetingSource {
+    pub event_id: Option<String>,
+    pub title: Option<String>,
+    pub start_at: Option<DateTime<Utc>>,
+    pub end_at: Option<DateTime<Utc>>,
+    pub attendee_emails: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GoogleEmailCandidateSource {
+    pub message_id: Option<String>,
+    pub from: Option<String>,
+    pub subject: Option<String>,
+    pub snippet: Option<String>,
+    pub received_at: Option<DateTime<Utc>>,
+    pub label_ids: Vec<String>,
+    pub has_attachments: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MeetingsTodayContext {
+    pub version: String,
+    pub calendar_day: String,
+    pub meeting_count: usize,
+    pub meetings: Vec<MeetingContextEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MeetingContextEntry {
+    pub event_ref: String,
+    pub title: String,
+    pub start_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_minutes: Option<u32>,
+    pub attendee_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UrgentEmailCandidatesContext {
+    pub version: String,
+    pub candidate_count: usize,
+    pub candidates: Vec<UrgentEmailCandidateContextEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UrgentEmailCandidateContextEntry {
+    pub message_ref: String,
+    pub from: String,
+    pub subject: String,
+    pub snippet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub received_at: Option<String>,
+    pub labels: Vec<String>,
+    pub has_attachments: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MorningBriefContext {
+    pub version: String,
+    pub local_date: String,
+    pub morning_brief_local_time: String,
+    pub meetings_today_count: usize,
+    pub urgent_email_candidate_count: usize,
+    pub meetings_today: Vec<MeetingContextEntry>,
+    pub urgent_email_candidates: Vec<UrgentEmailCandidateContextEntry>,
+}
+
+pub fn assemble_meetings_today_context(
+    calendar_day: NaiveDate,
+    meetings: &[GoogleCalendarMeetingSource],
+) -> MeetingsTodayContext {
+    let mut normalized: Vec<NormalizedMeeting> = meetings
+        .iter()
+        .filter_map(|meeting| normalize_meeting(calendar_day, meeting))
+        .collect();
+
+    normalized.sort_by(|left, right| {
+        left.start_at
+            .cmp(&right.start_at)
+            .then_with(|| left.event_ref.cmp(&right.event_ref))
+            .then_with(|| left.title.cmp(&right.title))
+    });
+
+    let mut fallback_index = 0usize;
+    let meetings = normalized
+        .into_iter()
+        .take(MAX_MEETINGS)
+        .map(|meeting| {
+            let event_ref = meeting.event_ref.unwrap_or_else(|| {
+                fallback_index += 1;
+                format!("meeting-{fallback_index:03}")
+            });
+            let duration_minutes = meeting
+                .end_at
+                .and_then(|end_at| positive_minutes(end_at - meeting.start_at));
+
+            MeetingContextEntry {
+                event_ref,
+                title: meeting.title,
+                start_at: format_datetime(meeting.start_at),
+                end_at: meeting.end_at.map(format_datetime),
+                duration_minutes,
+                attendee_count: meeting.attendee_count,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    MeetingsTodayContext {
+        version: CONTEXT_CONTRACT_VERSION_V1.to_string(),
+        calendar_day: calendar_day.to_string(),
+        meeting_count: meetings.len(),
+        meetings,
+    }
+}
+
+pub fn assemble_urgent_email_candidates_context(
+    candidates: &[GoogleEmailCandidateSource],
+) -> UrgentEmailCandidatesContext {
+    let mut normalized = candidates
+        .iter()
+        .map(normalize_email_candidate)
+        .collect::<Vec<_>>();
+
+    normalized.sort_by(|left, right| {
+        compare_received_at_desc(left.received_at, right.received_at)
+            .then_with(|| left.message_ref.cmp(&right.message_ref))
+            .then_with(|| left.subject.cmp(&right.subject))
+    });
+
+    let mut fallback_index = 0usize;
+    let candidates = normalized
+        .into_iter()
+        .take(MAX_EMAIL_CANDIDATES)
+        .map(|candidate| {
+            let message_ref = candidate.message_ref.unwrap_or_else(|| {
+                fallback_index += 1;
+                format!("email-{fallback_index:03}")
+            });
+
+            UrgentEmailCandidateContextEntry {
+                message_ref,
+                from: candidate.from,
+                subject: candidate.subject,
+                snippet: candidate.snippet,
+                received_at: candidate.received_at.map(format_datetime),
+                labels: candidate.labels,
+                has_attachments: candidate.has_attachments,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    UrgentEmailCandidatesContext {
+        version: CONTEXT_CONTRACT_VERSION_V1.to_string(),
+        candidate_count: candidates.len(),
+        candidates,
+    }
+}
+
+pub fn assemble_morning_brief_context(
+    local_date: NaiveDate,
+    morning_brief_local_time: &str,
+    meetings: &[GoogleCalendarMeetingSource],
+    urgent_email_candidates: &[GoogleEmailCandidateSource],
+) -> MorningBriefContext {
+    let meetings_today_context = assemble_meetings_today_context(local_date, meetings);
+    let urgent_email_context = assemble_urgent_email_candidates_context(urgent_email_candidates);
+
+    MorningBriefContext {
+        version: CONTEXT_CONTRACT_VERSION_V1.to_string(),
+        local_date: local_date.to_string(),
+        morning_brief_local_time: normalize_local_time(morning_brief_local_time),
+        meetings_today_count: meetings_today_context.meeting_count,
+        urgent_email_candidate_count: urgent_email_context.candidate_count,
+        meetings_today: meetings_today_context.meetings,
+        urgent_email_candidates: urgent_email_context.candidates,
+    }
+}
+
+#[derive(Debug)]
+struct NormalizedMeeting {
+    event_ref: Option<String>,
+    title: String,
+    start_at: DateTime<Utc>,
+    end_at: Option<DateTime<Utc>>,
+    attendee_count: usize,
+}
+
+fn normalize_meeting(
+    calendar_day: NaiveDate,
+    meeting: &GoogleCalendarMeetingSource,
+) -> Option<NormalizedMeeting> {
+    let start_at = meeting.start_at?;
+    if start_at.date_naive() != calendar_day {
+        return None;
+    }
+
+    let attendee_count = meeting
+        .attendee_emails
+        .iter()
+        .filter_map(|email| normalize_identifier(Some(email.as_str()), MAX_REF_CHARS))
+        .collect::<BTreeSet<_>>()
+        .len()
+        .min(MAX_ATTENDEE_COUNT);
+    let end_at = meeting.end_at.filter(|end_at| *end_at > start_at);
+
+    Some(NormalizedMeeting {
+        event_ref: normalize_identifier(meeting.event_id.as_deref(), MAX_REF_CHARS),
+        title: normalize_text(
+            meeting.title.as_deref(),
+            "Untitled meeting",
+            MAX_TITLE_CHARS,
+        ),
+        start_at,
+        end_at,
+        attendee_count,
+    })
+}
+
+#[derive(Debug)]
+struct NormalizedEmailCandidate {
+    message_ref: Option<String>,
+    from: String,
+    subject: String,
+    snippet: String,
+    received_at: Option<DateTime<Utc>>,
+    labels: Vec<String>,
+    has_attachments: bool,
+}
+
+fn normalize_email_candidate(candidate: &GoogleEmailCandidateSource) -> NormalizedEmailCandidate {
+    let labels = candidate
+        .label_ids
+        .iter()
+        .filter_map(|label| normalize_identifier(Some(label.as_str()), MAX_LABEL_CHARS))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .take(MAX_LABELS)
+        .collect::<Vec<_>>();
+
+    NormalizedEmailCandidate {
+        message_ref: normalize_identifier(candidate.message_id.as_deref(), MAX_REF_CHARS),
+        from: normalize_text(
+            candidate.from.as_deref(),
+            "unknown sender",
+            MAX_SENDER_CHARS,
+        ),
+        subject: normalize_text(
+            candidate.subject.as_deref(),
+            "(no subject)",
+            MAX_SUBJECT_CHARS,
+        ),
+        snippet: normalize_text(candidate.snippet.as_deref(), "", MAX_SNIPPET_CHARS),
+        received_at: candidate.received_at,
+        labels,
+        has_attachments: candidate.has_attachments,
+    }
+}
+
+fn positive_minutes(duration: chrono::Duration) -> Option<u32> {
+    let minutes = duration.num_minutes();
+    if minutes > 0 {
+        return Some(minutes as u32);
+    }
+
+    None
+}
+
+fn compare_received_at_desc(left: Option<DateTime<Utc>>, right: Option<DateTime<Utc>>) -> Ordering {
+    match (left, right) {
+        (Some(left), Some(right)) => right.cmp(&left),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+fn normalize_local_time(value: &str) -> String {
+    let compact = collapse_whitespace(value);
+    if compact.is_empty() {
+        return DEFAULT_MORNING_BRIEF_LOCAL_TIME.to_string();
+    }
+
+    truncate_chars(&compact, MAX_LOCAL_TIME_CHARS)
+}
+
+fn normalize_text(value: Option<&str>, fallback: &str, max_chars: usize) -> String {
+    let compact = collapse_whitespace(value.unwrap_or(""));
+    if compact.is_empty() {
+        return fallback.to_string();
+    }
+
+    truncate_chars(&compact, max_chars)
+}
+
+fn normalize_identifier(value: Option<&str>, max_chars: usize) -> Option<String> {
+    let compact = collapse_whitespace(value.unwrap_or(""));
+    if compact.is_empty() {
+        return None;
+    }
+
+    Some(truncate_chars(&compact, max_chars))
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+fn format_datetime(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::Secs, true)
+}

--- a/backend/crates/shared/src/llm/mod.rs
+++ b/backend/crates/shared/src/llm/mod.rs
@@ -1,9 +1,17 @@
+pub mod context;
 pub mod contracts;
 pub mod gateway;
 pub mod openrouter;
 pub mod prompts;
 pub mod validation;
 
+pub use context::{
+    CONTEXT_CONTRACT_VERSION_V1, GoogleCalendarMeetingSource, GoogleEmailCandidateSource,
+    MeetingContextEntry, MeetingsTodayContext, MorningBriefContext,
+    UrgentEmailCandidateContextEntry, UrgentEmailCandidatesContext,
+    assemble_meetings_today_context, assemble_morning_brief_context,
+    assemble_urgent_email_candidates_context,
+};
 pub use contracts::{
     AssistantCapability, AssistantOutputContract, ContractError, MeetingsSummaryContract,
     MorningBriefContract, UrgentEmailSummaryContract, output_schema,

--- a/backend/crates/shared/tests/fixtures/meetings_today_context.json
+++ b/backend/crates/shared/tests/fixtures/meetings_today_context.json
@@ -1,0 +1,23 @@
+{
+  "version": "2026-02-15",
+  "calendar_day": "2026-02-15",
+  "meeting_count": 2,
+  "meetings": [
+    {
+      "event_ref": "meeting-001",
+      "title": "Team sync",
+      "start_at": "2026-02-15T09:30:00Z",
+      "end_at": "2026-02-15T10:00:00Z",
+      "duration_minutes": 30,
+      "attendee_count": 0
+    },
+    {
+      "event_ref": "evt-planning",
+      "title": "Platform planning review",
+      "start_at": "2026-02-15T14:00:00Z",
+      "end_at": "2026-02-15T15:15:00Z",
+      "duration_minutes": 75,
+      "attendee_count": 2
+    }
+  ]
+}

--- a/backend/crates/shared/tests/fixtures/morning_brief_context.json
+++ b/backend/crates/shared/tests/fixtures/morning_brief_context.json
@@ -1,0 +1,59 @@
+{
+  "version": "2026-02-15",
+  "local_date": "2026-02-15",
+  "morning_brief_local_time": "08:30",
+  "meetings_today_count": 2,
+  "urgent_email_candidate_count": 3,
+  "meetings_today": [
+    {
+      "event_ref": "meeting-001",
+      "title": "Team sync",
+      "start_at": "2026-02-15T09:30:00Z",
+      "end_at": "2026-02-15T10:00:00Z",
+      "duration_minutes": 30,
+      "attendee_count": 0
+    },
+    {
+      "event_ref": "evt-planning",
+      "title": "Platform planning review",
+      "start_at": "2026-02-15T14:00:00Z",
+      "end_at": "2026-02-15T15:15:00Z",
+      "duration_minutes": 75,
+      "attendee_count": 2
+    }
+  ],
+  "urgent_email_candidates": [
+    {
+      "message_ref": "msg-1",
+      "from": "Ops",
+      "subject": "Server alert",
+      "snippet": "Latency high in us-east-1",
+      "received_at": "2026-02-15T19:00:00Z",
+      "labels": [
+        "ALERT",
+        "INBOX"
+      ],
+      "has_attachments": false
+    },
+    {
+      "message_ref": "msg-2",
+      "from": "CFO <cfo@example.com>",
+      "subject": "Budget variance follow-up",
+      "snippet": "Need approval today for vendor invoice.",
+      "received_at": "2026-02-15T18:00:00Z",
+      "labels": [
+        "IMPORTANT",
+        "INBOX"
+      ],
+      "has_attachments": true
+    },
+    {
+      "message_ref": "email-001",
+      "from": "unknown sender",
+      "subject": "(no subject)",
+      "snippet": "",
+      "labels": [],
+      "has_attachments": false
+    }
+  ]
+}

--- a/backend/crates/shared/tests/fixtures/urgent_email_context.json
+++ b/backend/crates/shared/tests/fixtures/urgent_email_context.json
@@ -1,0 +1,38 @@
+{
+  "version": "2026-02-15",
+  "candidate_count": 3,
+  "candidates": [
+    {
+      "message_ref": "msg-1",
+      "from": "Ops",
+      "subject": "Server alert",
+      "snippet": "Latency high in us-east-1",
+      "received_at": "2026-02-15T19:00:00Z",
+      "labels": [
+        "ALERT",
+        "INBOX"
+      ],
+      "has_attachments": false
+    },
+    {
+      "message_ref": "msg-2",
+      "from": "CFO <cfo@example.com>",
+      "subject": "Budget variance follow-up",
+      "snippet": "Need approval today for vendor invoice.",
+      "received_at": "2026-02-15T18:00:00Z",
+      "labels": [
+        "IMPORTANT",
+        "INBOX"
+      ],
+      "has_attachments": true
+    },
+    {
+      "message_ref": "email-001",
+      "from": "unknown sender",
+      "subject": "(no subject)",
+      "snippet": "",
+      "labels": [],
+      "has_attachments": false
+    }
+  ]
+}

--- a/backend/crates/shared/tests/llm_context.rs
+++ b/backend/crates/shared/tests/llm_context.rs
@@ -1,0 +1,182 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde_json::Value;
+use shared::llm::{
+    GoogleCalendarMeetingSource, GoogleEmailCandidateSource, assemble_meetings_today_context,
+    assemble_morning_brief_context, assemble_urgent_email_candidates_context,
+};
+
+#[test]
+fn meetings_today_context_is_deterministic_and_matches_fixture() {
+    let calendar_day = date("2026-02-15");
+    let meetings = sample_meetings_unsorted();
+    let mut reversed = meetings.clone();
+    reversed.reverse();
+
+    let context = assemble_meetings_today_context(calendar_day, &meetings);
+    let reversed_context = assemble_meetings_today_context(calendar_day, &reversed);
+
+    assert_eq!(context, reversed_context);
+    assert_eq!(
+        serde_json::to_value(context).expect("context should serialize"),
+        meetings_fixture()
+    );
+}
+
+#[test]
+fn urgent_email_context_matches_fixture_and_excludes_sensitive_source_fields() {
+    let candidates = sample_email_candidates_unsorted();
+    let context = assemble_urgent_email_candidates_context(&candidates);
+    let encoded = serde_json::to_string(&context).expect("context should encode");
+
+    assert!(!encoded.contains("access_token"));
+    assert!(!encoded.contains("raw_headers"));
+    assert_eq!(
+        serde_json::to_value(context).expect("context should serialize"),
+        urgent_email_fixture()
+    );
+}
+
+#[test]
+fn morning_brief_context_matches_fixture() {
+    let local_date = date("2026-02-15");
+    let meetings = sample_meetings_unsorted();
+    let candidates = sample_email_candidates_unsorted();
+
+    let context = assemble_morning_brief_context(local_date, " 08:30 ", &meetings, &candidates);
+
+    assert_eq!(
+        serde_json::to_value(context).expect("context should serialize"),
+        morning_brief_fixture()
+    );
+}
+
+#[test]
+fn assembly_handles_empty_and_noisy_inputs_gracefully() {
+    let local_date = date("2026-02-15");
+    let noisy_meetings = vec![GoogleCalendarMeetingSource {
+        event_id: Some("".to_string()),
+        title: Some("   ".to_string()),
+        start_at: None,
+        end_at: None,
+        attendee_emails: vec![" ".to_string()],
+    }];
+    let noisy_candidates = vec![GoogleEmailCandidateSource {
+        message_id: None,
+        from: Some("   ".to_string()),
+        subject: Some("   ".to_string()),
+        snippet: Some("   ".to_string()),
+        received_at: None,
+        label_ids: vec![" ".to_string()],
+        has_attachments: false,
+    }];
+
+    let context =
+        assemble_morning_brief_context(local_date, "   ", &noisy_meetings, &noisy_candidates);
+    let encoded = serde_json::to_string(&context).expect("context should encode");
+
+    assert_eq!(context.morning_brief_local_time, "08:00");
+    assert_eq!(context.meetings_today_count, 0);
+    assert_eq!(context.urgent_email_candidate_count, 1);
+    assert_eq!(context.urgent_email_candidates[0].message_ref, "email-001");
+    assert_eq!(context.urgent_email_candidates[0].from, "unknown sender");
+    assert_eq!(context.urgent_email_candidates[0].subject, "(no subject)");
+    assert_eq!(context.urgent_email_candidates[0].snippet, "");
+    assert!(context.urgent_email_candidates[0].received_at.is_none());
+    assert!(!encoded.contains("access_token"));
+    assert!(!encoded.contains("raw_headers"));
+}
+
+fn meetings_fixture() -> Value {
+    serde_json::from_str(include_str!("fixtures/meetings_today_context.json"))
+        .expect("fixture must be valid JSON")
+}
+
+fn urgent_email_fixture() -> Value {
+    serde_json::from_str(include_str!("fixtures/urgent_email_context.json"))
+        .expect("fixture must be valid JSON")
+}
+
+fn morning_brief_fixture() -> Value {
+    serde_json::from_str(include_str!("fixtures/morning_brief_context.json"))
+        .expect("fixture must be valid JSON")
+}
+
+fn sample_meetings_unsorted() -> Vec<GoogleCalendarMeetingSource> {
+    vec![
+        GoogleCalendarMeetingSource {
+            event_id: Some("evt-planning".to_string()),
+            title: Some(" Platform planning review ".to_string()),
+            start_at: Some(ts("2026-02-15T14:00:00Z")),
+            end_at: Some(ts("2026-02-15T15:15:00Z")),
+            attendee_emails: vec![
+                "alice@example.com".to_string(),
+                "bob@example.com".to_string(),
+                "alice@example.com".to_string(),
+                " ".to_string(),
+            ],
+        },
+        GoogleCalendarMeetingSource {
+            event_id: Some("evt-missing-start".to_string()),
+            title: Some("No start time".to_string()),
+            start_at: None,
+            end_at: None,
+            attendee_emails: vec![],
+        },
+        GoogleCalendarMeetingSource {
+            event_id: None,
+            title: Some(" Team sync ".to_string()),
+            start_at: Some(ts("2026-02-15T09:30:00Z")),
+            end_at: Some(ts("2026-02-15T10:00:00Z")),
+            attendee_emails: vec![],
+        },
+        GoogleCalendarMeetingSource {
+            event_id: None,
+            title: Some("Wrong day".to_string()),
+            start_at: Some(ts("2026-02-16T08:00:00Z")),
+            end_at: Some(ts("2026-02-16T08:15:00Z")),
+            attendee_emails: vec![],
+        },
+    ]
+}
+
+fn sample_email_candidates_unsorted() -> Vec<GoogleEmailCandidateSource> {
+    vec![
+        GoogleEmailCandidateSource {
+            message_id: Some("msg-2".to_string()),
+            from: Some(" CFO <cfo@example.com> ".to_string()),
+            subject: Some(" Budget variance follow-up ".to_string()),
+            snippet: Some(" Need approval today for vendor invoice. ".to_string()),
+            received_at: Some(ts("2026-02-15T18:00:00Z")),
+            label_ids: vec!["IMPORTANT".to_string(), "INBOX".to_string()],
+            has_attachments: true,
+        },
+        GoogleEmailCandidateSource {
+            message_id: None,
+            from: None,
+            subject: None,
+            snippet: Some(" ".to_string()),
+            received_at: None,
+            label_ids: vec![" ".to_string()],
+            has_attachments: false,
+        },
+        GoogleEmailCandidateSource {
+            message_id: Some("msg-1".to_string()),
+            from: Some("Ops".to_string()),
+            subject: Some("Server alert".to_string()),
+            snippet: Some("Latency high in us-east-1".to_string()),
+            received_at: Some(ts("2026-02-15T19:00:00Z")),
+            label_ids: vec!["INBOX".to_string(), "ALERT".to_string()],
+            has_attachments: false,
+        },
+    ]
+}
+
+fn date(value: &str) -> NaiveDate {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").expect("date must parse")
+}
+
+fn ts(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .expect("timestamp must parse")
+        .with_timezone(&Utc)
+}

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -210,7 +210,7 @@ Ship a private beta where iOS users can:
 | AI-000 | P0 | Remove rule-based assistant logic and legacy backend paths (`#91`) | BE | 2026-03-29 | DONE | - | Rule-based assistant decision path removed from production |
 | AI-001 | P0 | Add LLM gateway abstraction + typed output contracts (`#92`) | BE | 2026-03-06 | DONE | - | Provider-agnostic contract merged with schema validation |
 | AI-002 | P0 | Implement OpenRouter adapter + routing/fallback controls (`#93`) | BE | 2026-03-08 | DONE | AI-001 | Backend can execute LLM requests via OpenRouter with retries |
-| AI-003 | P0 | Build Google context assembler for LLM prompts (`#94`) | BE | 2026-03-10 | TODO | AI-001, AI-002 | Deterministic context payloads generated for assistant capabilities |
+| AI-003 | P0 | Build Google context assembler for LLM prompts (`#94`) | BE | 2026-03-10 | DONE | AI-001, AI-002 | Deterministic context payloads generated for assistant capabilities |
 | AI-004 | P0 | Add `/v1/assistant/query` endpoint for interactive questions (`#95`) | BE | 2026-03-12 | TODO | AI-002, AI-003 | Meetings query works end-to-end with typed assistant response |
 | AI-005 | P0 | Add LLM safety layer + deterministic fallback (`#96`) | SEC | 2026-03-14 | TODO | AI-001, AI-002 | Injection defenses and schema/policy guards enforced |
 | AI-006 | P0 | Migrate morning brief worker path to LLM orchestration (`#97`) | BE | 2026-03-16 | TODO | AI-003, AI-005 | Morning brief push content is LLM-generated and policy-safe |


### PR DESCRIPTION
## Summary
Implements AI-003 by adding a deterministic, schema-defined Google context assembly layer for LLM prompt payloads.

## Changes
- Added `shared::llm::context` with typed context assemblers for:
  - meetings-today
  - urgent-email candidates
  - morning brief
- Added normalization, truncation, and deterministic ordering for compact prompt-ready payloads.
- Added fixture-based tests for deterministic outputs and empty/noisy input handling.
- Updated `docs/phase1-master-todo.md` status for `AI-003` to `DONE`.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just backend-fmt`
- `just backend-deep-review`
- `just ios-build` (post-change)

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: fixture tests + `just backend-deep-review` pass
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no boundary violations; implementation remains in shared LLM module.
- Performance/scalability concerns: bounded item counts and truncation reduce prompt growth risk.
- Refactor recommendations: none for this scoped issue.

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #94
