### PR TITLE
SEC-006: move Google token-backed fetch paths into enclave runtime

### DIFF
--- a/backend/crates/api-server/src/http/assistant/fetch.rs
+++ b/backend/crates/api-server/src/http/assistant/fetch.rs
@@ -1,17 +1,20 @@
 use chrono::{DateTime, NaiveDate, Utc};
-use serde::Deserialize;
+use shared::enclave::{
+    ConnectorSecretRequest, EnclaveGoogleCalendarEvent, EnclaveRpcClient, EnclaveRpcError,
+    ProviderOperation,
+};
 use shared::llm::GoogleCalendarMeetingSource;
 use shared::timezone::local_day_bounds_utc;
 
-use super::super::errors::bad_gateway_response;
+use super::super::errors::{
+    bad_gateway_response, bad_request_response, decrypt_not_authorized_response,
+};
 
-const GOOGLE_CALENDAR_EVENTS_URL: &str =
-    "https://www.googleapis.com/calendar/v3/calendars/primary/events";
 const MAX_CALENDAR_EVENTS: usize = 25;
 
 pub(super) async fn fetch_meetings_for_day(
-    http_client: &reqwest::Client,
-    access_token: &str,
+    enclave_client: &EnclaveRpcClient,
+    connector_request: ConnectorSecretRequest,
     calendar_day: NaiveDate,
     time_zone: &str,
 ) -> Result<Vec<GoogleCalendarMeetingSource>, axum::response::Response> {
@@ -19,96 +22,94 @@ pub(super) async fn fetch_meetings_for_day(
         return Ok(Vec::new());
     };
 
-    let time_min = start_utc.to_rfc3339();
-    let time_max = end_utc.to_rfc3339();
-    let max_results = MAX_CALENDAR_EVENTS.to_string();
-
-    let response = match http_client
-        .get(GOOGLE_CALENDAR_EVENTS_URL)
-        .bearer_auth(access_token)
-        .query(&[
-            ("singleEvents", "true"),
-            ("orderBy", "startTime"),
-            ("timeMin", time_min.as_str()),
-            ("timeMax", time_max.as_str()),
-            ("maxResults", max_results.as_str()),
-        ])
-        .send()
+    let response = enclave_client
+        .fetch_google_calendar_events(
+            connector_request,
+            start_utc.to_rfc3339(),
+            end_utc.to_rfc3339(),
+            MAX_CALENDAR_EVENTS,
+        )
         .await
-    {
-        Ok(response) => response,
-        Err(_) => {
-            return Err(bad_gateway_response(
-                "google_calendar_unavailable",
-                "Unable to reach Google Calendar endpoint",
-            ));
-        }
-    };
+        .map_err(map_calendar_fetch_error)?;
 
-    if !response.status().is_success() {
-        return Err(bad_gateway_response(
-            "google_calendar_failed",
-            "Google Calendar request failed",
-        ));
-    }
-
-    let payload: GoogleCalendarEventsResponse = match response.json().await {
-        Ok(payload) => payload,
-        Err(_) => {
-            return Err(bad_gateway_response(
-                "google_calendar_invalid_response",
-                "Google Calendar response was invalid",
-            ));
-        }
-    };
-
-    Ok(payload
-        .items
+    Ok(response
+        .events
         .into_iter()
-        .map(GoogleCalendarMeetingSource::from)
+        .map(map_calendar_event)
         .collect())
 }
 
-#[derive(Debug, Deserialize)]
-struct GoogleCalendarEventsResponse {
-    #[serde(default)]
-    items: Vec<GoogleCalendarEvent>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GoogleCalendarEvent {
-    id: Option<String>,
-    summary: Option<String>,
-    start: Option<GoogleCalendarEventDateTime>,
-    end: Option<GoogleCalendarEventDateTime>,
-    #[serde(default)]
-    attendees: Vec<GoogleCalendarAttendee>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GoogleCalendarEventDateTime {
-    #[serde(rename = "dateTime")]
-    date_time: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GoogleCalendarAttendee {
-    email: Option<String>,
-}
-
-impl From<GoogleCalendarEvent> for GoogleCalendarMeetingSource {
-    fn from(event: GoogleCalendarEvent) -> Self {
-        Self {
-            event_id: event.id,
-            title: event.summary,
-            start_at: parse_utc_datetime(event.start.and_then(|start| start.date_time)),
-            end_at: parse_utc_datetime(event.end.and_then(|end| end.date_time)),
-            attendee_emails: event
-                .attendees
-                .into_iter()
-                .filter_map(|attendee| attendee.email)
-                .collect(),
+fn map_calendar_fetch_error(err: EnclaveRpcError) -> axum::response::Response {
+    match err {
+        EnclaveRpcError::DecryptNotAuthorized { .. } => decrypt_not_authorized_response(),
+        EnclaveRpcError::ConnectorTokenDecryptFailed { .. } => bad_gateway_response(
+            "connector_token_decrypt_failed",
+            "Connector token decrypt failed",
+        ),
+        EnclaveRpcError::ConnectorTokenUnavailable => bad_request_response(
+            "connector_token_unavailable",
+            "Connector token metadata changed; retry the request",
+        ),
+        EnclaveRpcError::ProviderRequestUnavailable { operation, .. } => match operation {
+            ProviderOperation::TokenRefresh => bad_gateway_response(
+                "google_token_refresh_unavailable",
+                "Unable to reach Google OAuth token endpoint",
+            ),
+            ProviderOperation::CalendarFetch => bad_gateway_response(
+                "google_calendar_unavailable",
+                "Unable to reach Google Calendar endpoint",
+            ),
+            ProviderOperation::TokenRevoke | ProviderOperation::GmailFetch => bad_gateway_response(
+                "google_calendar_unavailable",
+                "Google Calendar is unavailable",
+            ),
+        },
+        EnclaveRpcError::ProviderRequestFailed { operation, .. } => match operation {
+            ProviderOperation::TokenRefresh => bad_gateway_response(
+                "google_token_refresh_failed",
+                "Google OAuth token refresh failed",
+            ),
+            ProviderOperation::CalendarFetch => {
+                bad_gateway_response("google_calendar_failed", "Google Calendar request failed")
+            }
+            ProviderOperation::TokenRevoke | ProviderOperation::GmailFetch => {
+                bad_gateway_response("google_calendar_failed", "Google Calendar request failed")
+            }
+        },
+        EnclaveRpcError::ProviderResponseInvalid { operation, .. } => match operation {
+            ProviderOperation::TokenRefresh => bad_gateway_response(
+                "google_token_refresh_failed",
+                "Google OAuth token refresh failed",
+            ),
+            ProviderOperation::CalendarFetch => bad_gateway_response(
+                "google_calendar_invalid_response",
+                "Google Calendar response was invalid",
+            ),
+            ProviderOperation::TokenRevoke | ProviderOperation::GmailFetch => bad_gateway_response(
+                "google_calendar_invalid_response",
+                "Google Calendar response was invalid",
+            ),
+        },
+        EnclaveRpcError::RpcUnauthorized { .. }
+        | EnclaveRpcError::RpcContractRejected { .. }
+        | EnclaveRpcError::RpcTransportUnavailable { .. }
+        | EnclaveRpcError::RpcResponseInvalid { .. } => {
+            bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
         }
+    }
+}
+
+fn map_calendar_event(event: EnclaveGoogleCalendarEvent) -> GoogleCalendarMeetingSource {
+    GoogleCalendarMeetingSource {
+        event_id: event.id,
+        title: event.summary,
+        start_at: parse_utc_datetime(event.start.and_then(|start| start.date_time)),
+        end_at: parse_utc_datetime(event.end.and_then(|end| end.date_time)),
+        attendee_emails: event
+            .attendees
+            .into_iter()
+            .filter_map(|attendee| attendee.email)
+            .collect(),
     }
 }
 

--- a/backend/crates/api-server/src/http/assistant/session.rs
+++ b/backend/crates/api-server/src/http/assistant/session.rs
@@ -1,16 +1,13 @@
 use axum::response::Response;
-use shared::enclave::{ConnectorSecretRequest, EnclaveRpcClient, EnclaveRpcError};
+use shared::enclave::{ConnectorSecretRequest, EnclaveRpcClient};
 use shared::repos::LEGACY_CONNECTOR_TOKEN_KEY_ID;
 use uuid::Uuid;
 
 use super::super::AppState;
-use super::super::errors::{
-    bad_gateway_response, bad_request_response, decrypt_not_authorized_response,
-    store_error_response,
-};
+use super::super::errors::{bad_request_response, store_error_response};
 
 pub(super) struct GoogleSession {
-    pub(super) access_token: String,
+    pub(super) connector_request: ConnectorSecretRequest,
 }
 
 pub(super) async fn build_google_session(
@@ -18,21 +15,12 @@ pub(super) async fn build_google_session(
     user_id: Uuid,
 ) -> Result<GoogleSession, Response> {
     let active_connector = load_active_google_connector(state, user_id).await?;
-    let enclave_client = build_enclave_client(state);
-
-    let token_response = match enclave_client
-        .exchange_google_access_token(ConnectorSecretRequest {
-            user_id,
-            connector_id: active_connector.connector_id,
-        })
-        .await
-    {
-        Ok(token_response) => token_response,
-        Err(err) => return Err(map_token_exchange_error(err)),
-    };
 
     Ok(GoogleSession {
-        access_token: token_response.access_token,
+        connector_request: ConnectorSecretRequest {
+            user_id,
+            connector_id: active_connector.connector_id,
+        },
     })
 }
 
@@ -96,39 +84,10 @@ async fn load_active_google_connector(
     })
 }
 
-fn build_enclave_client(state: &AppState) -> EnclaveRpcClient {
+pub(super) fn build_enclave_client(state: &AppState) -> EnclaveRpcClient {
     EnclaveRpcClient::new(
         state.enclave_rpc.base_url.clone(),
         state.enclave_rpc.auth.clone(),
         state.http_client.clone(),
     )
-}
-
-fn map_token_exchange_error(err: EnclaveRpcError) -> Response {
-    match err {
-        EnclaveRpcError::DecryptNotAuthorized { .. } => decrypt_not_authorized_response(),
-        EnclaveRpcError::ConnectorTokenDecryptFailed { .. } => bad_gateway_response(
-            "connector_token_decrypt_failed",
-            "Connector token decrypt failed",
-        ),
-        EnclaveRpcError::ConnectorTokenUnavailable => bad_request_response(
-            "connector_token_unavailable",
-            "Connector token metadata changed; retry the request",
-        ),
-        EnclaveRpcError::ProviderRequestUnavailable { .. } => bad_gateway_response(
-            "google_token_refresh_unavailable",
-            "Unable to reach Google OAuth token endpoint",
-        ),
-        EnclaveRpcError::ProviderRequestFailed { .. }
-        | EnclaveRpcError::ProviderResponseInvalid { .. } => bad_gateway_response(
-            "google_token_refresh_failed",
-            "Google OAuth token refresh failed",
-        ),
-        EnclaveRpcError::RpcUnauthorized { .. }
-        | EnclaveRpcError::RpcContractRejected { .. }
-        | EnclaveRpcError::RpcTransportUnavailable { .. }
-        | EnclaveRpcError::RpcResponseInvalid { .. } => {
-            bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
-        }
-    }
 }

--- a/backend/crates/enclave-runtime/src/http/rpc.rs
+++ b/backend/crates/enclave-runtime/src/http/rpc.rs
@@ -1,0 +1,272 @@
+use axum::Json;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use chrono::Utc;
+use shared::enclave::{
+    ENCLAVE_RPC_AUTH_NONCE_HEADER, ENCLAVE_RPC_AUTH_SIGNATURE_HEADER,
+    ENCLAVE_RPC_AUTH_TIMESTAMP_HEADER, ENCLAVE_RPC_CONTRACT_VERSION,
+    ENCLAVE_RPC_CONTRACT_VERSION_HEADER, EnclaveRpcError, EnclaveRpcErrorEnvelope,
+    sign_rpc_request,
+};
+
+pub(super) struct RpcRejection {
+    pub(super) status: StatusCode,
+    pub(super) body: EnclaveRpcErrorEnvelope,
+}
+
+impl RpcRejection {
+    pub(super) fn into_response(self) -> Response {
+        error_response(self.status, self.body)
+    }
+}
+
+pub(super) type RpcResult<T> = Result<T, Box<RpcRejection>>;
+
+pub(super) fn reject(status: StatusCode, body: EnclaveRpcErrorEnvelope) -> Box<RpcRejection> {
+    Box::new(RpcRejection { status, body })
+}
+
+pub(super) fn authorize_request(
+    auth: &shared::enclave::EnclaveRpcAuthConfig,
+    replay_guard: &std::sync::Mutex<std::collections::HashMap<String, i64>>,
+    headers: &HeaderMap,
+    path: &str,
+    body: &[u8],
+) -> RpcResult<()> {
+    let contract_header = require_header(headers, ENCLAVE_RPC_CONTRACT_VERSION_HEADER)?;
+    if contract_header != ENCLAVE_RPC_CONTRACT_VERSION {
+        return Err(reject(
+            StatusCode::BAD_REQUEST,
+            EnclaveRpcErrorEnvelope::new(
+                None,
+                "invalid_contract_version",
+                "Unsupported enclave RPC contract version",
+                false,
+            ),
+        ));
+    }
+
+    let timestamp = require_header(headers, ENCLAVE_RPC_AUTH_TIMESTAMP_HEADER).and_then(|raw| {
+        raw.parse::<i64>().map_err(|_| {
+            reject(
+                StatusCode::UNAUTHORIZED,
+                EnclaveRpcErrorEnvelope::new(
+                    None,
+                    "invalid_request_header",
+                    "Invalid request timestamp header",
+                    false,
+                ),
+            )
+        })
+    })?;
+
+    let nonce = require_header(headers, ENCLAVE_RPC_AUTH_NONCE_HEADER)?;
+    if nonce.trim().is_empty() {
+        return Err(reject(
+            StatusCode::UNAUTHORIZED,
+            EnclaveRpcErrorEnvelope::new(
+                None,
+                "invalid_request_header",
+                "Nonce header must not be empty",
+                false,
+            ),
+        ));
+    }
+
+    let signature = require_header(headers, ENCLAVE_RPC_AUTH_SIGNATURE_HEADER)?;
+    let now = Utc::now().timestamp();
+    let max_skew = auth.max_clock_skew_seconds as i64;
+    if (now - timestamp).abs() > max_skew {
+        return Err(reject(
+            StatusCode::UNAUTHORIZED,
+            EnclaveRpcErrorEnvelope::new(
+                None,
+                "invalid_request_timestamp",
+                "Request timestamp outside allowed skew",
+                false,
+            ),
+        ));
+    }
+
+    let expected_signature =
+        sign_rpc_request(&auth.shared_secret, "POST", path, timestamp, &nonce, body);
+    if !shared::enclave::constant_time_eq(&expected_signature, &signature) {
+        return Err(reject(
+            StatusCode::UNAUTHORIZED,
+            EnclaveRpcErrorEnvelope::new(
+                None,
+                "invalid_request_signature",
+                "Request signature mismatch",
+                false,
+            ),
+        ));
+    }
+
+    let replay_window_expires = timestamp.checked_add(max_skew).ok_or_else(|| {
+        reject(
+            StatusCode::UNAUTHORIZED,
+            EnclaveRpcErrorEnvelope::new(
+                None,
+                "invalid_request_timestamp",
+                "Request timestamp is invalid",
+                false,
+            ),
+        )
+    })?;
+
+    let mut replay_guard = replay_guard.lock().map_err(|_| {
+        reject(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            EnclaveRpcErrorEnvelope::new(
+                None,
+                "rpc_internal_error",
+                "Replay guard unavailable",
+                true,
+            ),
+        )
+    })?;
+    replay_guard.retain(|_, expires_at| *expires_at >= now);
+
+    if replay_guard
+        .insert(nonce.to_string(), replay_window_expires)
+        .is_some()
+    {
+        return Err(reject(
+            StatusCode::UNAUTHORIZED,
+            EnclaveRpcErrorEnvelope::new(
+                None,
+                "request_replay_detected",
+                "Replay detected for RPC nonce",
+                false,
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+fn require_header(headers: &HeaderMap, key: &str) -> RpcResult<String> {
+    headers
+        .get(key)
+        .ok_or_else(|| {
+            reject(
+                StatusCode::UNAUTHORIZED,
+                EnclaveRpcErrorEnvelope::new(
+                    None,
+                    "missing_request_header",
+                    format!("Missing required header {key}"),
+                    false,
+                ),
+            )
+        })
+        .and_then(|value| {
+            value.to_str().map(ToString::to_string).map_err(|_| {
+                reject(
+                    StatusCode::UNAUTHORIZED,
+                    EnclaveRpcErrorEnvelope::new(
+                        None,
+                        "invalid_request_header",
+                        format!("Invalid header value for {key}"),
+                        false,
+                    ),
+                )
+            })
+        })
+}
+
+pub(super) fn map_rpc_service_error(
+    err: EnclaveRpcError,
+    request_id: Option<String>,
+) -> (StatusCode, Json<EnclaveRpcErrorEnvelope>) {
+    match err {
+        EnclaveRpcError::DecryptNotAuthorized { .. } => (
+            StatusCode::FORBIDDEN,
+            Json(EnclaveRpcErrorEnvelope::new(
+                request_id,
+                "decrypt_not_authorized",
+                "Connector decrypt denied by policy",
+                false,
+            )),
+        ),
+        EnclaveRpcError::ConnectorTokenDecryptFailed { .. } => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(EnclaveRpcErrorEnvelope::new(
+                request_id,
+                "connector_token_decrypt_failed",
+                "Connector token decrypt failed",
+                true,
+            )),
+        ),
+        EnclaveRpcError::ConnectorTokenUnavailable => (
+            StatusCode::BAD_REQUEST,
+            Json(EnclaveRpcErrorEnvelope::new(
+                request_id,
+                "connector_token_unavailable",
+                "Connector token metadata changed; retry request",
+                false,
+            )),
+        ),
+        EnclaveRpcError::ProviderRequestUnavailable { .. } => (
+            StatusCode::BAD_GATEWAY,
+            Json(EnclaveRpcErrorEnvelope::new(
+                request_id,
+                "provider_unavailable",
+                "Provider endpoint unavailable",
+                true,
+            )),
+        ),
+        EnclaveRpcError::ProviderRequestFailed {
+            status,
+            oauth_error,
+            ..
+        } => (
+            StatusCode::BAD_GATEWAY,
+            Json(EnclaveRpcErrorEnvelope::with_provider_failure(
+                request_id,
+                status,
+                oauth_error,
+            )),
+        ),
+        EnclaveRpcError::ProviderResponseInvalid { .. } => (
+            StatusCode::BAD_GATEWAY,
+            Json(EnclaveRpcErrorEnvelope::new(
+                request_id,
+                "provider_response_invalid",
+                "Provider response invalid",
+                true,
+            )),
+        ),
+        EnclaveRpcError::RpcUnauthorized { code } => (
+            StatusCode::UNAUTHORIZED,
+            Json(EnclaveRpcErrorEnvelope::new(
+                request_id,
+                code,
+                "RPC request unauthorized",
+                false,
+            )),
+        ),
+        EnclaveRpcError::RpcContractRejected { code } => (
+            StatusCode::BAD_REQUEST,
+            Json(EnclaveRpcErrorEnvelope::new(
+                request_id,
+                code,
+                "RPC request rejected by contract validation",
+                false,
+            )),
+        ),
+        EnclaveRpcError::RpcTransportUnavailable { .. }
+        | EnclaveRpcError::RpcResponseInvalid { .. } => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(EnclaveRpcErrorEnvelope::new(
+                request_id,
+                "rpc_internal_error",
+                "RPC internal processing failed",
+                true,
+            )),
+        ),
+    }
+}
+
+pub(super) fn error_response(status: StatusCode, body: EnclaveRpcErrorEnvelope) -> Response {
+    (status, Json(body)).into_response()
+}

--- a/backend/crates/enclave-runtime/src/http/tests.rs
+++ b/backend/crates/enclave-runtime/src/http/tests.rs
@@ -10,7 +10,7 @@ use shared::enclave::{
     EnclaveRpcAuthConfig, sign_rpc_request,
 };
 
-use super::authorize_request;
+use super::rpc::authorize_request;
 
 fn signed_headers(
     auth: &EnclaveRpcAuthConfig,

--- a/backend/crates/enclave-runtime/src/main.rs
+++ b/backend/crates/enclave-runtime/src/main.rs
@@ -112,6 +112,14 @@ async fn main() {
             "/v1/rpc/google/token/revoke",
             post(http::revoke_google_connector_token),
         )
+        .route(
+            "/v1/rpc/google/calendar/events",
+            post(http::fetch_google_calendar_events),
+        )
+        .route(
+            "/v1/rpc/google/gmail/urgent-candidates",
+            post(http::fetch_google_urgent_email_candidates),
+        )
         .with_state(RuntimeState {
             config: config.clone(),
             enclave_service,

--- a/backend/crates/shared/src/enclave/contract.rs
+++ b/backend/crates/shared/src/enclave/contract.rs
@@ -3,6 +3,9 @@ use serde::{Deserialize, Serialize};
 pub const ENCLAVE_RPC_CONTRACT_VERSION: &str = "v1";
 pub const ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN: &str = "/v1/rpc/google/token/exchange";
 pub const ENCLAVE_RPC_PATH_REVOKE_GOOGLE_TOKEN: &str = "/v1/rpc/google/token/revoke";
+pub const ENCLAVE_RPC_PATH_FETCH_GOOGLE_CALENDAR_EVENTS: &str = "/v1/rpc/google/calendar/events";
+pub const ENCLAVE_RPC_PATH_FETCH_GOOGLE_URGENT_EMAIL_CANDIDATES: &str =
+    "/v1/rpc/google/gmail/urgent-candidates";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AttestedIdentityPayload {
@@ -37,6 +40,73 @@ pub struct EnclaveRpcRevokeGoogleTokenResponse {
     pub contract_version: String,
     pub request_id: String,
     pub attested_identity: AttestedIdentityPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveRpcFetchGoogleCalendarEventsRequest {
+    pub contract_version: String,
+    pub request_id: String,
+    pub connector: super::ConnectorSecretRequest,
+    pub time_min: String,
+    pub time_max: String,
+    pub max_results: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveRpcFetchGoogleCalendarEventsResponse {
+    pub contract_version: String,
+    pub request_id: String,
+    pub events: Vec<EnclaveGoogleCalendarEvent>,
+    pub attested_identity: AttestedIdentityPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveGoogleCalendarEvent {
+    pub id: Option<String>,
+    pub summary: Option<String>,
+    pub start: Option<EnclaveGoogleCalendarEventDateTime>,
+    pub end: Option<EnclaveGoogleCalendarEventDateTime>,
+    #[serde(default)]
+    pub attendees: Vec<EnclaveGoogleCalendarAttendee>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveGoogleCalendarEventDateTime {
+    #[serde(rename = "dateTime")]
+    pub date_time: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveGoogleCalendarAttendee {
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveRpcFetchGoogleUrgentEmailCandidatesRequest {
+    pub contract_version: String,
+    pub request_id: String,
+    pub connector: super::ConnectorSecretRequest,
+    pub max_results: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveRpcFetchGoogleUrgentEmailCandidatesResponse {
+    pub contract_version: String,
+    pub request_id: String,
+    pub candidates: Vec<EnclaveGoogleEmailCandidate>,
+    pub attested_identity: AttestedIdentityPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveGoogleEmailCandidate {
+    pub message_id: Option<String>,
+    pub from: Option<String>,
+    pub subject: Option<String>,
+    pub snippet: Option<String>,
+    pub received_at: Option<String>,
+    #[serde(default)]
+    pub label_ids: Vec<String>,
+    pub has_attachments: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/crates/shared/src/enclave/mod.rs
+++ b/backend/crates/shared/src/enclave/mod.rs
@@ -14,9 +14,15 @@ use uuid::Uuid;
 pub use client::EnclaveRpcClient;
 pub use contract::{
     AttestedIdentityPayload, ENCLAVE_RPC_CONTRACT_VERSION, ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
-    ENCLAVE_RPC_PATH_REVOKE_GOOGLE_TOKEN, EnclaveRpcErrorEnvelope, EnclaveRpcErrorPayload,
+    ENCLAVE_RPC_PATH_FETCH_GOOGLE_CALENDAR_EVENTS,
+    ENCLAVE_RPC_PATH_FETCH_GOOGLE_URGENT_EMAIL_CANDIDATES, ENCLAVE_RPC_PATH_REVOKE_GOOGLE_TOKEN,
+    EnclaveGoogleCalendarAttendee, EnclaveGoogleCalendarEvent, EnclaveGoogleCalendarEventDateTime,
+    EnclaveGoogleEmailCandidate, EnclaveRpcErrorEnvelope, EnclaveRpcErrorPayload,
     EnclaveRpcExchangeGoogleTokenRequest, EnclaveRpcExchangeGoogleTokenResponse,
-    EnclaveRpcRevokeGoogleTokenRequest, EnclaveRpcRevokeGoogleTokenResponse,
+    EnclaveRpcFetchGoogleCalendarEventsRequest, EnclaveRpcFetchGoogleCalendarEventsResponse,
+    EnclaveRpcFetchGoogleUrgentEmailCandidatesRequest,
+    EnclaveRpcFetchGoogleUrgentEmailCandidatesResponse, EnclaveRpcRevokeGoogleTokenRequest,
+    EnclaveRpcRevokeGoogleTokenResponse,
 };
 pub use service::EnclaveOperationService;
 pub use transport_auth::{
@@ -50,10 +56,24 @@ pub struct RevokeGoogleTokenResponse {
     pub attested_identity: AttestedIdentityPayload,
 }
 
+#[derive(Debug, Clone)]
+pub struct FetchGoogleCalendarEventsResponse {
+    pub events: Vec<EnclaveGoogleCalendarEvent>,
+    pub attested_identity: AttestedIdentityPayload,
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchGoogleUrgentEmailCandidatesResponse {
+    pub candidates: Vec<EnclaveGoogleEmailCandidate>,
+    pub attested_identity: AttestedIdentityPayload,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderOperation {
     TokenRefresh,
     TokenRevoke,
+    CalendarFetch,
+    GmailFetch,
 }
 
 impl fmt::Display for ProviderOperation {
@@ -61,6 +81,8 @@ impl fmt::Display for ProviderOperation {
         match self {
             Self::TokenRefresh => write!(f, "token_refresh"),
             Self::TokenRevoke => write!(f, "token_revoke"),
+            Self::CalendarFetch => write!(f, "calendar_fetch"),
+            Self::GmailFetch => write!(f, "gmail_fetch"),
         }
     }
 }

--- a/backend/crates/shared/src/enclave/service.rs
+++ b/backend/crates/shared/src/enclave/service.rs
@@ -1,13 +1,23 @@
-use reqwest::StatusCode;
+use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
+use reqwest::{RequestBuilder, StatusCode};
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
 use crate::repos::{ConnectorKeyMetadata as PersistedConnectorKeyMetadata, Store};
 use crate::security::{ConnectorKeyMetadata as AuthorizedConnectorKeyMetadata, SecretRuntime};
 
 use super::{
-    AttestedIdentityPayload, ConnectorSecretRequest, EnclaveRpcError, ExchangeGoogleTokenResponse,
-    GoogleEnclaveOauthConfig, ProviderOperation, RevokeGoogleTokenResponse,
+    AttestedIdentityPayload, ConnectorSecretRequest, EnclaveGoogleCalendarAttendee,
+    EnclaveGoogleCalendarEvent, EnclaveGoogleCalendarEventDateTime, EnclaveGoogleEmailCandidate,
+    EnclaveRpcError, ExchangeGoogleTokenResponse, FetchGoogleCalendarEventsResponse,
+    FetchGoogleUrgentEmailCandidatesResponse, GoogleEnclaveOauthConfig, ProviderOperation,
+    RevokeGoogleTokenResponse,
 };
+
+const GOOGLE_CALENDAR_EVENTS_URL: &str =
+    "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+const GMAIL_MESSAGES_URL: &str = "https://gmail.googleapis.com/gmail/v1/users/me/messages";
+const MAX_GMAIL_CANDIDATES: usize = 50;
 
 #[derive(Clone)]
 pub struct EnclaveOperationService {
@@ -38,44 +48,10 @@ impl EnclaveOperationService {
     ) -> Result<ExchangeGoogleTokenResponse, EnclaveRpcError> {
         let (refresh_token, attested_identity) =
             self.load_authorized_refresh_token(&request).await?;
-
-        let response = self
-            .http_client
-            .post(&self.oauth.token_url)
-            .form(&[
-                ("grant_type", "refresh_token"),
-                ("client_id", self.oauth.client_id.as_str()),
-                ("client_secret", self.oauth.client_secret.as_str()),
-                ("refresh_token", refresh_token.as_str()),
-            ])
-            .send()
-            .await
-            .map_err(|err| EnclaveRpcError::ProviderRequestUnavailable {
-                operation: ProviderOperation::TokenRefresh,
-                message: err.to_string(),
-            })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            let oauth_error = parse_google_oauth_error(&body).and_then(|parsed| parsed.error);
-            return Err(EnclaveRpcError::ProviderRequestFailed {
-                operation: ProviderOperation::TokenRefresh,
-                status: status.as_u16(),
-                oauth_error,
-            });
-        }
-
-        let payload = response
-            .json::<GoogleRefreshTokenResponse>()
-            .await
-            .map_err(|err| EnclaveRpcError::ProviderResponseInvalid {
-                operation: ProviderOperation::TokenRefresh,
-                message: err.to_string(),
-            })?;
+        let access_token = self.exchange_access_token(&refresh_token).await?;
 
         Ok(ExchangeGoogleTokenResponse {
-            access_token: payload.access_token,
+            access_token,
             attested_identity,
         })
     }
@@ -106,18 +82,195 @@ impl EnclaveOperationService {
         let body = response.text().await.unwrap_or_default();
 
         if status == StatusCode::BAD_REQUEST
-            && let Some(error) = parse_google_oauth_error(&body).and_then(|parsed| parsed.error)
+            && let Some(error) = parse_google_error_code(&body)
             && error == "invalid_token"
         {
             return Ok(RevokeGoogleTokenResponse { attested_identity });
         }
 
-        let oauth_error = parse_google_oauth_error(&body).and_then(|parsed| parsed.error);
         Err(EnclaveRpcError::ProviderRequestFailed {
             operation: ProviderOperation::TokenRevoke,
             status: status.as_u16(),
-            oauth_error,
+            oauth_error: parse_google_error_code(&body),
         })
+    }
+
+    pub async fn fetch_google_calendar_events(
+        &self,
+        request: ConnectorSecretRequest,
+        time_min: String,
+        time_max: String,
+        max_results: usize,
+    ) -> Result<FetchGoogleCalendarEventsResponse, EnclaveRpcError> {
+        let (refresh_token, attested_identity) =
+            self.load_authorized_refresh_token(&request).await?;
+        let access_token = self.exchange_access_token(&refresh_token).await?;
+        let max_results = max_results.to_string();
+
+        let payload: GoogleCalendarEventsResponse = self
+            .send_google_json_request(
+                self.http_client
+                    .get(GOOGLE_CALENDAR_EVENTS_URL)
+                    .bearer_auth(access_token)
+                    .query(&[
+                        ("singleEvents", "true"),
+                        ("orderBy", "startTime"),
+                        ("timeMin", time_min.as_str()),
+                        ("timeMax", time_max.as_str()),
+                        ("maxResults", max_results.as_str()),
+                    ]),
+                ProviderOperation::CalendarFetch,
+            )
+            .await?;
+
+        let events = payload
+            .items
+            .into_iter()
+            .map(|event| EnclaveGoogleCalendarEvent {
+                id: event.id,
+                summary: event.summary,
+                start: event.start.map(|start| EnclaveGoogleCalendarEventDateTime {
+                    date_time: start.date_time,
+                }),
+                end: event.end.map(|end| EnclaveGoogleCalendarEventDateTime {
+                    date_time: end.date_time,
+                }),
+                attendees: event
+                    .attendees
+                    .into_iter()
+                    .map(|attendee| EnclaveGoogleCalendarAttendee {
+                        email: attendee.email,
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        Ok(FetchGoogleCalendarEventsResponse {
+            events,
+            attested_identity,
+        })
+    }
+
+    pub async fn fetch_google_urgent_email_candidates(
+        &self,
+        request: ConnectorSecretRequest,
+        max_results: usize,
+    ) -> Result<FetchGoogleUrgentEmailCandidatesResponse, EnclaveRpcError> {
+        let (refresh_token, attested_identity) =
+            self.load_authorized_refresh_token(&request).await?;
+        let access_token = self.exchange_access_token(&refresh_token).await?;
+        let max_results = max_results.clamp(1, MAX_GMAIL_CANDIDATES).to_string();
+
+        let payload: GmailMessagesResponse = self
+            .send_google_json_request(
+                self.http_client
+                    .get(GMAIL_MESSAGES_URL)
+                    .bearer_auth(&access_token)
+                    .query(&[
+                        ("labelIds", "INBOX"),
+                        ("q", "newer_than:2d"),
+                        ("maxResults", max_results.as_str()),
+                    ]),
+                ProviderOperation::GmailFetch,
+            )
+            .await?;
+
+        let mut candidates = Vec::with_capacity(payload.messages.len());
+        for message in payload.messages {
+            let details: GmailMessageMetadataResponse = self
+                .send_google_json_request(
+                    self.http_client
+                        .get(format!("{GMAIL_MESSAGES_URL}/{}", message.id))
+                        .bearer_auth(&access_token)
+                        .query(&[
+                            ("format", "metadata"),
+                            ("metadataHeaders", "From"),
+                            ("metadataHeaders", "Subject"),
+                        ]),
+                    ProviderOperation::GmailFetch,
+                )
+                .await?;
+            candidates.push(details.into_candidate());
+        }
+
+        Ok(FetchGoogleUrgentEmailCandidatesResponse {
+            candidates,
+            attested_identity,
+        })
+    }
+
+    async fn exchange_access_token(&self, refresh_token: &str) -> Result<String, EnclaveRpcError> {
+        let response = self
+            .http_client
+            .post(&self.oauth.token_url)
+            .form(&[
+                ("grant_type", "refresh_token"),
+                ("client_id", self.oauth.client_id.as_str()),
+                ("client_secret", self.oauth.client_secret.as_str()),
+                ("refresh_token", refresh_token),
+            ])
+            .send()
+            .await
+            .map_err(|err| EnclaveRpcError::ProviderRequestUnavailable {
+                operation: ProviderOperation::TokenRefresh,
+                message: err.to_string(),
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(EnclaveRpcError::ProviderRequestFailed {
+                operation: ProviderOperation::TokenRefresh,
+                status: status.as_u16(),
+                oauth_error: parse_google_error_code(&body),
+            });
+        }
+
+        let payload = response
+            .json::<GoogleRefreshTokenResponse>()
+            .await
+            .map_err(|err| EnclaveRpcError::ProviderResponseInvalid {
+                operation: ProviderOperation::TokenRefresh,
+                message: err.to_string(),
+            })?;
+
+        Ok(payload.access_token)
+    }
+
+    async fn send_google_json_request<T>(
+        &self,
+        request: RequestBuilder,
+        operation: ProviderOperation,
+    ) -> Result<T, EnclaveRpcError>
+    where
+        T: DeserializeOwned,
+    {
+        let response =
+            request
+                .send()
+                .await
+                .map_err(|err| EnclaveRpcError::ProviderRequestUnavailable {
+                    operation,
+                    message: err.to_string(),
+                })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(EnclaveRpcError::ProviderRequestFailed {
+                operation,
+                status: status.as_u16(),
+                oauth_error: parse_google_error_code(&body),
+            });
+        }
+
+        response
+            .json::<T>()
+            .await
+            .map_err(|err| EnclaveRpcError::ProviderResponseInvalid {
+                operation,
+                message: err.to_string(),
+            })
     }
 
     async fn load_authorized_refresh_token(
@@ -177,10 +330,171 @@ struct GoogleRefreshTokenResponse {
 }
 
 #[derive(Debug, Deserialize)]
+struct GoogleCalendarEventsResponse {
+    #[serde(default)]
+    items: Vec<GoogleCalendarEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleCalendarEvent {
+    id: Option<String>,
+    summary: Option<String>,
+    start: Option<GoogleCalendarEventDateTime>,
+    end: Option<GoogleCalendarEventDateTime>,
+    #[serde(default)]
+    attendees: Vec<GoogleCalendarAttendee>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleCalendarEventDateTime {
+    #[serde(rename = "dateTime")]
+    date_time: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleCalendarAttendee {
+    email: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessagesResponse {
+    #[serde(default)]
+    messages: Vec<GmailMessageListEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessageListEntry {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessageMetadataResponse {
+    id: String,
+    snippet: Option<String>,
+    #[serde(rename = "internalDate")]
+    internal_date: Option<String>,
+    #[serde(default, rename = "labelIds")]
+    label_ids: Vec<String>,
+    payload: Option<GmailMessagePayload>,
+}
+
+impl GmailMessageMetadataResponse {
+    fn into_candidate(self) -> EnclaveGoogleEmailCandidate {
+        let has_attachments = self.payload.as_ref().is_some_and(payload_has_attachments);
+        let from = self
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.header_value("From"));
+        let subject = self
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.header_value("Subject"));
+
+        EnclaveGoogleEmailCandidate {
+            message_id: Some(self.id),
+            from,
+            subject,
+            snippet: self.snippet,
+            received_at: self
+                .internal_date
+                .as_deref()
+                .and_then(parse_internal_date_millis)
+                .map(|value| value.to_rfc3339_opts(SecondsFormat::Secs, true)),
+            label_ids: self.label_ids,
+            has_attachments,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessagePayload {
+    #[serde(default)]
+    headers: Vec<GmailMessageHeader>,
+    #[serde(default)]
+    parts: Vec<GmailMessagePayload>,
+    #[serde(default)]
+    filename: String,
+    body: Option<GmailMessageBody>,
+}
+
+impl GmailMessagePayload {
+    fn header_value(&self, target_name: &str) -> Option<String> {
+        self.headers
+            .iter()
+            .find(|header| header.name.eq_ignore_ascii_case(target_name))
+            .map(|header| header.value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessageHeader {
+    name: String,
+    value: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GmailMessageBody {
+    #[serde(rename = "attachmentId")]
+    attachment_id: Option<String>,
+}
+
+fn payload_has_attachments(payload: &GmailMessagePayload) -> bool {
+    let has_attachment_id = payload
+        .body
+        .as_ref()
+        .and_then(|body| body.attachment_id.as_ref())
+        .is_some();
+    if has_attachment_id || !payload.filename.trim().is_empty() {
+        return true;
+    }
+
+    payload.parts.iter().any(payload_has_attachments)
+}
+
+fn parse_internal_date_millis(raw: &str) -> Option<DateTime<Utc>> {
+    let millis = raw.parse::<i64>().ok()?;
+    Utc.timestamp_millis_opt(millis).single()
+}
+
+#[derive(Debug, Deserialize)]
 struct GoogleOAuthErrorResponse {
     error: Option<String>,
 }
 
-fn parse_google_oauth_error(body: &str) -> Option<GoogleOAuthErrorResponse> {
-    serde_json::from_str::<GoogleOAuthErrorResponse>(body).ok()
+#[derive(Debug, Deserialize)]
+struct GoogleApiErrorEnvelope {
+    error: Option<GoogleApiErrorBody>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleApiErrorBody {
+    status: Option<String>,
+    message: Option<String>,
+}
+
+fn parse_google_error_code(body: &str) -> Option<String> {
+    if let Ok(parsed) = serde_json::from_str::<GoogleOAuthErrorResponse>(body)
+        && let Some(error) = parsed.error
+        && !error.trim().is_empty()
+    {
+        return Some(error);
+    }
+
+    if let Ok(parsed) = serde_json::from_str::<GoogleApiErrorEnvelope>(body)
+        && let Some(error) = parsed.error
+    {
+        if let Some(status) = error.status
+            && !status.trim().is_empty()
+        {
+            return Some(status);
+        }
+        if let Some(message) = error.message
+            && !message.trim().is_empty()
+        {
+            return Some(message);
+        }
+    }
+
+    None
 }

--- a/backend/crates/shared/src/enclave/tests/boundary_guards.rs
+++ b/backend/crates/shared/src/enclave/tests/boundary_guards.rs
@@ -1,0 +1,95 @@
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn sensitive_worker_api_paths_do_not_log_secret_token_fields() {
+    let shared_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let files = [
+        shared_root.join("../api-server/src/http/assistant/session.rs"),
+        shared_root.join("../api-server/src/http/connectors.rs"),
+        shared_root.join("../api-server/src/http/connectors/revoke.rs"),
+        shared_root.join("../worker/src/job_actions/google/session.rs"),
+        shared_root.join("../worker/src/privacy_delete_revoke.rs"),
+    ];
+
+    for file in files {
+        let content = fs::read_to_string(&file)
+            .expect("failed to read source file for secret logging guard test");
+        assert_no_sensitive_tracing_args(file.display().to_string().as_str(), &content);
+    }
+}
+
+#[test]
+fn host_paths_do_not_call_store_decrypt_directly() {
+    let shared_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let files = [
+        shared_root.join("../api-server/src/http/assistant/session.rs"),
+        shared_root.join("../api-server/src/http/connectors/revoke.rs"),
+        shared_root.join("../worker/src/job_actions/google/session.rs"),
+        shared_root.join("../worker/src/privacy_delete_revoke.rs"),
+    ];
+
+    for file in files {
+        let content = fs::read_to_string(&file)
+            .expect("failed to read source file for decrypt boundary guard test");
+        assert!(
+            !content.contains("decrypt_active_connector_refresh_token("),
+            "{} must not call connector decrypt repository API directly",
+            file.display()
+        );
+    }
+}
+
+#[test]
+fn host_paths_do_not_perform_google_bearer_fetches_outside_enclave() {
+    let shared_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let files = [
+        shared_root.join("../api-server/src/http/assistant/query.rs"),
+        shared_root.join("../api-server/src/http/assistant/fetch.rs"),
+        shared_root.join("../worker/src/job_actions/google/mod.rs"),
+        shared_root.join("../worker/src/job_actions/google/morning_brief.rs"),
+        shared_root.join("../worker/src/job_actions/google/urgent_email.rs"),
+        shared_root.join("../worker/src/job_actions/google/fetch.rs"),
+    ];
+
+    for file in files {
+        let content = fs::read_to_string(&file)
+            .expect("failed to read source file for enclave-only google fetch guard test");
+        assert!(
+            !content.contains(".bearer_auth("),
+            "{} must not perform direct bearer-auth Google fetches in host runtime",
+            file.display()
+        );
+    }
+}
+
+fn assert_no_sensitive_tracing_args(path: &str, content: &str) {
+    const TRACING_MACROS: [&str; 5] = ["trace!(", "debug!(", "info!(", "warn!(", "error!("];
+    const SENSITIVE_TERMS: [&str; 4] = [
+        "refresh_token",
+        "access_token",
+        "client_secret",
+        "apns_token",
+    ];
+
+    for macro_call in TRACING_MACROS {
+        let mut from = 0;
+        while let Some(start_offset) = content[from..].find(macro_call) {
+            let start = from + start_offset;
+            let Some(end_offset) = content[start..].find(");") else {
+                break;
+            };
+            let end = start + end_offset + 2;
+            let snippet = content[start..end].to_ascii_lowercase();
+
+            for term in SENSITIVE_TERMS {
+                assert!(
+                    !snippet.contains(term),
+                    "{path} contains sensitive term `{term}` in tracing macro: {snippet}"
+                );
+            }
+
+            from = end;
+        }
+    }
+}

--- a/backend/crates/worker/src/job_actions/google/session.rs
+++ b/backend/crates/worker/src/job_actions/google/session.rs
@@ -1,36 +1,28 @@
 use shared::config::WorkerConfig;
-use shared::enclave::{ConnectorSecretRequest, EnclaveRpcClient, EnclaveRpcError};
+use shared::enclave::{ConnectorSecretRequest, EnclaveRpcAuthConfig, EnclaveRpcClient};
 use shared::repos::{LEGACY_CONNECTOR_TOKEN_KEY_ID, Store};
 use shared::security::SecretRuntime;
 
-use super::fetch::classified_http_error;
 use crate::JobExecutionError;
 
 pub(super) struct GoogleSession {
-    pub(super) access_token: String,
-    pub(super) attested_measurement: String,
+    pub(super) connector_request: ConnectorSecretRequest,
 }
 
 pub(super) async fn build_google_session(
     store: &Store,
     config: &WorkerConfig,
     _secret_runtime: &SecretRuntime,
-    oauth_client: &reqwest::Client,
+    _oauth_client: &reqwest::Client,
     user_id: uuid::Uuid,
 ) -> Result<GoogleSession, JobExecutionError> {
     let connector = load_active_google_connector(store, config, user_id).await?;
-    let enclave_client = build_enclave_client(config, oauth_client);
-    let token_response = enclave_client
-        .exchange_google_access_token(ConnectorSecretRequest {
-            user_id,
-            connector_id: connector.connector_id,
-        })
-        .await
-        .map_err(map_exchange_enclave_error)?;
 
     Ok(GoogleSession {
-        access_token: token_response.access_token,
-        attested_measurement: token_response.attested_identity.measurement,
+        connector_request: ConnectorSecretRequest {
+            user_id,
+            connector_id: connector.connector_id,
+        },
     })
 }
 
@@ -103,63 +95,16 @@ async fn load_active_google_connector(
     })
 }
 
-fn build_enclave_client(config: &WorkerConfig, oauth_client: &reqwest::Client) -> EnclaveRpcClient {
+pub(super) fn build_enclave_client(
+    config: &WorkerConfig,
+    oauth_client: &reqwest::Client,
+) -> EnclaveRpcClient {
     EnclaveRpcClient::new(
         config.enclave_runtime_base_url.clone(),
-        shared::enclave::EnclaveRpcAuthConfig {
+        EnclaveRpcAuthConfig {
             shared_secret: config.enclave_rpc_shared_secret.clone(),
             max_clock_skew_seconds: config.enclave_rpc_auth_max_skew_seconds,
         },
         oauth_client.clone(),
     )
-}
-
-fn map_exchange_enclave_error(err: EnclaveRpcError) -> JobExecutionError {
-    match err {
-        EnclaveRpcError::DecryptNotAuthorized { message } => JobExecutionError::permanent(
-            "CONNECTOR_DECRYPT_NOT_AUTHORIZED",
-            format!("decrypt authorization failed: {message}"),
-        ),
-        EnclaveRpcError::ConnectorTokenDecryptFailed { message } => JobExecutionError::transient(
-            "CONNECTOR_TOKEN_DECRYPT_FAILED",
-            format!("failed to decrypt refresh token: {message}"),
-        ),
-        EnclaveRpcError::ConnectorTokenUnavailable => JobExecutionError::permanent(
-            "CONNECTOR_TOKEN_MISSING",
-            "refresh token was unavailable for active connector",
-        ),
-        EnclaveRpcError::ProviderRequestUnavailable { message, .. } => {
-            JobExecutionError::transient(
-                "GOOGLE_TOKEN_REFRESH_UNAVAILABLE",
-                format!("google token refresh request failed: {message}"),
-            )
-        }
-        EnclaveRpcError::ProviderRequestFailed {
-            status,
-            oauth_error,
-            ..
-        } => {
-            let status =
-                reqwest::StatusCode::from_u16(status).unwrap_or(reqwest::StatusCode::BAD_GATEWAY);
-            let message = match oauth_error {
-                Some(error) => format!("google token refresh rejected: {error}"),
-                None => format!("google token refresh failed with HTTP {}", status.as_u16()),
-            };
-            classified_http_error(status, "GOOGLE_TOKEN_REFRESH_FAILED", message)
-        }
-        EnclaveRpcError::ProviderResponseInvalid { message, .. } => JobExecutionError::transient(
-            "GOOGLE_TOKEN_REFRESH_PARSE_FAILED",
-            format!("google token refresh response was invalid: {message}"),
-        ),
-        EnclaveRpcError::RpcUnauthorized { code }
-        | EnclaveRpcError::RpcContractRejected { code } => JobExecutionError::permanent(
-            "ENCLAVE_RPC_REJECTED",
-            format!("secure enclave rpc request rejected: {code}"),
-        ),
-        EnclaveRpcError::RpcTransportUnavailable { message }
-        | EnclaveRpcError::RpcResponseInvalid { message } => JobExecutionError::transient(
-            "ENCLAVE_RPC_UNAVAILABLE",
-            format!("secure enclave rpc unavailable: {message}"),
-        ),
-    }
 }

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -108,7 +108,7 @@ Ship a private beta where iOS users can:
 | SEC-003 | P0 | Implement enclave attestation validation | SEC | 2026-03-04 | DONE | SEC-002 | Attestation verified end-to-end |
 | SEC-004 | P0 | Bind KMS decrypt access to enclave measurements | SEC | 2026-03-06 | DONE | SEC-003 | Decrypt denied outside attested enclave |
 | SEC-005 | P0 | Implement secure host<->enclave RPC contract | SEC | 2026-03-08 | DONE | SEC-002 | Versioned HMAC-authenticated RPC contract live with replay protection and tests |
-| SEC-006 | P0 | Move Google API fetch/decrypt path into enclave process | SEC | 2026-03-13 | TODO | SEC-004, BE-006 | Sensitive path enclave-only |
+| SEC-006 | P0 | Move Google API fetch/decrypt path into enclave process | SEC | 2026-03-13 | DONE | SEC-004, BE-006 | Sensitive path enclave-only (issue #126) |
 | SEC-007 | P0 | Token encryption/decryption service with key versioning | SEC | 2026-03-09 | IN_PROGRESS | SEC-004 | Key versioned crypto works |
 | SEC-008 | P1 | Add key rotation runbook + scripts | SEC | 2026-03-15 | TODO | SEC-007 | Rotation test executed |
 | SEC-009 | P0 | Secrets never logged tests and lint checks | SEC | 2026-03-10 | IN_PROGRESS | BE-003 | No secret leakage in logs |


### PR DESCRIPTION
## Summary
Move Google token-backed Calendar/Gmail fetches from host API/worker into enclave runtime RPC so decrypt/refresh/fetch stays enclave-only.

## Changes
- Extended enclave RPC contract/client/service/runtime with typed Google fetch operations:
  - `POST /v1/rpc/google/calendar/events`
  - `POST /v1/rpc/google/gmail/urgent-candidates`
- Refactored API assistant path to use enclave fetch RPC (removed host-side bearer token fetch path).
- Refactored worker meeting reminder, morning brief, and urgent email paths to use enclave fetch RPC (removed host-side bearer token fetch path).
- Added host-boundary guard tests to block regressions (`.bearer_auth(` in sensitive host modules) and expanded RPC client contract mismatch tests for new endpoints.
- Updated board tracking: `docs/phase1-master-todo.md` marks `SEC-006` as `DONE`.
- Extracted `enclave-runtime` HTTP RPC auth/error helpers into `http/rpc.rs` to keep handler module modular and below large-file threshold.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just backend-verify`
- `just backend-deep-review`

## Issue
Closes #126