### PR TITLE
P0-AI07: Migrate urgent-email worker path to LLM prioritization

### DIFF
--- a/backend/crates/worker/src/job_actions/google/fetch.rs
+++ b/backend/crates/worker/src/job_actions/google/fetch.rs
@@ -1,12 +1,14 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use reqwest::StatusCode;
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
+use shared::llm::GoogleEmailCandidateSource;
 
 use crate::{FailureClass, JobExecutionError};
 
 const GOOGLE_CALENDAR_EVENTS_URL: &str =
     "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+const GMAIL_MESSAGES_URL: &str = "https://gmail.googleapis.com/gmail/v1/users/me/messages";
 
 pub(super) async fn fetch_calendar_events(
     oauth_client: &reqwest::Client,
@@ -40,6 +42,57 @@ pub(super) async fn fetch_calendar_events(
     .await?;
 
     Ok(payload.items)
+}
+
+pub(super) async fn fetch_urgent_email_candidates(
+    oauth_client: &reqwest::Client,
+    access_token: &str,
+    max_results: usize,
+) -> Result<Vec<GoogleEmailCandidateSource>, JobExecutionError> {
+    let max_results = max_results.clamp(1, 50).to_string();
+    let request = oauth_client
+        .get(GMAIL_MESSAGES_URL)
+        .bearer_auth(access_token)
+        .query(&[
+            ("labelIds", "INBOX"),
+            ("q", "newer_than:2d"),
+            ("maxResults", max_results.as_str()),
+        ]);
+    let payload: GmailMessagesResponse = send_google_request(
+        request,
+        "GMAIL_UNAVAILABLE",
+        "gmail list request failed",
+        "GMAIL_MESSAGES_FAILED",
+        "gmail list request failed",
+        "GMAIL_MESSAGES_PARSE_FAILED",
+        "gmail list response was invalid",
+    )
+    .await?;
+
+    let mut candidates = Vec::with_capacity(payload.messages.len());
+    for message in payload.messages {
+        let request = oauth_client
+            .get(format!("{GMAIL_MESSAGES_URL}/{}", message.id))
+            .bearer_auth(access_token)
+            .query(&[
+                ("format", "metadata"),
+                ("metadataHeaders", "From"),
+                ("metadataHeaders", "Subject"),
+            ]);
+        let details: GmailMessageMetadataResponse = send_google_request(
+            request,
+            "GMAIL_UNAVAILABLE",
+            "gmail message request failed",
+            "GMAIL_MESSAGE_FAILED",
+            "gmail message request failed",
+            "GMAIL_MESSAGE_PARSE_FAILED",
+            "gmail message response was invalid",
+        )
+        .await?;
+        candidates.push(details.into_candidate());
+    }
+
+    Ok(candidates)
 }
 
 async fn send_google_request<T>(
@@ -95,6 +148,106 @@ fn classify_http_failure(status: StatusCode) -> FailureClass {
 struct GoogleCalendarEventsResponse {
     #[serde(default)]
     items: Vec<GoogleCalendarEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessagesResponse {
+    #[serde(default)]
+    messages: Vec<GmailMessageListEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessageListEntry {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessageMetadataResponse {
+    id: String,
+    snippet: Option<String>,
+    #[serde(rename = "internalDate")]
+    internal_date: Option<String>,
+    #[serde(default, rename = "labelIds")]
+    label_ids: Vec<String>,
+    payload: Option<GmailMessagePayload>,
+}
+
+impl GmailMessageMetadataResponse {
+    fn into_candidate(self) -> GoogleEmailCandidateSource {
+        let has_attachments = self.payload.as_ref().is_some_and(payload_has_attachments);
+        let from = self
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.header_value("From"));
+        let subject = self
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.header_value("Subject"));
+
+        GoogleEmailCandidateSource {
+            message_id: Some(self.id),
+            from,
+            subject,
+            snippet: self.snippet,
+            received_at: self
+                .internal_date
+                .as_deref()
+                .and_then(parse_internal_date_millis),
+            label_ids: self.label_ids,
+            has_attachments,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessagePayload {
+    #[serde(default)]
+    headers: Vec<GmailMessageHeader>,
+    #[serde(default)]
+    parts: Vec<GmailMessagePayload>,
+    #[serde(default)]
+    filename: String,
+    body: Option<GmailMessageBody>,
+}
+
+impl GmailMessagePayload {
+    fn header_value(&self, target_name: &str) -> Option<String> {
+        self.headers
+            .iter()
+            .find(|header| header.name.eq_ignore_ascii_case(target_name))
+            .map(|header| header.value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessageHeader {
+    name: String,
+    value: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessageBody {
+    #[serde(rename = "attachmentId")]
+    attachment_id: Option<String>,
+}
+
+fn payload_has_attachments(payload: &GmailMessagePayload) -> bool {
+    let has_attachment_id = payload
+        .body
+        .as_ref()
+        .and_then(|body| body.attachment_id.as_ref())
+        .is_some();
+    if has_attachment_id || !payload.filename.trim().is_empty() {
+        return true;
+    }
+
+    payload.parts.iter().any(payload_has_attachments)
+}
+
+fn parse_internal_date_millis(raw: &str) -> Option<DateTime<Utc>> {
+    let millis = raw.parse::<i64>().ok()?;
+    Utc.timestamp_millis_opt(millis).single()
 }
 
 #[derive(Debug, Deserialize)]

--- a/backend/crates/worker/src/job_actions/google/urgent_email.rs
+++ b/backend/crates/worker/src/job_actions/google/urgent_email.rs
@@ -1,0 +1,219 @@
+use std::collections::HashMap;
+
+use shared::config::WorkerConfig;
+use shared::llm::contracts::{UrgencyLevel, UrgentEmailSummaryOutput};
+use shared::llm::{
+    AssistantCapability, AssistantOutputContract, LlmGateway, LlmGatewayRequest, SafeOutputSource,
+    assemble_urgent_email_candidates_context, resolve_safe_output, sanitize_context_payload,
+    template_for_capability,
+};
+use shared::repos::Store;
+use shared::security::SecretRuntime;
+use tracing::warn;
+
+use super::super::JobActionResult;
+use super::fetch::fetch_urgent_email_candidates;
+use super::session::build_google_session;
+use super::util::truncate_for_notification;
+use crate::{JobExecutionError, NotificationContent};
+
+const URGENT_EMAIL_CANDIDATE_MAX_RESULTS: usize = 10;
+const URGENT_EMAIL_TITLE_MAX_CHARS: usize = 64;
+const URGENT_EMAIL_BODY_MAX_CHARS: usize = 180;
+
+pub(super) async fn build_urgent_email_alert(
+    store: &Store,
+    config: &WorkerConfig,
+    secret_runtime: &SecretRuntime,
+    oauth_client: &reqwest::Client,
+    llm_gateway: &dyn LlmGateway,
+    user_id: uuid::Uuid,
+) -> Result<JobActionResult, JobExecutionError> {
+    let session =
+        build_google_session(store, config, secret_runtime, oauth_client, user_id).await?;
+    let candidates = fetch_urgent_email_candidates(
+        oauth_client,
+        &session.access_token,
+        URGENT_EMAIL_CANDIDATE_MAX_RESULTS,
+    )
+    .await?;
+    let candidates_fetched = candidates.len();
+    let context = assemble_urgent_email_candidates_context(&candidates);
+
+    let raw_context_payload = serde_json::to_value(&context).map_err(|err| {
+        JobExecutionError::permanent(
+            "URGENT_EMAIL_CONTEXT_SERIALIZATION_FAILED",
+            format!("failed to serialize urgent email context: {err}"),
+        )
+    })?;
+    let context_payload = sanitize_context_payload(&raw_context_payload);
+    if context_payload != raw_context_payload {
+        warn!(
+            user_id = %user_id,
+            "urgent email context payload sanitized by safety policy"
+        );
+    }
+
+    let request = LlmGatewayRequest::from_template(
+        template_for_capability(AssistantCapability::UrgentEmailSummary),
+        context_payload.clone(),
+    );
+
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "action_source".to_string(),
+        "urgent_email_llm_orchestrator".to_string(),
+    );
+    metadata.insert(
+        "email_candidates_in_context".to_string(),
+        context.candidate_count.to_string(),
+    );
+    metadata.insert(
+        "gmail_candidates_fetched".to_string(),
+        candidates_fetched.to_string(),
+    );
+    metadata.insert(
+        "attested_measurement".to_string(),
+        session.attested_measurement,
+    );
+
+    let model_output = match llm_gateway.generate(request).await {
+        Ok(response) => {
+            metadata.insert("llm_model".to_string(), response.model);
+            if let Some(provider_request_id) = response.provider_request_id {
+                metadata.insert("llm_provider_request_id".to_string(), provider_request_id);
+            }
+            if let Some(usage) = response.usage {
+                metadata.insert(
+                    "llm_prompt_tokens".to_string(),
+                    usage.prompt_tokens.to_string(),
+                );
+                metadata.insert(
+                    "llm_completion_tokens".to_string(),
+                    usage.completion_tokens.to_string(),
+                );
+                metadata.insert(
+                    "llm_total_tokens".to_string(),
+                    usage.total_tokens.to_string(),
+                );
+            }
+            Some(response.output)
+        }
+        Err(err) => {
+            warn!(user_id = %user_id, "urgent email provider request failed: {err}");
+            metadata.insert("llm_error".to_string(), err.to_string());
+            None
+        }
+    };
+
+    let resolved = resolve_safe_output(
+        AssistantCapability::UrgentEmailSummary,
+        model_output.as_ref(),
+        &context_payload,
+    );
+    let output_source = match resolved.source {
+        SafeOutputSource::ModelOutput => "model_output",
+        SafeOutputSource::DeterministicFallback => {
+            warn!(
+                user_id = %user_id,
+                "urgent email returned deterministic fallback output"
+            );
+            "deterministic_fallback"
+        }
+    };
+    metadata.insert("llm_output_source".to_string(), output_source.to_string());
+
+    let AssistantOutputContract::UrgentEmailSummary(contract) = resolved.contract else {
+        return Err(JobExecutionError::permanent(
+            "URGENT_EMAIL_INVALID_CONTRACT",
+            "urgent email contract resolution returned unexpected capability",
+        ));
+    };
+
+    metadata.insert(
+        "urgent_email_should_notify".to_string(),
+        contract.output.should_notify.to_string(),
+    );
+    metadata.insert(
+        "urgent_email_urgency".to_string(),
+        urgency_label(&contract.output.urgency).to_string(),
+    );
+    metadata.insert(
+        "urgent_email_reason_present".to_string(),
+        non_empty(&contract.output.reason).is_some().to_string(),
+    );
+
+    if !contract.output.should_notify {
+        metadata.insert("reason".to_string(), "llm_marked_not_urgent".to_string());
+        return Ok(JobActionResult {
+            notification: None,
+            metadata,
+        });
+    }
+
+    Ok(JobActionResult {
+        notification: Some(notification_from_output(&contract.output)),
+        metadata,
+    })
+}
+
+fn notification_from_output(output: &UrgentEmailSummaryOutput) -> NotificationContent {
+    let title = truncate_for_notification(
+        notification_title_for_urgency(&output.urgency),
+        URGENT_EMAIL_TITLE_MAX_CHARS,
+    );
+    let body = truncate_for_notification(
+        &build_notification_body(output),
+        URGENT_EMAIL_BODY_MAX_CHARS,
+    );
+
+    NotificationContent { title, body }
+}
+
+fn notification_title_for_urgency(urgency: &UrgencyLevel) -> &'static str {
+    match urgency {
+        UrgencyLevel::Critical => "Critical email alert",
+        UrgencyLevel::High => "Urgent email alert",
+        UrgencyLevel::Medium | UrgencyLevel::Low => "Email alert",
+    }
+}
+
+fn build_notification_body(output: &UrgentEmailSummaryOutput) -> String {
+    let mut segments = Vec::new();
+
+    segments.push(
+        non_empty(&output.summary)
+            .unwrap_or("Urgent email needs attention.")
+            .to_string(),
+    );
+    if let Some(action) = first_non_empty(&output.suggested_actions) {
+        segments.push(format!("Action: {action}"));
+    }
+
+    segments.join(" • ")
+}
+
+fn urgency_label(urgency: &UrgencyLevel) -> &'static str {
+    match urgency {
+        UrgencyLevel::Low => "low",
+        UrgencyLevel::Medium => "medium",
+        UrgencyLevel::High => "high",
+        UrgencyLevel::Critical => "critical",
+    }
+}
+
+fn first_non_empty(values: &[String]) -> Option<&str> {
+    values.iter().find_map(|value| non_empty(value.as_str()))
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/backend/crates/worker/src/job_actions/google/urgent_email/tests.rs
+++ b/backend/crates/worker/src/job_actions/google/urgent_email/tests.rs
@@ -1,0 +1,65 @@
+use shared::llm::contracts::{UrgencyLevel, UrgentEmailSummaryOutput};
+
+use super::{
+    URGENT_EMAIL_BODY_MAX_CHARS, URGENT_EMAIL_TITLE_MAX_CHARS, build_notification_body,
+    notification_from_output,
+};
+
+#[test]
+fn notification_uses_summary_and_first_action() {
+    let output = UrgentEmailSummaryOutput {
+        should_notify: true,
+        urgency: UrgencyLevel::High,
+        summary: "Invoice approval is blocked by missing sign-off.".to_string(),
+        reason: "finance escalation".to_string(),
+        suggested_actions: vec![
+            "Review the request from Finance now.".to_string(),
+            "Confirm payment terms with Procurement.".to_string(),
+        ],
+    };
+
+    let notification = notification_from_output(&output);
+    assert_eq!(notification.title, "Urgent email alert");
+    assert!(
+        notification
+            .body
+            .contains("Invoice approval is blocked by missing sign-off.")
+    );
+    assert!(
+        notification
+            .body
+            .contains("Action: Review the request from Finance now.")
+    );
+}
+
+#[test]
+fn notification_falls_back_when_fields_are_empty() {
+    let output = UrgentEmailSummaryOutput {
+        should_notify: true,
+        urgency: UrgencyLevel::Critical,
+        summary: "   ".to_string(),
+        reason: "   ".to_string(),
+        suggested_actions: vec![" ".to_string()],
+    };
+
+    let notification = notification_from_output(&output);
+    assert_eq!(notification.title, "Critical email alert");
+    assert_eq!(notification.body, "Urgent email needs attention.");
+}
+
+#[test]
+fn notification_title_and_body_are_bounded() {
+    let output = UrgentEmailSummaryOutput {
+        should_notify: true,
+        urgency: UrgencyLevel::Critical,
+        summary: "S".repeat(URGENT_EMAIL_BODY_MAX_CHARS + 100),
+        reason: "r".to_string(),
+        suggested_actions: vec!["A".repeat(URGENT_EMAIL_BODY_MAX_CHARS + 80)],
+    };
+
+    let notification = notification_from_output(&output);
+    assert!(notification.body.ends_with("..."));
+    assert!(notification.title.chars().count() <= URGENT_EMAIL_TITLE_MAX_CHARS + 3);
+    assert!(notification.body.chars().count() <= URGENT_EMAIL_BODY_MAX_CHARS + 3);
+    assert!(notification.body.chars().count() < build_notification_body(&output).chars().count());
+}

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -214,7 +214,7 @@ Ship a private beta where iOS users can:
 | AI-004 | P0 | Add `/v1/assistant/query` endpoint for interactive questions (`#95`) | BE | 2026-03-12 | DONE | AI-002, AI-003 | Meetings query works end-to-end with typed assistant response |
 | AI-005 | P0 | Add LLM safety layer + deterministic fallback (`#96`) | SEC | 2026-03-14 | DONE | AI-001, AI-002 | Injection defenses and schema/policy guards enforced |
 | AI-006 | P0 | Migrate morning brief worker path to LLM orchestration (`#97`) | BE | 2026-03-16 | DONE | AI-003, AI-005 | Morning brief push content is LLM-generated and policy-safe |
-| AI-007 | P0 | Migrate urgent-email worker path to LLM prioritization (`#98`) | BE | 2026-03-18 | TODO | AI-003, AI-005 | Urgent-email decision path is LLM-based with safe fallback |
+| AI-007 | P0 | Migrate urgent-email worker path to LLM prioritization (`#98`) | BE | 2026-03-18 | DONE | AI-003, AI-005 | Urgent-email decision path is LLM-based with safe fallback |
 | AI-008 | P0 | Add AI observability + redacted audit events (`#99`) | SRE | 2026-03-20 | TODO | AI-004, AI-006, AI-007 | Latency/usage/cost metrics and redacted audit events are live |
 | AI-009 | P0 | Add LLM reliability guardrails (`#100`) | BE | 2026-03-22 | TODO | AI-004 | Circuit breaker/rate limits/cache/budgets enforced |
 | AI-010 | P0 | Add assistant session memory for follow-up continuity (`#101`) | BE | 2026-03-24 | TODO | AI-004 | Session-context follow-up queries supported with retention controls |


### PR DESCRIPTION
## Summary
Implements issue #98 by replacing the urgent-email placeholder worker path with an LLM-first orchestration flow using safe output resolution and deterministic fallback behavior.

## Changes
- Wired `JobType::UrgentEmailCheck` to a new `urgent_email` module instead of the placeholder pending path.
- Added Gmail candidate fetching (`users/me/messages` + metadata fetch) and conversion into `GoogleEmailCandidateSource` context inputs.
- Added urgent-email LLM orchestration using `AssistantCapability::UrgentEmailSummary`, context sanitization, schema-safe resolution, and deterministic fallback handling.
- Added concise notification shaping for actionable urgent outputs and structured metadata (`should_notify`, `urgency`, `llm_output_source`, token usage, candidate counts).
- Added urgent-email notification unit tests.
- Updated `docs/phase1-master-todo.md` to mark `AI-007` as `DONE`.

## Acceptance Criteria Mapping
- [x] Urgent-email decision path uses LLM output as source of truth.
- [x] Notification output is concise, redacted, and policy-safe.
- [x] LLM failures degrade gracefully without breaking worker loop.
- [x] Rule-based urgent classifier path is removed/hard-disabled.

## Validation
- `just check-tools` ✅
- `just backend-check` ✅
- `just ios-build` ✅
- `just backend-verify` ✅
- `just backend-deep-review` ✅
- `just ios-build` (post-change rerun) ✅

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: `just backend-verify`, `just backend-deep-review` all passed
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no findings; worker orchestration remains in worker module and shared LLM abstractions are reused
- Performance/scalability concerns: no blocking concerns at this scope
- Refactor recommendations: none required for this issue

### 4) Final Status
- `just backend-deep-review`: PASS
- Merge recommendation: `APPROVE`

Closes #98
