### PR TITLE
SEC-007: add idempotent connector key rotation workflow

### DIFF
--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -109,7 +109,7 @@ Ship a private beta where iOS users can:
 | SEC-004 | P0 | Bind KMS decrypt access to enclave measurements | SEC | 2026-03-06 | DONE | SEC-003 | Decrypt denied outside attested enclave |
 | SEC-005 | P0 | Implement secure host<->enclave RPC contract | SEC | 2026-03-08 | DONE | SEC-002 | Versioned HMAC-authenticated RPC contract live with replay protection and tests |
 | SEC-006 | P0 | Move Google API fetch/decrypt path into enclave process | SEC | 2026-03-13 | DONE | SEC-004, BE-006 | Sensitive path enclave-only (issue #126) |
-| SEC-007 | P0 | Token encryption/decryption service with key versioning | SEC | 2026-03-09 | IN_PROGRESS | SEC-004 | Key versioned crypto works |
+| SEC-007 | P0 | Token encryption/decryption service with key versioning | SEC | 2026-03-09 | DONE | SEC-004 | Key versioned crypto works with idempotent rotation/repair workflow |
 | SEC-008 | P1 | Add key rotation runbook + scripts | SEC | 2026-03-15 | TODO | SEC-007 | Rotation test executed |
 | SEC-009 | P0 | Secrets never logged tests and lint checks | SEC | 2026-03-10 | IN_PROGRESS | BE-003 | No secret leakage in logs |
 | SEC-010 | P0 | Threat model review (STRIDE) | SEC | 2026-03-17 | DONE | SEC-006 | Signed threat model doc |


### PR DESCRIPTION
## Summary
Implements SEC-007 key-versioned connector token metadata rotation path with deterministic, idempotent behavior for retries and partial update races.

## Changes
- Added `Store::ensure_active_connector_key_metadata` with compare-and-set rotation semantics and deterministic conflict handling.
- Replaced legacy-only metadata adoption in API/worker connector token paths with rotation-safe ensure flow.
- Added rotation outcome unit tests covering success, partial failure, and retry-safe concurrent completion behavior.
- Updated Phase I board entry `SEC-007` to `DONE` in `docs/phase1-master-todo.md`.

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `just backend-verify`
- `just backend-deep-review`
- `just ios-build` (post-change)

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: one regression risk found during review (extra metadata read on every request/job even when already current) and fixed in this PR
- Repro or test evidence: fixed by mismatch-gating before rotation ensure calls; full backend suite and deep-review gate pass
- Required fixes: included in this PR

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: repository logic remains in `shared/src/repos`; API/worker call-sites only orchestrate
- Performance/scalability concerns: no remaining material concerns for this scope
- Refactor recommendations: none required for this issue

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

## Issue
Closes #127
