### PR TITLE
AI-006: migrate morning brief worker path to LLM orchestration

### DIFF
--- a/backend/crates/worker/src/job_actions/context.rs
+++ b/backend/crates/worker/src/job_actions/context.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+
+use shared::config::WorkerConfig;
+use shared::llm::LlmGateway;
+use shared::repos::Store;
+use shared::security::SecretRuntime;
+
+use crate::{NotificationContent, PushSender};
+
+pub(crate) struct JobActionContext<'a> {
+    pub(crate) store: &'a Store,
+    pub(crate) config: &'a WorkerConfig,
+    pub(crate) secret_runtime: &'a SecretRuntime,
+    pub(crate) oauth_client: &'a reqwest::Client,
+    pub(crate) llm_gateway: &'a dyn LlmGateway,
+    pub(crate) push_sender: &'a PushSender,
+}
+
+pub(crate) struct JobActionResult {
+    pub(crate) notification: Option<NotificationContent>,
+    pub(crate) metadata: HashMap<String, String>,
+}

--- a/backend/crates/worker/src/job_actions/google/fetch.rs
+++ b/backend/crates/worker/src/job_actions/google/fetch.rs
@@ -102,10 +102,18 @@ pub(super) struct GoogleCalendarEvent {
     pub(super) id: Option<String>,
     pub(super) summary: Option<String>,
     pub(super) start: Option<GoogleCalendarEventStart>,
+    pub(super) end: Option<GoogleCalendarEventStart>,
+    #[serde(default)]
+    pub(super) attendees: Vec<GoogleCalendarAttendee>,
 }
 
 #[derive(Debug, Deserialize)]
 pub(super) struct GoogleCalendarEventStart {
     #[serde(rename = "dateTime")]
     pub(super) date_time: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GoogleCalendarAttendee {
+    pub(super) email: Option<String>,
 }

--- a/backend/crates/worker/src/job_actions/google/morning_brief.rs
+++ b/backend/crates/worker/src/job_actions/google/morning_brief.rs
@@ -1,0 +1,273 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Days, NaiveDate, Utc};
+use shared::config::WorkerConfig;
+use shared::llm::contracts::MorningBriefOutput;
+use shared::llm::{
+    AssistantCapability, AssistantOutputContract, GoogleCalendarMeetingSource, LlmGateway,
+    LlmGatewayRequest, SafeOutputSource, assemble_morning_brief_context, resolve_safe_output,
+    sanitize_context_payload, template_for_capability,
+};
+use shared::models::Preferences;
+use shared::repos::Store;
+use shared::security::SecretRuntime;
+use tracing::warn;
+
+use super::super::JobActionResult;
+use super::fetch::{GoogleCalendarEvent, fetch_calendar_events};
+use super::session::build_google_session;
+use super::util::truncate_for_notification;
+use crate::{JobExecutionError, NotificationContent};
+
+const MORNING_BRIEF_CALENDAR_MAX_RESULTS: usize = 20;
+const MORNING_BRIEF_TITLE_MAX_CHARS: usize = 64;
+const MORNING_BRIEF_BODY_MAX_CHARS: usize = 180;
+
+pub(super) async fn build_morning_brief(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    llm_gateway: &dyn LlmGateway,
+    user_id: uuid::Uuid,
+    preferences: &Preferences,
+) -> Result<JobActionResult, JobExecutionError> {
+    let session =
+        build_google_session(store, config, secret_runtime, oauth_client, user_id).await?;
+    let local_date = Utc::now().date_naive();
+    let (time_min, time_max) = calendar_day_window(local_date)?;
+
+    let events = fetch_calendar_events(
+        oauth_client,
+        &session.access_token,
+        time_min,
+        time_max,
+        MORNING_BRIEF_CALENDAR_MAX_RESULTS,
+    )
+    .await?;
+    let events_fetched = events.len();
+
+    let meetings = events
+        .into_iter()
+        .filter_map(calendar_event_to_meeting_source)
+        .collect::<Vec<_>>();
+
+    let context = assemble_morning_brief_context(
+        local_date,
+        &preferences.morning_brief_local_time,
+        &meetings,
+        &[],
+    );
+
+    let raw_context_payload = serde_json::to_value(&context).map_err(|err| {
+        JobExecutionError::permanent(
+            "MORNING_BRIEF_CONTEXT_SERIALIZATION_FAILED",
+            format!("failed to serialize morning brief context: {err}"),
+        )
+    })?;
+    let context_payload = sanitize_context_payload(&raw_context_payload);
+    if context_payload != raw_context_payload {
+        warn!(
+            user_id = %user_id,
+            "morning brief context payload sanitized by safety policy"
+        );
+    }
+
+    let request = LlmGatewayRequest::from_template(
+        template_for_capability(AssistantCapability::MorningBrief),
+        context_payload.clone(),
+    );
+
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "action_source".to_string(),
+        "morning_brief_llm_orchestrator".to_string(),
+    );
+    metadata.insert(
+        "morning_brief_local_time".to_string(),
+        context.morning_brief_local_time.clone(),
+    );
+    metadata.insert(
+        "meetings_in_context".to_string(),
+        context.meetings_today_count.to_string(),
+    );
+    metadata.insert(
+        "urgent_email_candidates_in_context".to_string(),
+        context.urgent_email_candidate_count.to_string(),
+    );
+    metadata.insert(
+        "calendar_events_fetched".to_string(),
+        events_fetched.to_string(),
+    );
+    metadata.insert(
+        "urgent_email_context_source".to_string(),
+        "pending_ai07_integration".to_string(),
+    );
+    metadata.insert(
+        "attested_measurement".to_string(),
+        session.attested_measurement,
+    );
+
+    let model_output = match llm_gateway.generate(request).await {
+        Ok(response) => {
+            metadata.insert("llm_model".to_string(), response.model);
+            if let Some(provider_request_id) = response.provider_request_id {
+                metadata.insert("llm_provider_request_id".to_string(), provider_request_id);
+            }
+            if let Some(usage) = response.usage {
+                metadata.insert(
+                    "llm_prompt_tokens".to_string(),
+                    usage.prompt_tokens.to_string(),
+                );
+                metadata.insert(
+                    "llm_completion_tokens".to_string(),
+                    usage.completion_tokens.to_string(),
+                );
+                metadata.insert(
+                    "llm_total_tokens".to_string(),
+                    usage.total_tokens.to_string(),
+                );
+            }
+            Some(response.output)
+        }
+        Err(err) => {
+            warn!(user_id = %user_id, "morning brief provider request failed: {err}");
+            metadata.insert("llm_error".to_string(), err.to_string());
+            None
+        }
+    };
+
+    let resolved = resolve_safe_output(
+        AssistantCapability::MorningBrief,
+        model_output.as_ref(),
+        &context_payload,
+    );
+    let output_source = match resolved.source {
+        SafeOutputSource::ModelOutput => "model_output",
+        SafeOutputSource::DeterministicFallback => {
+            warn!(user_id = %user_id, "morning brief returned deterministic fallback output");
+            "deterministic_fallback"
+        }
+    };
+    metadata.insert("llm_output_source".to_string(), output_source.to_string());
+
+    let AssistantOutputContract::MorningBrief(contract) = resolved.contract else {
+        return Err(JobExecutionError::permanent(
+            "MORNING_BRIEF_INVALID_CONTRACT",
+            "morning brief contract resolution returned unexpected capability",
+        ));
+    };
+
+    Ok(JobActionResult {
+        notification: Some(notification_from_output(&contract.output)),
+        metadata,
+    })
+}
+
+fn calendar_day_window(
+    local_date: NaiveDate,
+) -> Result<(DateTime<Utc>, DateTime<Utc>), JobExecutionError> {
+    let Some(start_of_day) = local_date.and_hms_opt(0, 0, 0) else {
+        return Err(JobExecutionError::permanent(
+            "MORNING_BRIEF_INVALID_CALENDAR_DATE",
+            "unable to compute start of day",
+        ));
+    };
+    let Some(next_day) = local_date.checked_add_days(Days::new(1)) else {
+        return Err(JobExecutionError::permanent(
+            "MORNING_BRIEF_INVALID_CALENDAR_DATE",
+            "unable to compute next day",
+        ));
+    };
+    let Some(start_of_next_day) = next_day.and_hms_opt(0, 0, 0) else {
+        return Err(JobExecutionError::permanent(
+            "MORNING_BRIEF_INVALID_CALENDAR_DATE",
+            "unable to compute next day start",
+        ));
+    };
+
+    Ok((
+        DateTime::<Utc>::from_naive_utc_and_offset(start_of_day, Utc),
+        DateTime::<Utc>::from_naive_utc_and_offset(start_of_next_day, Utc),
+    ))
+}
+
+fn calendar_event_to_meeting_source(
+    event: GoogleCalendarEvent,
+) -> Option<GoogleCalendarMeetingSource> {
+    let start_at = parse_rfc3339_utc(event.start?.date_time)?;
+    let end_at = event.end.and_then(|end| parse_rfc3339_utc(end.date_time));
+
+    Some(GoogleCalendarMeetingSource {
+        event_id: event.id,
+        title: event.summary,
+        start_at: Some(start_at),
+        end_at,
+        attendee_emails: event
+            .attendees
+            .into_iter()
+            .filter_map(|attendee| attendee.email)
+            .collect(),
+    })
+}
+
+fn parse_rfc3339_utc(value: Option<String>) -> Option<DateTime<Utc>> {
+    let value = value?;
+    DateTime::parse_from_rfc3339(&value)
+        .ok()
+        .map(|parsed| parsed.with_timezone(&Utc))
+}
+
+fn notification_from_output(output: &MorningBriefOutput) -> NotificationContent {
+    let title = if output.headline.trim().is_empty() {
+        "Morning brief".to_string()
+    } else {
+        truncate_for_notification(&output.headline, MORNING_BRIEF_TITLE_MAX_CHARS)
+    };
+
+    let body = build_notification_body(output);
+
+    NotificationContent {
+        title,
+        body: truncate_for_notification(&body, MORNING_BRIEF_BODY_MAX_CHARS),
+    }
+}
+
+fn build_notification_body(output: &MorningBriefOutput) -> String {
+    let mut segments = Vec::new();
+
+    if let Some(summary) = non_empty(&output.summary) {
+        segments.push(summary.to_string());
+    }
+    if let Some(priority) = first_non_empty(&output.priorities) {
+        segments.push(format!("Priority: {priority}"));
+    }
+    if let Some(schedule) = first_non_empty(&output.schedule) {
+        segments.push(format!("Schedule: {schedule}"));
+    }
+    if let Some(alert) = first_non_empty(&output.alerts) {
+        segments.push(format!("Alert: {alert}"));
+    }
+
+    if segments.is_empty() {
+        return "Review your calendar and inbox for today.".to_string();
+    }
+
+    segments.join(" • ")
+}
+
+fn first_non_empty(values: &[String]) -> Option<&str> {
+    values.iter().find_map(|value| non_empty(value.as_str()))
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/backend/crates/worker/src/job_actions/google/morning_brief/tests.rs
+++ b/backend/crates/worker/src/job_actions/google/morning_brief/tests.rs
@@ -1,0 +1,67 @@
+use shared::llm::contracts::MorningBriefOutput;
+
+use super::{
+    MORNING_BRIEF_BODY_MAX_CHARS, MORNING_BRIEF_TITLE_MAX_CHARS, build_notification_body,
+    notification_from_output,
+};
+
+#[test]
+fn notification_uses_structured_morning_brief_content() {
+    let output = MorningBriefOutput {
+        headline: "Tuesday plan".to_string(),
+        summary: "You have 2 meetings and 1 urgent email candidate.".to_string(),
+        priorities: vec!["Confirm demo scope before 10 AM".to_string()],
+        schedule: vec!["09:00 - Team standup".to_string()],
+        alerts: vec!["Invoice reminder from Finance".to_string()],
+    };
+
+    let notification = notification_from_output(&output);
+    assert_eq!(notification.title, "Tuesday plan");
+    assert!(
+        notification
+            .body
+            .contains("Priority: Confirm demo scope before 10 AM")
+    );
+    assert!(notification.body.contains("Schedule: 09:00 - Team standup"));
+    assert!(
+        notification
+            .body
+            .contains("Alert: Invoice reminder from Finance")
+    );
+}
+
+#[test]
+fn notification_falls_back_when_output_fields_are_empty() {
+    let output = MorningBriefOutput {
+        headline: "   ".to_string(),
+        summary: "   ".to_string(),
+        priorities: vec!["".to_string()],
+        schedule: vec!["".to_string()],
+        alerts: vec![],
+    };
+
+    let notification = notification_from_output(&output);
+    assert_eq!(notification.title, "Morning brief");
+    assert_eq!(
+        notification.body,
+        "Review your calendar and inbox for today."
+    );
+}
+
+#[test]
+fn notification_body_and_title_are_bounded() {
+    let output = MorningBriefOutput {
+        headline: "X".repeat(MORNING_BRIEF_TITLE_MAX_CHARS + 20),
+        summary: "Y".repeat(MORNING_BRIEF_BODY_MAX_CHARS + 80),
+        priorities: Vec::new(),
+        schedule: Vec::new(),
+        alerts: Vec::new(),
+    };
+
+    let notification = notification_from_output(&output);
+    assert!(notification.title.ends_with("..."));
+    assert!(notification.body.ends_with("..."));
+    assert!(notification.title.chars().count() <= MORNING_BRIEF_TITLE_MAX_CHARS + 3);
+    assert!(notification.body.chars().count() <= MORNING_BRIEF_BODY_MAX_CHARS + 3);
+    assert!(notification.body.chars().count() < build_notification_body(&output).chars().count());
+}

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -213,7 +213,7 @@ Ship a private beta where iOS users can:
 | AI-003 | P0 | Build Google context assembler for LLM prompts (`#94`) | BE | 2026-03-10 | DONE | AI-001, AI-002 | Deterministic context payloads generated for assistant capabilities |
 | AI-004 | P0 | Add `/v1/assistant/query` endpoint for interactive questions (`#95`) | BE | 2026-03-12 | DONE | AI-002, AI-003 | Meetings query works end-to-end with typed assistant response |
 | AI-005 | P0 | Add LLM safety layer + deterministic fallback (`#96`) | SEC | 2026-03-14 | DONE | AI-001, AI-002 | Injection defenses and schema/policy guards enforced |
-| AI-006 | P0 | Migrate morning brief worker path to LLM orchestration (`#97`) | BE | 2026-03-16 | TODO | AI-003, AI-005 | Morning brief push content is LLM-generated and policy-safe |
+| AI-006 | P0 | Migrate morning brief worker path to LLM orchestration (`#97`) | BE | 2026-03-16 | DONE | AI-003, AI-005 | Morning brief push content is LLM-generated and policy-safe |
 | AI-007 | P0 | Migrate urgent-email worker path to LLM prioritization (`#98`) | BE | 2026-03-18 | TODO | AI-003, AI-005 | Urgent-email decision path is LLM-based with safe fallback |
 | AI-008 | P0 | Add AI observability + redacted audit events (`#99`) | SRE | 2026-03-20 | TODO | AI-004, AI-006, AI-007 | Latency/usage/cost metrics and redacted audit events are live |
 | AI-009 | P0 | Add LLM reliability guardrails (`#100`) | BE | 2026-03-22 | TODO | AI-004 | Circuit breaker/rate limits/cache/budgets enforced |


### PR DESCRIPTION
## Summary
Migrate worker morning brief execution from pending/no-notification behavior to the LLM orchestration path with safe fallback and notification-safe payload shaping.

## What changed
- Added dedicated morning brief orchestration module at backend/crates/worker/src/job_actions/google/morning_brief.rs.
- Wired OpenRouterGateway into worker runtime/job dispatch so morning brief jobs can call the LLM gateway.
- Built normalized morning-brief context from Google Calendar events, then ran safety sanitization and deterministic fallback resolution.
- Formatted morning brief push title/body to remain concise and bounded for notification readability.
- Added focused unit tests for morning-brief notification shaping.
- Updated board status AI-006 to DONE in docs/phase1-master-todo.md.

## Structural changes
- Added backend/crates/worker/src/job_actions/context.rs to keep dispatch dependencies modular.
- Added backend/crates/worker/src/job_actions/google/morning_brief/tests.rs to keep implementation file within file-size target.

## Validation
- just check-tools
- just backend-check
- just ios-build
- just backend-verify
- just backend-deep-review
- just ios-build (post-change rerun)

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: backend-verify and backend-deep-review passed, including worker unit tests
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no violations; worker dispatch context extraction keeps ownership boundaries clearer
- Performance/scalability concerns: no new high-risk path introduced; calendar fetch and notification output are both bounded
- Refactor recommendations: none for this issue scope

### 4) Final Status
- backend-deep-review: pass
- Merge recommendation: APPROVE

Closes #97
