### PR TITLE
SEC-004: bind decrypt authorization to persisted connector key metadata

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -90,6 +90,7 @@ Connector token usage boundary:
 2. Sensitive Google token refresh/revoke flows execute through the enclave RPC contract in `shared::enclave`.
 3. Decrypt authorization fails closed when challenge-bound attestation verification/KMS policy checks fail or connector key metadata drifts.
 4. API/worker startup now performs fail-closed connectivity checks against enclave runtime `GET /healthz`, `GET /v1/attestation/document`, and `POST /v1/attestation/challenge`.
+5. Enclave decrypt flow re-reads connector key metadata from storage and does not trust host-provided key metadata in RPC requests.
 
 Enclave runtime commands:
 

--- a/backend/crates/api-server/src/http/assistant/session.rs
+++ b/backend/crates/api-server/src/http/assistant/session.rs
@@ -25,8 +25,6 @@ pub(super) async fn build_google_session(
         .exchange_google_access_token(ConnectorSecretRequest {
             user_id,
             connector_id: active_connector.connector_id,
-            token_key_id: active_connector.token_key_id,
-            token_version: active_connector.token_version,
         })
         .await
     {
@@ -42,8 +40,6 @@ pub(super) async fn build_google_session(
 #[derive(Clone)]
 struct ActiveGoogleConnector {
     connector_id: Uuid,
-    token_key_id: String,
-    token_version: i32,
 }
 
 async fn load_active_google_connector(
@@ -98,8 +94,6 @@ async fn load_active_google_connector(
 
     Ok(ActiveGoogleConnector {
         connector_id: connector.connector_id,
-        token_key_id: connector.token_key_id,
-        token_version: connector.token_version,
     })
 }
 

--- a/backend/crates/worker/src/job_actions/google/session.rs
+++ b/backend/crates/worker/src/job_actions/google/session.rs
@@ -26,8 +26,6 @@ pub(super) async fn build_google_session(
         .exchange_google_access_token(ConnectorSecretRequest {
             user_id,
             connector_id: connector.connector_id,
-            token_key_id: connector.token_key_id,
-            token_version: connector.token_version,
         })
         .await
         .map_err(map_exchange_enclave_error)?;
@@ -41,8 +39,6 @@ pub(super) async fn build_google_session(
 #[derive(Clone)]
 struct ActiveGoogleConnector {
     connector_id: uuid::Uuid,
-    token_key_id: String,
-    token_version: i32,
 }
 
 async fn load_active_google_connector(
@@ -106,8 +102,6 @@ async fn load_active_google_connector(
 
     Ok(ActiveGoogleConnector {
         connector_id: connector.connector_id,
-        token_key_id: connector.token_key_id,
-        token_version: connector.token_version,
     })
 }
 

--- a/backend/crates/worker/src/privacy_delete_revoke.rs
+++ b/backend/crates/worker/src/privacy_delete_revoke.rs
@@ -69,8 +69,6 @@ async fn revoke_single_connector(
         .revoke_google_connector_token(ConnectorSecretRequest {
             user_id,
             connector_id: connector.connector_id,
-            token_key_id: connector.token_key_id.clone(),
-            token_version: connector.token_version,
         })
         .await
         .map_err(map_revoke_enclave_error)?;

--- a/docs/cloud-deployment-local-testing.md
+++ b/docs/cloud-deployment-local-testing.md
@@ -219,6 +219,8 @@ API:
 Security/TEE:
 1. For non-production smoke staging only: `TEE_ATTESTATION_REQUIRED=false`, `TEE_ALLOW_INSECURE_DEV_ATTESTATION=true`, `TEE_ATTESTATION_DOCUMENT={}`
 2. For production-like secure mode: provide attestation document source, challenge signing key (`TEE_ATTESTATION_SIGNING_PRIVATE_KEY`), verifier public key (`TEE_ATTESTATION_PUBLIC_KEY`), and keep insecure mode disabled.
+3. Set KMS policy inputs: `KMS_KEY_ID`, `KMS_KEY_VERSION`, and `KMS_ALLOWED_MEASUREMENTS`.
+4. Production key policy must allow decrypt only for approved attested enclave measurements and deny direct host-role decrypt paths.
 
 Worker/APNs (if testing push delivery):
 1. `APNS_SANDBOX_ENDPOINT` and/or `APNS_PRODUCTION_ENDPOINT`

--- a/docs/iam-least-privilege-review.md
+++ b/docs/iam-least-privilege-review.md
@@ -23,7 +23,7 @@
 
 ## 3) Evidence Collected
 
-1. Code path enforces enclave-attested decrypt checks before secret use (`backend/crates/shared/src/security.rs`).
+1. Code path enforces enclave-attested decrypt checks before secret use (`backend/crates/shared/src/security/mod.rs`).
 2. API and worker bootstrap only consume env-scoped credentials and do not expose raw secret material in responses.
 3. CI runs static + test gates without production infra credentials in workflow definition.
 

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -106,7 +106,7 @@ Ship a private beta where iOS users can:
 | SEC-001 | P0 | Pick TEE provider/architecture decision record | SEC | 2026-02-21 | DONE | - | ADR approved |
 | SEC-002 | P0 | Build enclave image baseline | SEC | 2026-02-28 | DONE | SEC-001 | Image boot + smoke pass |
 | SEC-003 | P0 | Implement enclave attestation validation | SEC | 2026-03-04 | DONE | SEC-002 | Attestation verified end-to-end |
-| SEC-004 | P0 | Bind KMS decrypt access to enclave measurements | SEC | 2026-03-06 | IN_PROGRESS | SEC-003 | Decrypt denied outside attested enclave |
+| SEC-004 | P0 | Bind KMS decrypt access to enclave measurements | SEC | 2026-03-06 | DONE | SEC-003 | Decrypt denied outside attested enclave |
 | SEC-005 | P0 | Implement secure host<->enclave RPC contract | SEC | 2026-03-08 | IN_PROGRESS | SEC-002 | RPC path stable and tested |
 | SEC-006 | P0 | Move Google API fetch/decrypt path into enclave process | SEC | 2026-03-13 | TODO | SEC-004, BE-006 | Sensitive path enclave-only |
 | SEC-007 | P0 | Token encryption/decryption service with key versioning | SEC | 2026-03-09 | IN_PROGRESS | SEC-004 | Key versioned crypto works |


### PR DESCRIPTION
## Summary
- remove host-provided `token_key_id`/`token_version` from `ConnectorSecretRequest` so host paths cannot influence decrypt key binding
- in `shared::enclave`, re-read active connector key metadata from storage before attestation/KMS authorization and decrypt
- tighten connector decrypt query to require provider + persisted key metadata
- add boundary guard test to ensure API/worker host paths do not call decrypt repository API directly
- update security docs and mark `SEC-004` as `DONE` in phase todo board

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just backend-verify`
- `just backend-deep-review`
- `just ios-build` (post-change)

## AI Review Summary
### 1) Security Audit
- Findings: no new vulnerabilities introduced; decrypt path now binds to persisted key metadata and attestation/KMS checks inside enclave flow; added guard test for host direct-decrypt boundary.
- Risk level: low.
- Required fixes: none.

### 2) Bug Check
- Findings: no functional regressions found in changed paths after full backend + iOS validation.
- Repro or test evidence: `cargo test` (workspace) and new `host_paths_do_not_call_store_decrypt_directly` test pass.
- Required fixes: none.

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: boundary remains intact (`repos` for SQL, host handlers call enclave client).
- Performance/scalability concerns: additional metadata lookup in enclave path is single-row indexed read and acceptable for token refresh/revoke path.
- Refactor recommendations: none required for this scope.

### 4) Final Status
- `just backend-deep-review`: pass.
- Merge recommendation: `APPROVE`.

Closes #124
