### PR TITLE
P0-AI04: Add /v1/assistant/query endpoint for meetings-today assistant queries

### DIFF
--- a/alfred/Packages/AlfredAPIClient/Sources/AlfredAPIClient.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/AlfredAPIClient.swift
@@ -59,6 +59,15 @@ public final class AlfredAPIClient: Sendable {
         )
     }
 
+    public func queryAssistant(_ request: AssistantQueryRequest) async throws -> AssistantQueryResponse {
+        try await send(
+            method: "POST",
+            path: "/v1/assistant/query",
+            body: request,
+            requiresAuth: true
+        )
+    }
+
     public func startGoogleOAuth(_ request: StartGoogleConnectRequest) async throws -> StartGoogleConnectResponse {
         try await send(
             method: "POST",

--- a/alfred/Packages/AlfredAPIClient/Sources/Models.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/Models.swift
@@ -43,6 +43,44 @@ public struct SendTestNotificationResponse: Codable, Sendable {
     }
 }
 
+public struct AssistantQueryRequest: Codable, Sendable {
+    public let query: String
+
+    public init(query: String) {
+        self.query = query
+    }
+}
+
+public enum AssistantQueryCapability: String, Codable, Sendable {
+    case meetingsToday = "meetings_today"
+}
+
+public struct AssistantMeetingsTodayPayload: Codable, Sendable {
+    public let title: String
+    public let summary: String
+    public let keyPoints: [String]
+    public let followUps: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case summary
+        case keyPoints = "key_points"
+        case followUps = "follow_ups"
+    }
+}
+
+public struct AssistantQueryResponse: Codable, Sendable {
+    public let capability: AssistantQueryCapability
+    public let displayText: String
+    public let payload: AssistantMeetingsTodayPayload
+
+    enum CodingKeys: String, CodingKey {
+        case capability
+        case displayText = "display_text"
+        case payload
+    }
+}
+
 public struct StartGoogleConnectRequest: Codable, Sendable {
     public let redirectURI: String
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7,6 +7,7 @@ servers:
   - url: https://api.alfredapp.com
 tags:
   - name: Devices
+  - name: Assistant
   - name: Connectors
   - name: Preferences
   - name: Audit
@@ -58,6 +59,34 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /v1/assistant/query:
+    post:
+      tags: [Assistant]
+      summary: Query assistant with natural language
+      operationId: queryAssistant
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssistantQueryRequest"
+      responses:
+        "200":
+          description: Assistant query response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssistantQueryResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "502":
+          $ref: "#/components/responses/BadGateway"
   /v1/connectors/google/start:
     post:
       tags: [Connectors]
@@ -315,6 +344,42 @@ components:
         status:
           type: string
           enum: [QUEUED]
+    AssistantQueryRequest:
+      type: object
+      required: [query]
+      properties:
+        query:
+          type: string
+          minLength: 1
+    AssistantQueryCapability:
+      type: string
+      enum: [meetings_today]
+    AssistantMeetingsTodayPayload:
+      type: object
+      required: [title, summary, key_points, follow_ups]
+      properties:
+        title:
+          type: string
+        summary:
+          type: string
+        key_points:
+          type: array
+          items:
+            type: string
+        follow_ups:
+          type: array
+          items:
+            type: string
+    AssistantQueryResponse:
+      type: object
+      required: [capability, display_text, payload]
+      properties:
+        capability:
+          $ref: "#/components/schemas/AssistantQueryCapability"
+        display_text:
+          type: string
+        payload:
+          $ref: "#/components/schemas/AssistantMeetingsTodayPayload"
     StartGoogleConnectRequest:
       type: object
       required: [redirect_uri]

--- a/backend/crates/api-server/src/http/assistant/fetch.rs
+++ b/backend/crates/api-server/src/http/assistant/fetch.rs
@@ -1,0 +1,124 @@
+use chrono::{DateTime, Days, NaiveDate, Utc};
+use serde::Deserialize;
+use shared::llm::GoogleCalendarMeetingSource;
+
+use super::super::errors::bad_gateway_response;
+
+const GOOGLE_CALENDAR_EVENTS_URL: &str =
+    "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+const MAX_CALENDAR_EVENTS: usize = 25;
+
+pub(super) async fn fetch_meetings_for_day(
+    http_client: &reqwest::Client,
+    access_token: &str,
+    calendar_day: NaiveDate,
+) -> Result<Vec<GoogleCalendarMeetingSource>, axum::response::Response> {
+    let Some(start_of_day) = calendar_day.and_hms_opt(0, 0, 0) else {
+        return Ok(Vec::new());
+    };
+    let Some(next_day) = calendar_day.checked_add_days(Days::new(1)) else {
+        return Ok(Vec::new());
+    };
+    let Some(start_of_next_day) = next_day.and_hms_opt(0, 0, 0) else {
+        return Ok(Vec::new());
+    };
+
+    let time_min = DateTime::<Utc>::from_naive_utc_and_offset(start_of_day, Utc).to_rfc3339();
+    let time_max = DateTime::<Utc>::from_naive_utc_and_offset(start_of_next_day, Utc).to_rfc3339();
+    let max_results = MAX_CALENDAR_EVENTS.to_string();
+
+    let response = match http_client
+        .get(GOOGLE_CALENDAR_EVENTS_URL)
+        .bearer_auth(access_token)
+        .query(&[
+            ("singleEvents", "true"),
+            ("orderBy", "startTime"),
+            ("timeMin", time_min.as_str()),
+            ("timeMax", time_max.as_str()),
+            ("maxResults", max_results.as_str()),
+        ])
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(_) => {
+            return Err(bad_gateway_response(
+                "google_calendar_unavailable",
+                "Unable to reach Google Calendar endpoint",
+            ));
+        }
+    };
+
+    if !response.status().is_success() {
+        return Err(bad_gateway_response(
+            "google_calendar_failed",
+            "Google Calendar request failed",
+        ));
+    }
+
+    let payload: GoogleCalendarEventsResponse = match response.json().await {
+        Ok(payload) => payload,
+        Err(_) => {
+            return Err(bad_gateway_response(
+                "google_calendar_invalid_response",
+                "Google Calendar response was invalid",
+            ));
+        }
+    };
+
+    Ok(payload
+        .items
+        .into_iter()
+        .map(GoogleCalendarMeetingSource::from)
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleCalendarEventsResponse {
+    #[serde(default)]
+    items: Vec<GoogleCalendarEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleCalendarEvent {
+    id: Option<String>,
+    summary: Option<String>,
+    start: Option<GoogleCalendarEventDateTime>,
+    end: Option<GoogleCalendarEventDateTime>,
+    #[serde(default)]
+    attendees: Vec<GoogleCalendarAttendee>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleCalendarEventDateTime {
+    #[serde(rename = "dateTime")]
+    date_time: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleCalendarAttendee {
+    email: Option<String>,
+}
+
+impl From<GoogleCalendarEvent> for GoogleCalendarMeetingSource {
+    fn from(event: GoogleCalendarEvent) -> Self {
+        Self {
+            event_id: event.id,
+            title: event.summary,
+            start_at: parse_utc_datetime(event.start.and_then(|start| start.date_time)),
+            end_at: parse_utc_datetime(event.end.and_then(|end| end.date_time)),
+            attendee_emails: event
+                .attendees
+                .into_iter()
+                .filter_map(|attendee| attendee.email)
+                .collect(),
+        }
+    }
+}
+
+fn parse_utc_datetime(value: Option<String>) -> Option<DateTime<Utc>> {
+    let value = value?;
+    DateTime::parse_from_rfc3339(&value)
+        .ok()
+        .map(|parsed| parsed.with_timezone(&Utc))
+}

--- a/backend/crates/api-server/src/http/assistant/mod.rs
+++ b/backend/crates/api-server/src/http/assistant/mod.rs
@@ -1,0 +1,5 @@
+mod fetch;
+mod query;
+mod session;
+
+pub(crate) use query::query_assistant;

--- a/backend/crates/api-server/src/http/assistant/query.rs
+++ b/backend/crates/api-server/src/http/assistant/query.rs
@@ -1,0 +1,175 @@
+use axum::Json;
+use axum::extract::{Extension, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use chrono::Utc;
+use shared::llm::{
+    AssistantCapability, AssistantOutputContract, LlmGateway, LlmGatewayError, LlmGatewayRequest,
+    assemble_meetings_today_context, template_for_capability, validate_output_value,
+};
+use shared::models::{
+    AssistantMeetingsTodayPayload, AssistantQueryCapability, AssistantQueryRequest,
+    AssistantQueryResponse,
+};
+use tracing::warn;
+
+use super::super::errors::{bad_gateway_response, bad_request_response};
+use super::super::{AppState, AuthUser};
+use super::fetch::fetch_meetings_for_day;
+use super::session::build_google_session;
+
+pub(crate) async fn query_assistant(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Json(req): Json<AssistantQueryRequest>,
+) -> Response {
+    let trimmed_query = req.query.trim();
+    if trimmed_query.is_empty() {
+        return bad_request_response("invalid_query", "Query must not be empty");
+    }
+
+    let capability = match detect_query_capability(trimmed_query) {
+        Some(capability) => capability,
+        None => {
+            return bad_request_response(
+                "unsupported_assistant_query",
+                "Only meetings-today queries are currently supported",
+            );
+        }
+    };
+
+    match capability {
+        AssistantQueryCapability::MeetingsToday => {
+            handle_meetings_today_query(&state, user.user_id).await
+        }
+    }
+}
+
+async fn handle_meetings_today_query(state: &AppState, user_id: uuid::Uuid) -> Response {
+    let session = match build_google_session(state, user_id).await {
+        Ok(session) => session,
+        Err(response) => return response,
+    };
+
+    let calendar_day = Utc::now().date_naive();
+    let meetings =
+        match fetch_meetings_for_day(&state.http_client, &session.access_token, calendar_day).await
+        {
+            Ok(meetings) => meetings,
+            Err(response) => return response,
+        };
+
+    let context = assemble_meetings_today_context(calendar_day, &meetings);
+    let context_payload = match serde_json::to_value(&context) {
+        Ok(value) => value,
+        Err(_) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(shared::models::ErrorResponse {
+                    error: shared::models::ErrorBody {
+                        code: "internal_error".to_string(),
+                        message: "Unexpected server error".to_string(),
+                    },
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let request = LlmGatewayRequest::from_template(
+        template_for_capability(AssistantCapability::MeetingsSummary),
+        context_payload,
+    );
+
+    let llm_response = match state.llm_gateway.generate(request).await {
+        Ok(response) => response,
+        Err(err) => return map_gateway_error(err),
+    };
+
+    let contract =
+        match validate_output_value(AssistantCapability::MeetingsSummary, &llm_response.output) {
+            Ok(contract) => contract,
+            Err(err) => {
+                warn!("assistant output validation failed: {err}");
+                return bad_gateway_response(
+                    "assistant_invalid_output",
+                    "Assistant provider returned invalid output",
+                );
+            }
+        };
+
+    let AssistantOutputContract::MeetingsSummary(contract) = contract else {
+        return bad_gateway_response(
+            "assistant_invalid_output",
+            "Assistant provider returned invalid output",
+        );
+    };
+
+    let payload = AssistantMeetingsTodayPayload {
+        title: contract.output.title,
+        summary: contract.output.summary.clone(),
+        key_points: contract.output.key_points,
+        follow_ups: contract.output.follow_ups,
+    };
+
+    (
+        StatusCode::OK,
+        Json(AssistantQueryResponse {
+            capability: AssistantQueryCapability::MeetingsToday,
+            display_text: payload.summary.clone(),
+            payload,
+        }),
+    )
+        .into_response()
+}
+
+fn detect_query_capability(query: &str) -> Option<AssistantQueryCapability> {
+    let normalized = query.to_ascii_lowercase();
+    let asks_for_today = normalized.contains("today");
+    let asks_for_meetings = normalized.contains("meeting")
+        || normalized.contains("calendar")
+        || normalized.contains("schedule");
+
+    if asks_for_today && asks_for_meetings {
+        return Some(AssistantQueryCapability::MeetingsToday);
+    }
+
+    None
+}
+
+fn map_gateway_error(err: LlmGatewayError) -> Response {
+    match err {
+        LlmGatewayError::Timeout => {
+            bad_gateway_response("assistant_provider_timeout", "Assistant provider timed out")
+        }
+        LlmGatewayError::ProviderFailure(_) => bad_gateway_response(
+            "assistant_provider_failed",
+            "Assistant provider request failed",
+        ),
+        LlmGatewayError::InvalidProviderPayload(_) => bad_gateway_response(
+            "assistant_provider_invalid",
+            "Assistant provider returned invalid payload",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detect_query_capability;
+    use shared::models::AssistantQueryCapability;
+
+    #[test]
+    fn detect_query_capability_matches_meetings_today_queries() {
+        let query = "What meetings do I have today?";
+        assert_eq!(
+            detect_query_capability(query),
+            Some(AssistantQueryCapability::MeetingsToday)
+        );
+    }
+
+    #[test]
+    fn detect_query_capability_rejects_unsupported_queries() {
+        let query = "Show me urgent emails";
+        assert_eq!(detect_query_capability(query), None);
+    }
+}

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -32,6 +32,32 @@ pub struct SendTestNotificationResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantQueryRequest {
+    pub query: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssistantQueryCapability {
+    MeetingsToday,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantMeetingsTodayPayload {
+    pub title: String,
+    pub summary: String,
+    pub key_points: Vec<String>,
+    pub follow_ups: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantQueryResponse {
+    pub capability: AssistantQueryCapability,
+    pub display_text: String,
+    pub payload: AssistantMeetingsTodayPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StartGoogleConnectRequest {
     pub redirect_uri: String,
 }

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -211,7 +211,7 @@ Ship a private beta where iOS users can:
 | AI-001 | P0 | Add LLM gateway abstraction + typed output contracts (`#92`) | BE | 2026-03-06 | DONE | - | Provider-agnostic contract merged with schema validation |
 | AI-002 | P0 | Implement OpenRouter adapter + routing/fallback controls (`#93`) | BE | 2026-03-08 | DONE | AI-001 | Backend can execute LLM requests via OpenRouter with retries |
 | AI-003 | P0 | Build Google context assembler for LLM prompts (`#94`) | BE | 2026-03-10 | DONE | AI-001, AI-002 | Deterministic context payloads generated for assistant capabilities |
-| AI-004 | P0 | Add `/v1/assistant/query` endpoint for interactive questions (`#95`) | BE | 2026-03-12 | TODO | AI-002, AI-003 | Meetings query works end-to-end with typed assistant response |
+| AI-004 | P0 | Add `/v1/assistant/query` endpoint for interactive questions (`#95`) | BE | 2026-03-12 | DONE | AI-002, AI-003 | Meetings query works end-to-end with typed assistant response |
 | AI-005 | P0 | Add LLM safety layer + deterministic fallback (`#96`) | SEC | 2026-03-14 | TODO | AI-001, AI-002 | Injection defenses and schema/policy guards enforced |
 | AI-006 | P0 | Migrate morning brief worker path to LLM orchestration (`#97`) | BE | 2026-03-16 | TODO | AI-003, AI-005 | Morning brief push content is LLM-generated and policy-safe |
 | AI-007 | P0 | Migrate urgent-email worker path to LLM prioritization (`#98`) | BE | 2026-03-18 | TODO | AI-003, AI-005 | Urgent-email decision path is LLM-based with safe fallback |


### PR DESCRIPTION
## Summary
Implement authenticated backend assistant query support for the initial meetings-today capability, using the shared LLM gateway/OpenRouter path and deterministic context assembly.

## Changes
- Added `POST /v1/assistant/query` in API router under auth + sensitive rate limiting.
- Implemented new backend assistant module (`http/assistant/*`) for query classification, Google connector token/session exchange via enclave path, calendar context fetch, LLM invocation, and schema-validated output mapping.
- Added shared API models for assistant query request/response envelope with typed meetings payload and display text.
- Updated OpenAPI contract for assistant endpoint/schemas.
- Updated iOS API package models + client call for assistant query.
- Updated Phase I board entry `AI-004` to `DONE` in `docs/phase1-master-todo.md`.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just backend-verify`
- `just backend-deep-review`
- `just ios-build` (post-change)

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: backend tests pass including new assistant capability tests.
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no findings; new behavior is isolated to `backend/crates/api-server/src/http/assistant/*` and DB access stays in `Store`.
- Performance/scalability concerns: no critical concerns for current scope.
- Refactor recommendations: none required for this issue.

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #95
