### PR TITLE
Harden non-local TEE posture and RPC auth coverage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -86,6 +86,14 @@ These vars control TEE/KMS-bound decrypt policy for connector refresh tokens:
 21. `ENCLAVE_RPC_SHARED_SECRET` (shared secret for signed host↔enclave RPC request authentication; required outside local)
 22. `ENCLAVE_RPC_AUTH_MAX_SKEW_SECONDS` (default: `30`; max allowed timestamp skew for signed RPC requests)
 
+Non-local (`ALFRED_ENV=staging|production`) security guards:
+
+1. `ENCLAVE_RUNTIME_MODE` must be `remote`.
+2. `TEE_ATTESTATION_REQUIRED=true` and `TEE_ALLOW_INSECURE_DEV_ATTESTATION=false`.
+3. `TEE_ALLOWED_MEASUREMENTS` and `KMS_ALLOWED_MEASUREMENTS` must not contain `dev-local-enclave`.
+4. `ENCLAVE_RUNTIME_BASE_URL` must use `https`, or loopback `http` only (`127.0.0.1`, `localhost`, `[::1]`).
+5. Enclave runtime rejects inline `TEE_ATTESTATION_DOCUMENT` outside local.
+
 Connector token usage boundary:
 
 1. API/worker handler modules do not call connector decrypt repository APIs directly.

--- a/backend/crates/enclave-runtime/src/http/tests.rs
+++ b/backend/crates/enclave-runtime/src/http/tests.rs
@@ -1,0 +1,201 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use chrono::Utc;
+use shared::enclave::{
+    ENCLAVE_RPC_AUTH_NONCE_HEADER, ENCLAVE_RPC_AUTH_SIGNATURE_HEADER,
+    ENCLAVE_RPC_AUTH_TIMESTAMP_HEADER, ENCLAVE_RPC_CONTRACT_VERSION,
+    ENCLAVE_RPC_CONTRACT_VERSION_HEADER, ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+    EnclaveRpcAuthConfig, sign_rpc_request,
+};
+
+use super::authorize_request;
+
+fn signed_headers(
+    auth: &EnclaveRpcAuthConfig,
+    path: &str,
+    body: &[u8],
+    timestamp: i64,
+    nonce: &str,
+) -> HeaderMap {
+    let signature = sign_rpc_request(&auth.shared_secret, "POST", path, timestamp, nonce, body);
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        ENCLAVE_RPC_CONTRACT_VERSION_HEADER,
+        HeaderValue::from_static(ENCLAVE_RPC_CONTRACT_VERSION),
+    );
+    headers.insert(
+        ENCLAVE_RPC_AUTH_TIMESTAMP_HEADER,
+        HeaderValue::from_str(&timestamp.to_string()).expect("timestamp header should parse"),
+    );
+    headers.insert(
+        ENCLAVE_RPC_AUTH_NONCE_HEADER,
+        HeaderValue::from_str(nonce).expect("nonce header should parse"),
+    );
+    headers.insert(
+        ENCLAVE_RPC_AUTH_SIGNATURE_HEADER,
+        HeaderValue::from_str(signature.as_str()).expect("signature header should parse"),
+    );
+
+    headers
+}
+
+fn default_auth() -> EnclaveRpcAuthConfig {
+    EnclaveRpcAuthConfig {
+        shared_secret: "unit-test-shared-secret-123".to_string(),
+        max_clock_skew_seconds: 30,
+    }
+}
+
+#[test]
+fn authorize_request_allows_valid_signed_request() {
+    let auth = default_auth();
+    let body = br#"{"request_id":"req-1"}"#;
+    let nonce = "rpc-nonce-1";
+    let timestamp = Utc::now().timestamp();
+    let headers = signed_headers(
+        &auth,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+        timestamp,
+        nonce,
+    );
+    let replay_guard = Mutex::new(HashMap::new());
+
+    let result = authorize_request(
+        &auth,
+        &replay_guard,
+        &headers,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+    );
+    assert!(result.is_ok(), "valid RPC auth request should pass");
+}
+
+#[test]
+fn authorize_request_rejects_missing_signature_header() {
+    let auth = default_auth();
+    let body = br#"{"request_id":"req-1"}"#;
+    let nonce = "rpc-nonce-2";
+    let timestamp = Utc::now().timestamp();
+    let mut headers = signed_headers(
+        &auth,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+        timestamp,
+        nonce,
+    );
+    headers.remove(ENCLAVE_RPC_AUTH_SIGNATURE_HEADER);
+    let replay_guard = Mutex::new(HashMap::new());
+
+    let err = authorize_request(
+        &auth,
+        &replay_guard,
+        &headers,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+    )
+    .expect_err("missing auth signature header must fail");
+
+    assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(err.body.error.code, "missing_request_header");
+}
+
+#[test]
+fn authorize_request_rejects_invalid_signature() {
+    let auth = default_auth();
+    let body = br#"{"request_id":"req-1"}"#;
+    let nonce = "rpc-nonce-3";
+    let timestamp = Utc::now().timestamp();
+    let mut headers = signed_headers(
+        &auth,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+        timestamp,
+        nonce,
+    );
+    headers.insert(
+        ENCLAVE_RPC_AUTH_SIGNATURE_HEADER,
+        HeaderValue::from_static("deadbeef"),
+    );
+    let replay_guard = Mutex::new(HashMap::new());
+
+    let err = authorize_request(
+        &auth,
+        &replay_guard,
+        &headers,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+    )
+    .expect_err("signature mismatch must fail");
+
+    assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(err.body.error.code, "invalid_request_signature");
+}
+
+#[test]
+fn authorize_request_rejects_timestamp_outside_skew() {
+    let auth = default_auth();
+    let body = br#"{"request_id":"req-1"}"#;
+    let nonce = "rpc-nonce-4";
+    let timestamp = Utc::now().timestamp() - 120;
+    let headers = signed_headers(
+        &auth,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+        timestamp,
+        nonce,
+    );
+    let replay_guard = Mutex::new(HashMap::new());
+
+    let err = authorize_request(
+        &auth,
+        &replay_guard,
+        &headers,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+    )
+    .expect_err("stale timestamp must fail");
+
+    assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(err.body.error.code, "invalid_request_timestamp");
+}
+
+#[test]
+fn authorize_request_rejects_nonce_replay() {
+    let auth = default_auth();
+    let body = br#"{"request_id":"req-1"}"#;
+    let nonce = "rpc-replay-nonce";
+    let timestamp = Utc::now().timestamp();
+    let headers = signed_headers(
+        &auth,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+        timestamp,
+        nonce,
+    );
+    let replay_guard = Mutex::new(HashMap::new());
+
+    let first = authorize_request(
+        &auth,
+        &replay_guard,
+        &headers,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+    );
+    assert!(first.is_ok(), "first nonce use should pass");
+
+    let err = authorize_request(
+        &auth,
+        &replay_guard,
+        &headers,
+        ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
+        body,
+    )
+    .expect_err("nonce replay should fail");
+
+    assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(err.body.error.code, "request_replay_detected");
+}

--- a/backend/crates/shared/src/config_enclave_runtime.rs
+++ b/backend/crates/shared/src/config_enclave_runtime.rs
@@ -10,10 +10,7 @@ pub(crate) fn parse_alfred_environment() -> Result<AlfredEnvironment, ConfigErro
         .map_err(ConfigError::InvalidConfiguration)
 }
 
-pub(crate) fn parse_enclave_runtime_mode(
-    key: &str,
-    _alfred_environment: AlfredEnvironment,
-) -> Result<EnclaveRuntimeMode, ConfigError> {
+pub(crate) fn parse_enclave_runtime_mode(key: &str) -> Result<EnclaveRuntimeMode, ConfigError> {
     env::var(key)
         .unwrap_or_else(|_| "remote".to_string())
         .parse::<EnclaveRuntimeMode>()
@@ -49,6 +46,81 @@ pub(crate) fn validate_enclave_runtime_guards(
     Ok(())
 }
 
+pub(crate) fn validate_non_local_enclave_security_posture(
+    alfred_environment: AlfredEnvironment,
+    tee_attestation_required: bool,
+    tee_allow_insecure_dev_attestation: bool,
+    tee_allowed_measurements: &[String],
+    kms_allowed_measurements: &[String],
+    enclave_runtime_base_url: &str,
+) -> Result<(), ConfigError> {
+    if matches!(alfred_environment, AlfredEnvironment::Local) {
+        return Ok(());
+    }
+
+    if !tee_attestation_required {
+        return Err(ConfigError::InvalidConfiguration(
+            "TEE_ATTESTATION_REQUIRED must be true outside local environment".to_string(),
+        ));
+    }
+
+    if tee_allow_insecure_dev_attestation {
+        return Err(ConfigError::InvalidConfiguration(
+            "TEE_ALLOW_INSECURE_DEV_ATTESTATION must be false outside local environment"
+                .to_string(),
+        ));
+    }
+
+    validate_measurement_allowlist("TEE_ALLOWED_MEASUREMENTS", tee_allowed_measurements)?;
+    validate_measurement_allowlist("KMS_ALLOWED_MEASUREMENTS", kms_allowed_measurements)?;
+    validate_non_local_runtime_base_url(enclave_runtime_base_url)?;
+
+    Ok(())
+}
+
+fn validate_measurement_allowlist(key: &str, measurements: &[String]) -> Result<(), ConfigError> {
+    if measurements.is_empty() {
+        return Err(ConfigError::InvalidConfiguration(format!(
+            "{key} must contain at least one non-dev measurement outside local environment"
+        )));
+    }
+
+    if measurements
+        .iter()
+        .any(|measurement| measurement == "dev-local-enclave")
+    {
+        return Err(ConfigError::InvalidConfiguration(format!(
+            "{key} must not include dev-local-enclave outside local environment"
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_non_local_runtime_base_url(base_url: &str) -> Result<(), ConfigError> {
+    let parsed = reqwest::Url::parse(base_url).map_err(|_| {
+        ConfigError::InvalidConfiguration(
+            "ENCLAVE_RUNTIME_BASE_URL must be a valid URL".to_string(),
+        )
+    })?;
+    if parsed.scheme() == "https" {
+        return Ok(());
+    }
+
+    if parsed.scheme() == "http"
+        && matches!(
+            parsed.host_str(),
+            Some("127.0.0.1") | Some("localhost") | Some("::1")
+        )
+    {
+        return Ok(());
+    }
+
+    Err(ConfigError::InvalidConfiguration(
+        "ENCLAVE_RUNTIME_BASE_URL must use https outside local environment unless it is loopback http".to_string(),
+    ))
+}
+
 pub(crate) fn parse_enclave_rpc_shared_secret(
     environment: AlfredEnvironment,
 ) -> Result<String, ConfigError> {
@@ -74,4 +146,78 @@ pub(crate) fn parse_enclave_rpc_shared_secret(
     Err(ConfigError::MissingVar(
         "ENCLAVE_RPC_SHARED_SECRET".to_string(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_non_local_enclave_security_posture, validate_non_local_runtime_base_url};
+    use crate::enclave_runtime::AlfredEnvironment;
+
+    fn prod_measurements() -> Vec<String> {
+        vec!["mr-enclave-prod-a".to_string()]
+    }
+
+    #[test]
+    fn non_local_rejects_disabled_attestation() {
+        let err = validate_non_local_enclave_security_posture(
+            AlfredEnvironment::Production,
+            false,
+            false,
+            &prod_measurements(),
+            &prod_measurements(),
+            "https://enclave.internal",
+        )
+        .expect_err("non-local should fail when attestation is disabled");
+
+        assert!(err.to_string().contains("TEE_ATTESTATION_REQUIRED"));
+    }
+
+    #[test]
+    fn non_local_rejects_insecure_dev_attestation() {
+        let err = validate_non_local_enclave_security_posture(
+            AlfredEnvironment::Staging,
+            true,
+            true,
+            &prod_measurements(),
+            &prod_measurements(),
+            "https://enclave.internal",
+        )
+        .expect_err("non-local should fail when insecure attestation mode is enabled");
+
+        assert!(
+            err.to_string()
+                .contains("TEE_ALLOW_INSECURE_DEV_ATTESTATION")
+        );
+    }
+
+    #[test]
+    fn non_local_rejects_dev_measurement_entries() {
+        let err = validate_non_local_enclave_security_posture(
+            AlfredEnvironment::Production,
+            true,
+            false,
+            &["dev-local-enclave".to_string()],
+            &prod_measurements(),
+            "https://enclave.internal",
+        )
+        .expect_err("non-local should reject dev measurements");
+
+        assert!(err.to_string().contains("TEE_ALLOWED_MEASUREMENTS"));
+    }
+
+    #[test]
+    fn non_local_rejects_non_loopback_http_runtime_url() {
+        let err = validate_non_local_runtime_base_url("http://enclave.internal:8181")
+            .expect_err("non-loopback http should fail outside local");
+
+        assert!(err.to_string().contains("ENCLAVE_RUNTIME_BASE_URL"));
+    }
+
+    #[test]
+    fn non_local_accepts_https_or_loopback_http_runtime_url() {
+        validate_non_local_runtime_base_url("https://enclave.internal:8181")
+            .expect("https runtime URL should pass");
+        validate_non_local_runtime_base_url("http://127.0.0.1:8181")
+            .expect("loopback runtime URL should pass");
+    }
 }

--- a/backend/crates/shared/src/config_env.rs
+++ b/backend/crates/shared/src/config_env.rs
@@ -1,0 +1,107 @@
+use std::env;
+use std::net::IpAddr;
+
+use crate::config::ConfigError;
+
+pub(crate) fn require_env(key: &str) -> Result<String, ConfigError> {
+    env::var(key).map_err(|_| ConfigError::MissingVar(key.to_string()))
+}
+
+pub(crate) fn parse_u32_env(key: &str, default: u32) -> Result<u32, ConfigError> {
+    match env::var(key) {
+        Ok(raw) => raw
+            .parse::<u32>()
+            .map_err(|_| ConfigError::ParseInt(key.to_string())),
+        Err(_) => Ok(default),
+    }
+}
+
+pub(crate) fn parse_u64_env(key: &str, default: u64) -> Result<u64, ConfigError> {
+    match env::var(key) {
+        Ok(raw) => raw
+            .parse::<u64>()
+            .map_err(|_| ConfigError::ParseInt(key.to_string())),
+        Err(_) => Ok(default),
+    }
+}
+
+pub(crate) fn parse_i32_env(key: &str, default: i32) -> Result<i32, ConfigError> {
+    match env::var(key) {
+        Ok(raw) => raw
+            .parse::<i32>()
+            .map_err(|_| ConfigError::ParseInt(key.to_string())),
+        Err(_) => Ok(default),
+    }
+}
+
+pub(crate) fn parse_bool_env(key: &str, default: bool) -> Result<bool, ConfigError> {
+    match env::var(key) {
+        Ok(raw) => {
+            let normalized = raw.trim().to_ascii_lowercase();
+            match normalized.as_str() {
+                "true" | "1" | "yes" | "on" => Ok(true),
+                "false" | "0" | "no" | "off" => Ok(false),
+                _ => Err(ConfigError::ParseBool(key.to_string())),
+            }
+        }
+        Err(_) => Ok(default),
+    }
+}
+
+pub(crate) fn parse_ip_list_env(key: &str) -> Result<Vec<IpAddr>, ConfigError> {
+    let Some(raw) = optional_trimmed_env(key) else {
+        return Ok(Vec::new());
+    };
+
+    raw.split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(|item| {
+            item.parse::<IpAddr>().map_err(|_| {
+                ConfigError::InvalidConfiguration(format!(
+                    "{key} contains invalid IP address '{item}'"
+                ))
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn parse_list_env(key: &str, default: &[&str]) -> Vec<String> {
+    match env::var(key) {
+        Ok(raw) => parse_csv_list(raw),
+        Err(_) => default.iter().map(|item| (*item).to_string()).collect(),
+    }
+}
+
+pub(crate) fn parse_list_env_with_fallback(key: &str, fallback: &[String]) -> Vec<String> {
+    match env::var(key) {
+        Ok(raw) => parse_csv_list(raw),
+        Err(_) => fallback.to_vec(),
+    }
+}
+
+pub(crate) fn optional_trimmed_env(key: &str) -> Option<String> {
+    env::var(key).ok().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn parse_csv_list(raw: String) -> Vec<String> {
+    let parsed = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+
+    if parsed.is_empty() {
+        vec!["dev-local-enclave".to_string()]
+    } else {
+        parsed
+    }
+}

--- a/backend/crates/shared/src/lib.rs
+++ b/backend/crates/shared/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 mod config_enclave_runtime;
+mod config_env;
 pub mod enclave;
 pub mod enclave_runtime;
 pub mod llm;


### PR DESCRIPTION
## Summary
- enforce fail-closed non-local TEE posture in shared config and enclave-runtime config
- block insecure non-local combinations (, )
- reject dev measurements () in non-local allowlists
- validate  with strict URL parsing (https required outside local unless loopback http)
- reject inline  outside local for enclave-runtime
- refactor RPC request authorization into a directly testable unit and add replay/auth tests
- extract env parsing helpers to  to keep  modular and below 500 lines
- document new non-local security guards in 

## Validation
- Tools OK: xcodebuild, cargo, swift
- 
- Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project alfred/alfred.xcodeproj -scheme alfred -destination "generic/platform=iOS Simulator" build

Resolve Package Graph

Package: alfredapiclient

Package: clerk-ios

fatalError
- 
running 25 tests
test http::assistant::memory::tests::detect_query_capability_matches_meetings_today_queries ... ok
test http::assistant::memory::tests::detect_query_capability_rejects_unsupported_queries ... ok
test http::assistant::memory::tests::resolve_query_capability_rejects_non_follow_up_without_match ... ok
test http::assistant::memory::tests::session_memory_context_omits_empty_turns ... ok
test http::clerk_jwks_cache::tests::parse_cache_control_max_age_ignores_invalid_values ... ok
test http::assistant::memory::tests::build_updated_memory_keeps_bounded_recent_turns ... ok
test http::clerk_jwks_cache::tests::parse_cache_control_max_age_reads_valid_directive ... ok
test http::clerk_jwks_cache::tests::jwks_contains_key_checks_known_kid ... ok
test http::assistant::memory::tests::resolve_query_capability_uses_prior_for_short_follow_up ... ok
test http::clerk_jwks_cache::tests::resolve_cache_ttl_seconds_clamps_to_safe_range ... ok
test http::observability::tests::normalizes_valid_request_ids ... ok
test http::observability::tests::attaches_request_trace_to_existing_payload ... ok
test http::observability::tests::rejects_invalid_request_ids ... ok
test http::observability::tests::trace_payload_includes_request_id ... ok
test http::oauth_bridge::tests::keeps_expected_google_callback_parameters ... ok
test http::rate_limit::tests::allows_until_limit_then_denies ... ok
test http::rate_limit::tests::different_endpoints_have_independent_limits ... ok
test http::rate_limit::tests::request_subject_prefers_connect_info_over_spoofable_forward_headers ... ok
test http::rate_limit::tests::request_subject_consumes_all_xff_header_values ... ok
test http::rate_limit::tests::stale_buckets_are_pruned ... ok
test http::rate_limit::tests::request_subject_uses_forwarded_chain_when_peer_is_trusted_proxy ... ok
test http::rate_limit::tests::window_resets_after_expiration ... ok
test http::clerk_identity::tests::verify_identity_token_accepts_valid_token ... ok
test http::clerk_identity::tests::verify_identity_token_rejects_expired_token ... ok
test http::clerk_identity::tests::verify_identity_token_rejects_invalid_audience ... ok

test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.39s


running 11 tests
test config::tests::non_local_security_posture_rejects_insecure_attestation_flags ... ok
test config::tests::remote_attestation_document_fails_when_source_missing ... ok
test config::tests::non_local_security_posture_rejects_dev_measurement ... ok
test config::tests::dev_shim_attestation_document_is_generated ... ok
test config::tests::non_local_runtime_base_url_allows_https_or_loopback_http ... ok
test config::tests::challenge_response_is_signed_and_echoes_challenge_fields ... ok
test http::tests::authorize_request_rejects_missing_signature_header ... ok
test http::tests::authorize_request_rejects_nonce_replay ... ok
test http::tests::authorize_request_rejects_timestamp_outside_skew ... ok
test http::tests::authorize_request_rejects_invalid_signature ... ok
test http::tests::authorize_request_allows_valid_signed_request ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 43 tests
test config_enclave_runtime::tests::non_local_accepts_https_or_loopback_http_runtime_url ... ok
test config_enclave_runtime::tests::non_local_rejects_insecure_dev_attestation ... ok
test config_enclave_runtime::tests::non_local_rejects_disabled_attestation ... ok
test config_enclave_runtime::tests::non_local_rejects_non_loopback_http_runtime_url ... ok
test config_enclave_runtime::tests::non_local_rejects_dev_measurement_entries ... ok
test enclave::tests::sensitive_worker_api_paths_do_not_log_secret_token_fields ... ok
test enclave::tests::host_paths_do_not_call_store_decrypt_directly ... ok
test enclave_runtime::tests::parse_alfred_environment_aliases ... ok
test enclave_runtime::tests::parse_enclave_runtime_mode_values ... ok
test llm::reliability::redis_state::tests::fixed_window_start_aligns_timestamp_to_window_boundary ... ok
test llm::reliability::redis_state::tests::retry_after_seconds_is_at_least_one_second ... ok
test llm::reliability::redis_state::tests::usd_to_micros_rounds_to_integer_micro_units ... ok
test llm::safety::tests::sanitize_context_payload_redacts_injection_like_content ... ok
test enclave::tests::rpc_client_rejects_request_id_mismatch_in_exchange_response ... ok
test enclave::tests::rpc_client_rejects_request_id_mismatch_in_revoke_response ... ok
test enclave::tests::rpc_client_maps_transport_auth_rejection ... ok
test enclave::tests::rpc_client_revoke_maps_transport_auth_rejection ... ok
test enclave::tests::rpc_client_rejects_contract_version_drift ... ok
test enclave::tests::rpc_client_maps_provider_failure_error_contract ... ok
test security::tests::validate_key_binding_denies_key_version_mismatch ... ok
test security::tests::validate_key_binding_denies_key_mismatch ... ok
test security::tests::verify_challenge_response_denies_evidence_outside_challenge_window ... ok
test security::tests::verify_challenge_response_denies_expired_challenge ... ok
test security::tests::verify_challenge_response_allows_valid_signed_attestation ... ok
test security::tests::verify_challenge_response_denies_runtime_mismatch ... ok
test security::tests::verify_challenge_response_denies_measurement_mismatch ... ok
test security::tests::verify_challenge_response_denies_nonce_replay ... ok
test security::tests::verify_challenge_response_denies_signature_mismatch ... ok
test timezone::tests::normalize_time_zone_accepts_valid_iana_name ... ok
test timezone::tests::local_day_bounds_convert_local_midnight_to_utc ... ok
test timezone::tests::normalize_time_zone_rejects_invalid_values ... ok
test timezone::tests::user_local_date_uses_default_when_time_zone_is_invalid ... ok
test timezone::tests::user_local_time_converts_from_utc ... ok
test security::tests::verify_challenge_response_denies_stale_evidence_timestamp ... ok
test llm::safety::tests::resolve_safe_output_blocks_unsafe_actionable_urgent_email_output ... ok
test llm::validation::tests::validate_output_value_rejects_schema_mismatch_for_capability ... ok
test llm::safety::tests::resolve_safe_output_keeps_valid_model_output ... ok
test llm::validation::tests::validate_output_value_accepts_valid_meetings_summary_contract ... ok
test llm::validation::tests::validate_output_json_rejects_invalid_output_shape ... ok
test llm::validation::tests::validate_output_value_rejects_contract_version_mismatch ... ok
test llm::safety::tests::resolve_safe_output_rejects_oversized_model_output ... ok
test llm::safety::tests::resolve_safe_output_falls_back_when_output_is_invalid ... ok
test enclave::tests::rpc_client_maps_timeout_to_transport_unavailable ... ok

test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s


running 4 tests
test assembly_handles_empty_and_noisy_inputs_gracefully ... ok
test meetings_today_context_is_deterministic_and_matches_fixture ... ok
test urgent_email_context_matches_fixture_and_excludes_sensitive_source_fields ... ok
test morning_brief_context_matches_fixture ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test returns_cached_response_without_hitting_provider ... ok
test switches_to_budget_gateway_when_budget_threshold_exceeded ... ok
test opens_circuit_breaker_after_consecutive_failures ... ok
test enforces_per_user_rate_limit ... ok
test enforces_global_rate_limit ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test does_not_fallback_on_unauthorized_provider_error ... ok
test uses_primary_model_and_parses_response ... ok
test falls_back_when_primary_returns_invalid_json_payload ... ok
test falls_back_to_secondary_model_after_primary_retries_exhausted ... ok
test retries_transient_failures_before_succeeding ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 16 tests
test job_actions::google::morning_brief::tests::notification_falls_back_when_output_fields_are_empty ... ok
test job_actions::google::morning_brief::tests::notification_body_and_title_are_bounded ... ok
test job_actions::google::urgent_email::tests::notification_falls_back_when_fields_are_empty ... ok
test job_actions::google::morning_brief::tests::notification_uses_structured_morning_brief_content ... ok
test job_actions::google::urgent_email::tests::notification_title_and_body_are_bounded ... ok
test job_actions::google::util::tests::notification_truncation_appends_ellipsis ... ok
test job_actions::helpers::tests::extracts_request_id_from_trace_payload ... ok
test job_actions::google::urgent_email::tests::notification_uses_summary_and_first_action ... ok
test job_actions::helpers::tests::quiet_hours_supports_non_wrapped_ranges ... ok
test job_actions::helpers::tests::quiet_hours_supports_wrapped_ranges ... ok
test job_actions::helpers::tests::quiet_hours_with_equal_bounds_suppresses_all_day ... ok
test job_actions::helpers::tests::rejects_invalid_request_id_from_trace_payload ... ok
test job_actions::helpers::tests::simulated_failures_are_parsed ... ok
test push_sender::tests::classifies_client_errors_as_permanent ... ok
test push_sender::tests::classifies_retryable_http_status_codes_as_transient ... ok
test retry::tests::retry_backoff_is_exponential_and_capped ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
running 25 tests
test http::assistant::memory::tests::detect_query_capability_matches_meetings_today_queries ... ok
test http::assistant::memory::tests::detect_query_capability_rejects_unsupported_queries ... ok
test http::assistant::memory::tests::resolve_query_capability_uses_prior_for_short_follow_up ... ok
test http::assistant::memory::tests::resolve_query_capability_rejects_non_follow_up_without_match ... ok
test http::assistant::memory::tests::session_memory_context_omits_empty_turns ... ok
test http::clerk_jwks_cache::tests::parse_cache_control_max_age_ignores_invalid_values ... ok
test http::clerk_jwks_cache::tests::parse_cache_control_max_age_reads_valid_directive ... ok
test http::assistant::memory::tests::build_updated_memory_keeps_bounded_recent_turns ... ok
test http::clerk_jwks_cache::tests::jwks_contains_key_checks_known_kid ... ok
test http::clerk_jwks_cache::tests::resolve_cache_ttl_seconds_clamps_to_safe_range ... ok
test http::observability::tests::normalizes_valid_request_ids ... ok
test http::observability::tests::attaches_request_trace_to_existing_payload ... ok
test http::observability::tests::rejects_invalid_request_ids ... ok
test http::oauth_bridge::tests::keeps_expected_google_callback_parameters ... ok
test http::observability::tests::trace_payload_includes_request_id ... ok
test http::rate_limit::tests::allows_until_limit_then_denies ... ok
test http::rate_limit::tests::different_endpoints_have_independent_limits ... ok
test http::rate_limit::tests::request_subject_prefers_connect_info_over_spoofable_forward_headers ... ok
test http::rate_limit::tests::request_subject_consumes_all_xff_header_values ... ok
test http::rate_limit::tests::request_subject_uses_forwarded_chain_when_peer_is_trusted_proxy ... ok
test http::rate_limit::tests::stale_buckets_are_pruned ... ok
test http::rate_limit::tests::window_resets_after_expiration ... ok
test http::clerk_identity::tests::verify_identity_token_rejects_expired_token ... ok
test http::clerk_identity::tests::verify_identity_token_rejects_invalid_audience ... ok
test http::clerk_identity::tests::verify_identity_token_accepts_valid_token ... ok

test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.03s


running 11 tests
test config::tests::non_local_security_posture_rejects_dev_measurement ... ok
test config::tests::dev_shim_attestation_document_is_generated ... ok
test config::tests::remote_attestation_document_fails_when_source_missing ... ok
test config::tests::non_local_security_posture_rejects_insecure_attestation_flags ... ok
test config::tests::non_local_runtime_base_url_allows_https_or_loopback_http ... ok
test http::tests::authorize_request_rejects_invalid_signature ... ok
test http::tests::authorize_request_rejects_missing_signature_header ... ok
test http::tests::authorize_request_rejects_timestamp_outside_skew ... ok
test http::tests::authorize_request_allows_valid_signed_request ... ok
test http::tests::authorize_request_rejects_nonce_replay ... ok
test config::tests::challenge_response_is_signed_and_echoes_challenge_fields ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 43 tests
test config_enclave_runtime::tests::non_local_rejects_insecure_dev_attestation ... ok
test config_enclave_runtime::tests::non_local_rejects_dev_measurement_entries ... ok
test config_enclave_runtime::tests::non_local_rejects_disabled_attestation ... ok
test config_enclave_runtime::tests::non_local_rejects_non_loopback_http_runtime_url ... ok
test config_enclave_runtime::tests::non_local_accepts_https_or_loopback_http_runtime_url ... ok
test enclave_runtime::tests::parse_alfred_environment_aliases ... ok
test enclave::tests::host_paths_do_not_call_store_decrypt_directly ... ok
test enclave_runtime::tests::parse_enclave_runtime_mode_values ... ok
test llm::reliability::redis_state::tests::fixed_window_start_aligns_timestamp_to_window_boundary ... ok
test llm::reliability::redis_state::tests::retry_after_seconds_is_at_least_one_second ... ok
test llm::reliability::redis_state::tests::usd_to_micros_rounds_to_integer_micro_units ... ok
test enclave::tests::sensitive_worker_api_paths_do_not_log_secret_token_fields ... ok
test llm::safety::tests::sanitize_context_payload_redacts_injection_like_content ... ok
test enclave::tests::rpc_client_rejects_request_id_mismatch_in_revoke_response ... ok
test enclave::tests::rpc_client_maps_provider_failure_error_contract ... ok
test enclave::tests::rpc_client_rejects_contract_version_drift ... ok
test enclave::tests::rpc_client_rejects_request_id_mismatch_in_exchange_response ... ok
test enclave::tests::rpc_client_revoke_maps_transport_auth_rejection ... ok
test enclave::tests::rpc_client_maps_transport_auth_rejection ... ok
test security::tests::validate_key_binding_denies_key_version_mismatch ... ok
test security::tests::validate_key_binding_denies_key_mismatch ... ok
test security::tests::verify_challenge_response_denies_evidence_outside_challenge_window ... ok
test security::tests::verify_challenge_response_denies_expired_challenge ... ok
test security::tests::verify_challenge_response_allows_valid_signed_attestation ... ok
test security::tests::verify_challenge_response_denies_measurement_mismatch ... ok
test security::tests::verify_challenge_response_denies_runtime_mismatch ... ok
test security::tests::verify_challenge_response_denies_signature_mismatch ... ok
test timezone::tests::local_day_bounds_convert_local_midnight_to_utc ... ok
test timezone::tests::normalize_time_zone_accepts_valid_iana_name ... ok
test security::tests::verify_challenge_response_denies_stale_evidence_timestamp ... ok
test timezone::tests::normalize_time_zone_rejects_invalid_values ... ok
test timezone::tests::user_local_date_uses_default_when_time_zone_is_invalid ... ok
test timezone::tests::user_local_time_converts_from_utc ... ok
test security::tests::verify_challenge_response_denies_nonce_replay ... ok
test llm::safety::tests::resolve_safe_output_blocks_unsafe_actionable_urgent_email_output ... ok
test llm::validation::tests::validate_output_value_rejects_schema_mismatch_for_capability ... ok
test llm::safety::tests::resolve_safe_output_keeps_valid_model_output ... ok
test llm::validation::tests::validate_output_value_rejects_contract_version_mismatch ... ok
test llm::safety::tests::resolve_safe_output_rejects_oversized_model_output ... ok
test llm::validation::tests::validate_output_value_accepts_valid_meetings_summary_contract ... ok
test llm::safety::tests::resolve_safe_output_falls_back_when_output_is_invalid ... ok
test llm::validation::tests::validate_output_json_rejects_invalid_output_shape ... ok
test enclave::tests::rpc_client_maps_timeout_to_transport_unavailable ... ok

test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s


running 4 tests
test assembly_handles_empty_and_noisy_inputs_gracefully ... ok
test meetings_today_context_is_deterministic_and_matches_fixture ... ok
test urgent_email_context_matches_fixture_and_excludes_sensitive_source_fields ... ok
test morning_brief_context_matches_fixture ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test returns_cached_response_without_hitting_provider ... ok
test switches_to_budget_gateway_when_budget_threshold_exceeded ... ok
test opens_circuit_breaker_after_consecutive_failures ... ok
test enforces_global_rate_limit ... ok
test enforces_per_user_rate_limit ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test uses_primary_model_and_parses_response ... ok
test does_not_fallback_on_unauthorized_provider_error ... ok
test falls_back_when_primary_returns_invalid_json_payload ... ok
test falls_back_to_secondary_model_after_primary_retries_exhausted ... ok
test retries_transient_failures_before_succeeding ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 16 tests
test job_actions::google::morning_brief::tests::notification_falls_back_when_output_fields_are_empty ... ok
test job_actions::google::morning_brief::tests::notification_body_and_title_are_bounded ... ok
test job_actions::google::morning_brief::tests::notification_uses_structured_morning_brief_content ... ok
test job_actions::google::urgent_email::tests::notification_falls_back_when_fields_are_empty ... ok
test job_actions::google::urgent_email::tests::notification_title_and_body_are_bounded ... ok
test job_actions::google::util::tests::notification_truncation_appends_ellipsis ... ok
test job_actions::google::urgent_email::tests::notification_uses_summary_and_first_action ... ok
test job_actions::helpers::tests::extracts_request_id_from_trace_payload ... ok
test job_actions::helpers::tests::quiet_hours_supports_non_wrapped_ranges ... ok
test job_actions::helpers::tests::quiet_hours_supports_wrapped_ranges ... ok
test job_actions::helpers::tests::quiet_hours_with_equal_bounds_suppresses_all_day ... ok
test job_actions::helpers::tests::rejects_invalid_request_id_from_trace_payload ... ok
test job_actions::helpers::tests::simulated_failures_are_parsed ... ok
test push_sender::tests::classifies_client_errors_as_permanent ... ok
test push_sender::tests::classifies_retryable_http_status_codes_as_transient ... ok
test retry::tests::retry_backoff_is_exponential_and_capped ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project alfred/alfred.xcodeproj -scheme alfred -destination "generic/platform=iOS Simulator" build

Resolve Package Graph

Package: clerk-ios

Package: alfredapiclient

fatalError (post-change)

## AI Deep Review Report
- Security review: no new findings in this patch; changes add fail-closed guards and coverage for previously untested RPC auth/replay paths.
- Bug check: no logic regressions found in modified paths after full verify + deep review runs.
- Scalability/maintainability: extracted env parsing helpers into a dedicated module and kept touched large files below the 500-line ceiling.
