### PR TITLE
Harden backend auth/timezone/LLM paths with Redis JWKS cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 
 # Core runtime
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/alfred
+REDIS_URL=redis://127.0.0.1:6379/0
 DATA_ENCRYPTION_KEY=dev-only-change-me
 API_BIND_ADDR=127.0.0.1:8080
 
@@ -17,6 +18,10 @@ CLERK_AUDIENCE=alfred-api
 CLERK_SECRET_KEY=sk_test_replace_me
 # Optional override. If omitted, backend uses https://api.clerk.com/v1
 # CLERK_BACKEND_API_URL=https://api.clerk.com/v1
+# Optional JWKS cache tuning
+# CLERK_JWKS_CACHE_KEY=alfred:clerk:jwks:v1
+# CLERK_JWKS_CACHE_DEFAULT_TTL_SECONDS=300
+# CLERK_JWKS_CACHE_STALE_TTL_SECONDS=300
 
 # Dev-only TEE/KMS toggles for local startup
 TEE_ATTESTATION_REQUIRED=false
@@ -36,6 +41,8 @@ OPENROUTER_API_KEY=or-local-dev-key
 OPENROUTER_TIMEOUT_MS=15000
 OPENROUTER_MAX_RETRIES=2
 OPENROUTER_RETRY_BASE_BACKOFF_MS=250
+OPENROUTER_MAX_OUTPUT_TOKENS=600
+# OPENROUTER_ALLOW_INSECURE_HTTP=true
 
 # Global model routing (primary + fallback)
 OPENROUTER_MODEL_PRIMARY=openai/gpt-4o-mini

--- a/Justfile
+++ b/Justfile
@@ -42,15 +42,17 @@ ios-package-build:
 backend-check:
     cd {{ backend_dir }} && cargo check
 
-# Start local infrastructure (Postgres).
+# Start local infrastructure (Postgres + Redis).
 infra-up:
-    docker compose up -d postgres
+    docker compose up -d postgres redis
     @echo "Postgres is starting on 127.0.0.1:5432 (DB: alfred, user: postgres)."
+    @echo "Redis is starting on 127.0.0.1:6379."
     @echo "Export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/alfred"
+    @echo "Export REDIS_URL=redis://127.0.0.1:6379/0"
 
 # Stop local infrastructure without deleting volumes.
 infra-stop:
-    docker compose stop postgres
+    docker compose stop postgres redis
 
 # Stop and remove local infrastructure including volumes.
 infra-down:
@@ -58,7 +60,7 @@ infra-down:
 
 # Tail local infrastructure logs.
 infra-logs:
-    docker compose logs -f postgres
+    docker compose logs -f postgres redis
 
 # Build Rust backend workspace.
 backend-build:

--- a/alfred/Packages/AlfredAPIClient/Sources/Models.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/Models.swift
@@ -150,6 +150,7 @@ public struct Preferences: Codable, Sendable {
     public let morningBriefLocalTime: String
     public let quietHoursStart: String
     public let quietHoursEnd: String
+    public let timeZone: String
     public let highRiskRequiresConfirm: Bool
 
     enum CodingKeys: String, CodingKey {
@@ -157,6 +158,7 @@ public struct Preferences: Codable, Sendable {
         case morningBriefLocalTime = "morning_brief_local_time"
         case quietHoursStart = "quiet_hours_start"
         case quietHoursEnd = "quiet_hours_end"
+        case timeZone = "time_zone"
         case highRiskRequiresConfirm = "high_risk_requires_confirm"
     }
 
@@ -165,12 +167,14 @@ public struct Preferences: Codable, Sendable {
         morningBriefLocalTime: String,
         quietHoursStart: String,
         quietHoursEnd: String,
+        timeZone: String,
         highRiskRequiresConfirm: Bool
     ) {
         self.meetingReminderMinutes = meetingReminderMinutes
         self.morningBriefLocalTime = morningBriefLocalTime
         self.quietHoursStart = quietHoursStart
         self.quietHoursEnd = quietHoursEnd
+        self.timeZone = timeZone
         self.highRiskRequiresConfirm = highRiskRequiresConfirm
     }
 }

--- a/alfred/alfred/AppModel.swift
+++ b/alfred/alfred/AppModel.swift
@@ -52,6 +52,7 @@ final class AppModel: ObservableObject {
     @Published var morningBriefLocalTime = "08:00"
     @Published var quietHoursStart = "22:00"
     @Published var quietHoursEnd = "07:00"
+    @Published var timeZone = TimeZone.current.identifier
     @Published var highRiskRequiresConfirm = true
 
     @Published private(set) var auditEvents: [AuditEvent] = []
@@ -160,6 +161,7 @@ final class AppModel: ObservableObject {
             morningBriefLocalTime = prefs.morningBriefLocalTime
             quietHoursStart = prefs.quietHoursStart
             quietHoursEnd = prefs.quietHoursEnd
+            timeZone = prefs.timeZone
             highRiskRequiresConfirm = prefs.highRiskRequiresConfirm
             preferencesStatus = "Preferences synced."
         }
@@ -176,6 +178,7 @@ final class AppModel: ObservableObject {
             morningBriefLocalTime: morningBriefLocalTime.trimmingCharacters(in: .whitespacesAndNewlines),
             quietHoursStart: quietHoursStart.trimmingCharacters(in: .whitespacesAndNewlines),
             quietHoursEnd: quietHoursEnd.trimmingCharacters(in: .whitespacesAndNewlines),
+            timeZone: normalizedTimeZoneIdentifier(from: timeZone),
             highRiskRequiresConfirm: highRiskRequiresConfirm
         )
 
@@ -268,6 +271,14 @@ final class AppModel: ObservableObject {
                 sourceAction: action
             )
         }
+    }
+
+    private func normalizedTimeZoneIdentifier(from value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return TimeZone.current.identifier
+        }
+        return TimeZone(identifier: trimmed)?.identifier ?? TimeZone.current.identifier
     }
 
     private func startAuthEventObserver() {

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -437,6 +437,7 @@ components:
           morning_brief_local_time,
           quiet_hours_start,
           quiet_hours_end,
+          time_zone,
           high_risk_requires_confirm
         ]
       properties:
@@ -454,6 +455,11 @@ components:
         quiet_hours_end:
           type: string
           pattern: "^([01]\\d|2[0-3]):[0-5]\\d$"
+        time_zone:
+          type: string
+          description: IANA timezone identifier (for example, America/Los_Angeles).
+          minLength: 1
+          maxLength: 64
         high_risk_requires_confirm:
           type: boolean
     UpdatePreferencesRequest:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,10 +6,14 @@ WORKER_TICK_SECONDS=30
 
 # Shared OAuth vars (used by API + worker job execution)
 # DATABASE_URL=postgres://postgres:postgres@localhost:5432/alfred
+# REDIS_URL=redis://127.0.0.1:6379/0
 # CLERK_ISSUER=https://your-tenant.clerk.accounts.dev
 # CLERK_AUDIENCE=alfred-api
 # CLERK_SECRET_KEY=sk_test_replace_me
 # CLERK_BACKEND_API_URL=https://api.clerk.com/v1
+# CLERK_JWKS_CACHE_KEY=alfred:clerk:jwks:v1
+# CLERK_JWKS_CACHE_DEFAULT_TTL_SECONDS=300
+# CLERK_JWKS_CACHE_STALE_TTL_SECONDS=300
 # GOOGLE_OAUTH_CLIENT_ID=replace-me
 # GOOGLE_OAUTH_CLIENT_SECRET=replace-me
 # OPENROUTER_API_KEY=replace-me
@@ -17,5 +21,7 @@ WORKER_TICK_SECONDS=30
 # OPENROUTER_TIMEOUT_MS=15000
 # OPENROUTER_MAX_RETRIES=2
 # OPENROUTER_RETRY_BASE_BACKOFF_MS=250
+# OPENROUTER_MAX_OUTPUT_TOKENS=600
+# OPENROUTER_ALLOW_INSECURE_HTTP=true
 # OPENROUTER_MODEL_PRIMARY=openai/gpt-4o-mini
 # OPENROUTER_MODEL_FALLBACK=anthropic/claude-3.5-haiku

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "chrono",
  "jsonwebtoken",
  "rand 0.8.5",
+ "redis",
  "reqwest",
  "rsa",
  "serde",
@@ -117,6 +118,15 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -190,6 +200,15 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -304,6 +323,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +377,20 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -629,6 +672,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -988,7 +1037,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1572,6 +1621,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,7 +1742,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror",
  "tokio",
  "tracing",
@@ -1712,7 +1779,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1789,6 +1856,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redis"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc42f3a12fd4408ce64d8efef67048a924e543bd35c6591c0447fda9054695f"
+dependencies = [
+ "arc-swap",
+ "backon",
+ "bytes",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -2155,6 +2245,7 @@ dependencies = [
  "axum",
  "base64",
  "chrono",
+ "chrono-tz",
  "dotenvy",
  "ed25519-dalek",
  "jsonschema",
@@ -2208,6 +2299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2317,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2605,7 +2712,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2638,6 +2745,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -15,10 +15,12 @@ license = "UNLICENSED"
 axum = "0.8"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 dotenvy = "0.15"
 ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
 jsonschema = "0.18"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+redis = { version = "0.29", default-features = false, features = ["tokio-comp", "connection-manager"] }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -26,7 +28,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json", "migrate"] }
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = "2"

--- a/backend/crates/api-server/Cargo.toml
+++ b/backend/crates/api-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 axum.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
+redis.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 jsonwebtoken.workspace = true

--- a/backend/crates/api-server/src/http/authn.rs
+++ b/backend/crates/api-server/src/http/authn.rs
@@ -34,6 +34,7 @@ pub(super) async fn auth_middleware(
 
     let identity = match verify_identity_token(
         &state.http_client,
+        &state.clerk_jwks_cache,
         &state.clerk_jwks_url,
         &state.clerk_secret_key,
         &state.clerk_issuer,

--- a/backend/crates/api-server/src/http/clerk_jwks_cache.rs
+++ b/backend/crates/api-server/src/http/clerk_jwks_cache.rs
@@ -1,0 +1,293 @@
+use std::sync::Arc;
+
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
+use reqwest::header::{CACHE_CONTROL, HeaderMap};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+const MIN_CACHE_CONTROL_TTL_SECONDS: u64 = 60;
+const MAX_CACHE_CONTROL_TTL_SECONDS: u64 = 3600;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClerkJwksCacheConfig {
+    pub(crate) redis_url: String,
+    pub(crate) cache_key: String,
+    pub(crate) default_ttl_seconds: u64,
+    pub(crate) stale_ttl_seconds: u64,
+}
+
+#[derive(Clone)]
+pub(crate) struct ClerkJwksCache {
+    connection: ConnectionManager,
+    config: ClerkJwksCacheConfig,
+    refresh_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+#[derive(Debug)]
+pub(crate) enum ClerkJwksCacheError {
+    UnknownKeyId,
+    UpstreamUnavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedJwksEntry {
+    jwks_json: String,
+    fetched_at: i64,
+    expires_at: i64,
+    stale_until: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct JwksEnvelope {
+    #[serde(default)]
+    keys: Vec<JwksKey>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JwksKey {
+    kid: String,
+}
+
+impl ClerkJwksCache {
+    pub(crate) async fn new(config: ClerkJwksCacheConfig) -> Result<Self, String> {
+        if config.default_ttl_seconds == 0 {
+            return Err("clerk jwks cache default ttl must be greater than 0".to_string());
+        }
+        if config.stale_ttl_seconds == 0 {
+            return Err("clerk jwks cache stale ttl must be greater than 0".to_string());
+        }
+        if config.cache_key.trim().is_empty() {
+            return Err("clerk jwks cache key must not be empty".to_string());
+        }
+
+        let client =
+            redis::Client::open(config.redis_url.as_str()).map_err(|err| err.to_string())?;
+        let connection = ConnectionManager::new(client)
+            .await
+            .map_err(|err| err.to_string())?;
+
+        let mut health_connection = connection.clone();
+        redis::cmd("PING")
+            .query_async::<String>(&mut health_connection)
+            .await
+            .map_err(|err| format!("failed to connect to redis: {err}"))?;
+
+        Ok(Self {
+            connection,
+            config,
+            refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+        })
+    }
+
+    pub(crate) async fn load_jwks_for_key(
+        &self,
+        http_client: &reqwest::Client,
+        jwks_url: &str,
+        key_id: &str,
+    ) -> Result<String, ClerkJwksCacheError> {
+        let now = unix_timestamp();
+        if let Some(cached) = self.read_cached_entry().await
+            && now <= cached.expires_at
+            && jwks_contains_key(&cached.jwks_json, key_id)
+        {
+            return Ok(cached.jwks_json);
+        }
+
+        let _refresh_guard = self.refresh_lock.lock().await;
+
+        let now = unix_timestamp();
+        let cached_after_lock = self.read_cached_entry().await;
+        if let Some(cached) = cached_after_lock.as_ref()
+            && now <= cached.expires_at
+            && jwks_contains_key(&cached.jwks_json, key_id)
+        {
+            return Ok(cached.jwks_json.clone());
+        }
+
+        let stale_fallback = cached_after_lock.as_ref().and_then(|cached| {
+            (now <= cached.stale_until && jwks_contains_key(&cached.jwks_json, key_id))
+                .then(|| cached.jwks_json.clone())
+        });
+
+        match self.fetch_and_cache_jwks(http_client, jwks_url).await {
+            Ok(fetched) => {
+                if jwks_contains_key(&fetched.jwks_json, key_id) {
+                    Ok(fetched.jwks_json)
+                } else {
+                    Err(ClerkJwksCacheError::UnknownKeyId)
+                }
+            }
+            Err(err) => {
+                if let Some(stale_jwks) = stale_fallback {
+                    warn!(
+                        key_id = %key_id,
+                        "using stale Clerk JWKS cache entry because refresh failed"
+                    );
+                    Ok(stale_jwks)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    async fn read_cached_entry(&self) -> Option<CachedJwksEntry> {
+        let mut connection = self.connection.clone();
+        let raw: Option<String> = match connection.get(&self.config.cache_key).await {
+            Ok(raw) => raw,
+            Err(err) => {
+                warn!("failed to read Clerk JWKS cache entry from redis: {err}");
+                return None;
+            }
+        };
+
+        raw.and_then(
+            |payload| match serde_json::from_str::<CachedJwksEntry>(&payload) {
+                Ok(parsed) => Some(parsed),
+                Err(err) => {
+                    warn!("failed to parse Clerk JWKS cache entry from redis: {err}");
+                    None
+                }
+            },
+        )
+    }
+
+    async fn fetch_and_cache_jwks(
+        &self,
+        http_client: &reqwest::Client,
+        jwks_url: &str,
+    ) -> Result<CachedJwksEntry, ClerkJwksCacheError> {
+        let response = http_client
+            .get(jwks_url)
+            .send()
+            .await
+            .map_err(|_| ClerkJwksCacheError::UpstreamUnavailable)?;
+        if !response.status().is_success() {
+            return Err(ClerkJwksCacheError::UpstreamUnavailable);
+        }
+
+        let ttl_seconds =
+            resolve_cache_ttl_seconds(response.headers(), self.config.default_ttl_seconds);
+        let body = response
+            .text()
+            .await
+            .map_err(|_| ClerkJwksCacheError::UpstreamUnavailable)?;
+
+        if !looks_like_jwks(&body) {
+            return Err(ClerkJwksCacheError::UpstreamUnavailable);
+        }
+
+        let now = unix_timestamp();
+        let expires_at = now.saturating_add(i64::try_from(ttl_seconds).unwrap_or(i64::MAX));
+        let stale_until = expires_at
+            .saturating_add(i64::try_from(self.config.stale_ttl_seconds).unwrap_or(i64::MAX));
+
+        let entry = CachedJwksEntry {
+            jwks_json: body,
+            fetched_at: now,
+            expires_at,
+            stale_until,
+        };
+
+        let redis_ttl_seconds = ttl_seconds.saturating_add(self.config.stale_ttl_seconds);
+        self.write_cached_entry(&entry, redis_ttl_seconds).await;
+
+        Ok(entry)
+    }
+
+    async fn write_cached_entry(&self, entry: &CachedJwksEntry, ttl_seconds: u64) {
+        let serialized = match serde_json::to_string(entry) {
+            Ok(serialized) => serialized,
+            Err(err) => {
+                warn!("failed to serialize Clerk JWKS cache entry: {err}");
+                return;
+            }
+        };
+
+        let mut connection = self.connection.clone();
+        if let Err(err) = connection
+            .set_ex::<_, _, ()>(&self.config.cache_key, serialized, ttl_seconds)
+            .await
+        {
+            warn!("failed to write Clerk JWKS cache entry to redis: {err}");
+        }
+    }
+}
+
+fn looks_like_jwks(jwks_json: &str) -> bool {
+    serde_json::from_str::<JwksEnvelope>(jwks_json)
+        .map(|jwks| !jwks.keys.is_empty())
+        .unwrap_or(false)
+}
+
+fn jwks_contains_key(jwks_json: &str, key_id: &str) -> bool {
+    serde_json::from_str::<JwksEnvelope>(jwks_json)
+        .map(|jwks| jwks.keys.into_iter().any(|key| key.kid == key_id))
+        .unwrap_or(false)
+}
+
+fn resolve_cache_ttl_seconds(headers: &HeaderMap, default_ttl_seconds: u64) -> u64 {
+    let ttl_seconds = headers
+        .get(CACHE_CONTROL)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_cache_control_max_age)
+        .unwrap_or(default_ttl_seconds);
+
+    ttl_seconds.clamp(MIN_CACHE_CONTROL_TTL_SECONDS, MAX_CACHE_CONTROL_TTL_SECONDS)
+}
+
+fn parse_cache_control_max_age(cache_control: &str) -> Option<u64> {
+    for directive in cache_control.split(',') {
+        let normalized = directive.trim().to_ascii_lowercase();
+        if let Some(value) = normalized.strip_prefix("max-age=")
+            && let Ok(parsed) = value.parse::<u64>()
+        {
+            return Some(parsed);
+        }
+    }
+
+    None
+}
+
+fn unix_timestamp() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::{HeaderMap, HeaderValue};
+
+    use super::{jwks_contains_key, parse_cache_control_max_age, resolve_cache_ttl_seconds};
+
+    #[test]
+    fn parse_cache_control_max_age_reads_valid_directive() {
+        assert_eq!(
+            parse_cache_control_max_age("public, max-age=120, must-revalidate"),
+            Some(120)
+        );
+    }
+
+    #[test]
+    fn parse_cache_control_max_age_ignores_invalid_values() {
+        assert_eq!(parse_cache_control_max_age("private, max-age=abc"), None);
+        assert_eq!(parse_cache_control_max_age("no-store"), None);
+    }
+
+    #[test]
+    fn resolve_cache_ttl_seconds_clamps_to_safe_range() {
+        let mut headers = HeaderMap::new();
+        headers.insert("cache-control", HeaderValue::from_static("max-age=5"));
+        assert_eq!(resolve_cache_ttl_seconds(&headers, 300), 60);
+
+        headers.insert("cache-control", HeaderValue::from_static("max-age=7200"));
+        assert_eq!(resolve_cache_ttl_seconds(&headers, 300), 3600);
+    }
+
+    #[test]
+    fn jwks_contains_key_checks_known_kid() {
+        let jwks = r#"{"keys":[{"kid":"kid-a"},{"kid":"kid-b"}]}"#;
+        assert!(jwks_contains_key(jwks, "kid-a"));
+        assert!(!jwks_contains_key(jwks, "kid-missing"));
+    }
+}

--- a/backend/crates/api-server/src/http/mod.rs
+++ b/backend/crates/api-server/src/http/mod.rs
@@ -11,6 +11,7 @@ mod assistant;
 mod audit;
 mod authn;
 mod clerk_identity;
+mod clerk_jwks_cache;
 mod connectors;
 mod devices;
 mod errors;
@@ -21,6 +22,7 @@ mod preferences;
 mod privacy;
 mod rate_limit;
 mod tokens;
+pub(crate) use clerk_jwks_cache::{ClerkJwksCache, ClerkJwksCacheConfig};
 pub use rate_limit::RateLimiter;
 
 #[derive(Clone)]
@@ -47,6 +49,7 @@ pub struct AppState {
     pub clerk_audience: String,
     pub clerk_secret_key: String,
     pub clerk_jwks_url: String,
+    pub clerk_jwks_cache: ClerkJwksCache,
     pub http_client: reqwest::Client,
 }
 

--- a/backend/crates/api-server/src/http/preferences.rs
+++ b/backend/crates/api-server/src/http/preferences.rs
@@ -34,6 +34,7 @@ pub(super) async fn update_preferences(
         "meeting_reminder_minutes".to_string(),
         req.meeting_reminder_minutes.to_string(),
     );
+    metadata.insert("time_zone".to_string(), req.time_zone.clone());
 
     if let Err(err) = state
         .store

--- a/backend/crates/shared/Cargo.toml
+++ b/backend/crates/shared/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 base64.workspace = true
 chrono.workspace = true
+chrono-tz.workspace = true
 dotenvy.workspace = true
 ed25519-dalek.workspace = true
 jsonschema.workspace = true

--- a/backend/crates/shared/src/lib.rs
+++ b/backend/crates/shared/src/lib.rs
@@ -4,3 +4,4 @@ pub mod llm;
 pub mod models;
 pub mod repos;
 pub mod security;
+pub mod timezone;

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -104,6 +104,7 @@ pub struct Preferences {
     pub morning_brief_local_time: String,
     pub quiet_hours_start: String,
     pub quiet_hours_end: String,
+    pub time_zone: String,
     pub high_risk_requires_confirm: bool,
 }
 

--- a/backend/crates/shared/src/repos/mod.rs
+++ b/backend/crates/shared/src/repos/mod.rs
@@ -18,6 +18,7 @@ const DEFAULT_MEETING_REMINDER_MINUTES: i32 = 15;
 const DEFAULT_MORNING_BRIEF_LOCAL_TIME: &str = "08:00";
 const DEFAULT_QUIET_HOURS_START: &str = "22:00";
 const DEFAULT_QUIET_HOURS_END: &str = "07:00";
+const DEFAULT_TIME_ZONE: &str = "UTC";
 pub const LEGACY_CONNECTOR_TOKEN_KEY_ID: &str = "__legacy__";
 
 #[derive(Debug, Clone)]

--- a/backend/crates/shared/src/repos/preferences.rs
+++ b/backend/crates/shared/src/repos/preferences.rs
@@ -2,10 +2,11 @@ use sqlx::Row;
 use uuid::Uuid;
 
 use crate::models::Preferences;
+use crate::timezone::{DEFAULT_USER_TIME_ZONE, normalize_time_zone};
 
 use super::{
     DEFAULT_MEETING_REMINDER_MINUTES, DEFAULT_MORNING_BRIEF_LOCAL_TIME, DEFAULT_QUIET_HOURS_END,
-    DEFAULT_QUIET_HOURS_START, Store, StoreError,
+    DEFAULT_QUIET_HOURS_START, DEFAULT_TIME_ZONE, Store, StoreError,
 };
 
 impl Store {
@@ -17,7 +18,7 @@ impl Store {
 
         if let Some(row) = sqlx::query(
             "SELECT meeting_reminder_minutes, morning_brief_local_time, quiet_hours_start,
-                    quiet_hours_end, high_risk_requires_confirm
+                    quiet_hours_end, time_zone, high_risk_requires_confirm
              FROM user_preferences
              WHERE user_id = $1",
         )
@@ -35,14 +36,16 @@ impl Store {
                 morning_brief_local_time,
                 quiet_hours_start,
                 quiet_hours_end,
+                time_zone,
                 high_risk_requires_confirm
-             ) VALUES ($1, $2, $3, $4, $5, $6)",
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
         )
         .bind(user_id)
         .bind(DEFAULT_MEETING_REMINDER_MINUTES)
         .bind(DEFAULT_MORNING_BRIEF_LOCAL_TIME)
         .bind(DEFAULT_QUIET_HOURS_START)
         .bind(DEFAULT_QUIET_HOURS_END)
+        .bind(DEFAULT_TIME_ZONE)
         .bind(true)
         .execute(&self.pool)
         .await?;
@@ -52,6 +55,7 @@ impl Store {
             morning_brief_local_time: DEFAULT_MORNING_BRIEF_LOCAL_TIME.to_string(),
             quiet_hours_start: DEFAULT_QUIET_HOURS_START.to_string(),
             quiet_hours_end: DEFAULT_QUIET_HOURS_END.to_string(),
+            time_zone: DEFAULT_TIME_ZONE.to_string(),
             high_risk_requires_confirm: true,
         })
     }
@@ -62,6 +66,10 @@ impl Store {
         preferences: &Preferences,
     ) -> Result<(), StoreError> {
         self.ensure_user(user_id).await?;
+        let normalized_time_zone =
+            normalize_time_zone(&preferences.time_zone).ok_or_else(|| {
+                StoreError::InvalidData("time_zone is not a valid IANA timezone".to_string())
+            })?;
 
         sqlx::query(
             "INSERT INTO user_preferences (
@@ -70,14 +78,16 @@ impl Store {
                 morning_brief_local_time,
                 quiet_hours_start,
                 quiet_hours_end,
+                time_zone,
                 high_risk_requires_confirm
-             ) VALUES ($1, $2, $3, $4, $5, $6)
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7)
              ON CONFLICT (user_id)
              DO UPDATE SET
                meeting_reminder_minutes = EXCLUDED.meeting_reminder_minutes,
                morning_brief_local_time = EXCLUDED.morning_brief_local_time,
                quiet_hours_start = EXCLUDED.quiet_hours_start,
                quiet_hours_end = EXCLUDED.quiet_hours_end,
+               time_zone = EXCLUDED.time_zone,
                high_risk_requires_confirm = EXCLUDED.high_risk_requires_confirm,
                updated_at = NOW()",
         )
@@ -86,6 +96,7 @@ impl Store {
         .bind(&preferences.morning_brief_local_time)
         .bind(&preferences.quiet_hours_start)
         .bind(&preferences.quiet_hours_end)
+        .bind(&normalized_time_zone)
         .bind(preferences.high_risk_requires_confirm)
         .execute(&self.pool)
         .await?;
@@ -105,6 +116,11 @@ fn row_to_preferences(row: &sqlx::postgres::PgRow) -> Result<Preferences, StoreE
         morning_brief_local_time: row.try_get("morning_brief_local_time")?,
         quiet_hours_start: row.try_get("quiet_hours_start")?,
         quiet_hours_end: row.try_get("quiet_hours_end")?,
+        time_zone: row
+            .try_get::<String, _>("time_zone")
+            .ok()
+            .and_then(|raw| normalize_time_zone(&raw))
+            .unwrap_or_else(|| DEFAULT_USER_TIME_ZONE.to_string()),
         high_risk_requires_confirm: row.try_get("high_risk_requires_confirm")?,
     })
 }

--- a/backend/crates/shared/src/timezone.rs
+++ b/backend/crates/shared/src/timezone.rs
@@ -1,0 +1,111 @@
+use chrono::{DateTime, Days, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+use chrono_tz::Tz;
+
+pub const DEFAULT_USER_TIME_ZONE: &str = "UTC";
+
+pub fn normalize_time_zone(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    trimmed.parse::<Tz>().ok().map(|tz| tz.name().to_string())
+}
+
+pub fn parse_time_zone_or_default(value: &str) -> Tz {
+    normalize_time_zone(value)
+        .and_then(|normalized| normalized.parse::<Tz>().ok())
+        .unwrap_or(chrono_tz::UTC)
+}
+
+pub fn user_local_date(now_utc: DateTime<Utc>, time_zone: &str) -> NaiveDate {
+    let tz = parse_time_zone_or_default(time_zone);
+    now_utc.with_timezone(&tz).date_naive()
+}
+
+pub fn user_local_time(now_utc: DateTime<Utc>, time_zone: &str) -> NaiveTime {
+    let tz = parse_time_zone_or_default(time_zone);
+    now_utc.with_timezone(&tz).time()
+}
+
+pub fn local_day_bounds_utc(
+    local_date: NaiveDate,
+    time_zone: &str,
+) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+    let start_of_day = local_date.and_hms_opt(0, 0, 0)?;
+    let next_day = local_date.checked_add_days(Days::new(1))?;
+    let start_of_next_day = next_day.and_hms_opt(0, 0, 0)?;
+
+    let tz = parse_time_zone_or_default(time_zone);
+    let local_start = resolve_local_datetime(&tz, start_of_day)?;
+    let local_end = resolve_local_datetime(&tz, start_of_next_day)?;
+
+    Some((
+        local_start.with_timezone(&Utc),
+        local_end.with_timezone(&Utc),
+    ))
+}
+
+fn resolve_local_datetime(tz: &Tz, local: NaiveDateTime) -> Option<DateTime<Tz>> {
+    match tz.from_local_datetime(&local) {
+        LocalResult::Single(value) => Some(value),
+        LocalResult::Ambiguous(earliest, _) => Some(earliest),
+        LocalResult::None => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{NaiveDate, TimeZone, Timelike, Utc};
+
+    use super::{
+        DEFAULT_USER_TIME_ZONE, local_day_bounds_utc, normalize_time_zone, user_local_date,
+        user_local_time,
+    };
+
+    #[test]
+    fn normalize_time_zone_accepts_valid_iana_name() {
+        assert_eq!(
+            normalize_time_zone("America/Los_Angeles"),
+            Some("America/Los_Angeles".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_time_zone_rejects_invalid_values() {
+        assert_eq!(normalize_time_zone(""), None);
+        assert_eq!(normalize_time_zone("Mars/Olympus"), None);
+    }
+
+    #[test]
+    fn user_local_date_uses_default_when_time_zone_is_invalid() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 2, 17, 1, 15, 0)
+            .single()
+            .expect("valid utc datetime");
+        let local_date = user_local_date(now, "not-a-time-zone");
+        assert_eq!(local_date.to_string(), "2026-02-17");
+        assert_eq!(DEFAULT_USER_TIME_ZONE, "UTC");
+    }
+
+    #[test]
+    fn local_day_bounds_convert_local_midnight_to_utc() {
+        let local_date = NaiveDate::from_ymd_opt(2026, 2, 17).expect("valid local date");
+        let (start_utc, end_utc) =
+            local_day_bounds_utc(local_date, "America/Los_Angeles").expect("time bounds");
+
+        assert_eq!(start_utc.date_naive().to_string(), "2026-02-17");
+        assert_eq!(start_utc.hour(), 8);
+        assert_eq!(end_utc.hour(), 8);
+    }
+
+    #[test]
+    fn user_local_time_converts_from_utc() {
+        let now = Utc
+            .with_ymd_and_hms(2026, 2, 17, 9, 30, 0)
+            .single()
+            .expect("valid utc datetime");
+        let local_time = user_local_time(now, "America/New_York");
+        assert_eq!(local_time.format("%H:%M").to_string(), "04:30");
+    }
+}

--- a/backend/crates/shared/tests/openrouter_gateway.rs
+++ b/backend/crates/shared/tests/openrouter_gateway.rs
@@ -216,6 +216,8 @@ fn config_for(
         timeout_ms: 5_000,
         max_retries,
         retry_base_backoff_ms,
+        max_output_tokens: 600,
+        allow_insecure_http: true,
         model_route: OpenRouterModelRoute {
             primary_model: "primary-model".to_string(),
             fallback_model: Some("fallback-model".to_string()),

--- a/backend/crates/worker/src/job_actions/mod.rs
+++ b/backend/crates/worker/src/job_actions/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use chrono::Utc;
 use shared::repos::{AuditResult, ClaimedJob, Store};
+use shared::timezone::user_local_time;
 use tracing::{info, warn};
 
 use crate::{
@@ -90,8 +91,9 @@ pub(super) async fn dispatch_job_action(
         return Ok(());
     };
 
+    let now_local_time = user_local_time(Utc::now(), &preferences.time_zone);
     if helpers::is_within_quiet_hours(
-        Utc::now().time(),
+        now_local_time,
         &preferences.quiet_hours_start,
         &preferences.quiet_hours_end,
     )

--- a/backend/crates/worker/src/main.rs
+++ b/backend/crates/worker/src/main.rs
@@ -68,7 +68,16 @@ async fn main() {
         config.apns_production_endpoint.clone(),
         config.apns_auth_token.clone(),
     );
-    let oauth_client = reqwest::Client::new();
+    let oauth_client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            error!("failed to initialize worker http client: {err}");
+            std::process::exit(1);
+        }
+    };
     let secret_runtime = SecretRuntime::new(
         TeeAttestationPolicy {
             required: config.tee_attestation_required,

--- a/db/migrations/0008_user_preferences_time_zone.sql
+++ b/db/migrations/0008_user_preferences_time_zone.sql
@@ -1,0 +1,6 @@
+ALTER TABLE user_preferences
+ADD COLUMN IF NOT EXISTS time_zone TEXT NOT NULL DEFAULT 'UTC';
+
+UPDATE user_preferences
+SET time_zone = 'UTC'
+WHERE trim(time_zone) = '';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,21 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  redis:
+    image: redis:7-alpine
+    container_name: alfred-redis
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   postgres_data:
+  redis_data:


### PR DESCRIPTION
## Summary
- add Redis infrastructure and a Redis-backed Clerk JWKS cache with TTL + stale fallback and singleflight refresh
- remove direct per-request JWKS fetch path dependency from auth middleware and route identity verification through cache
- add timezone-aware preference support (time_zone) with migration and update assistant/morning-brief/quiet-hours logic to use user local time
- harden outbound HTTP clients with explicit timeouts (API + worker)
- harden OpenRouter config/output controls (HTTPS-by-default, max output tokens, oversized output guardrails)
- align API and iOS client preference contracts for new timezone field

## Validation
- just backend-deep-review
- just check-tools
- just ios-build
