### PR TITLE
SEC-009: harden secret logging guard coverage and metadata redaction

### DIFF
--- a/backend/crates/worker/src/job_actions/google/morning_brief.rs
+++ b/backend/crates/worker/src/job_actions/google/morning_brief.rs
@@ -66,10 +66,10 @@ pub(super) async fn build_morning_brief(
         &[],
     );
 
-    let raw_context_payload = serde_json::to_value(&context).map_err(|err| {
+    let raw_context_payload = serde_json::to_value(&context).map_err(|_err| {
         JobExecutionError::permanent(
             "MORNING_BRIEF_CONTEXT_SERIALIZATION_FAILED",
-            format!("failed to serialize morning brief context: {err}"),
+            "failed to serialize morning brief context",
         )
     })?;
     let context_payload = sanitize_context_payload(&raw_context_payload);

--- a/backend/crates/worker/src/job_actions/google/session.rs
+++ b/backend/crates/worker/src/job_actions/google/session.rs
@@ -39,10 +39,10 @@ async fn load_active_google_connector(
     let connector = store
         .list_active_connector_metadata(user_id)
         .await
-        .map_err(|err| {
+        .map_err(|_err| {
             JobExecutionError::transient(
                 "CONNECTOR_METADATA_READ_FAILED",
-                format!("failed to read connector metadata: {err}"),
+                "failed to read connector metadata",
             )
         })?
         .into_iter()
@@ -73,10 +73,10 @@ async fn load_active_google_connector(
                     "connector key metadata changed; retry the job",
                 ));
             }
-            Err(err) => {
+            Err(_err) => {
                 return Err(JobExecutionError::transient(
                     "CONNECTOR_KEY_METADATA_UPDATE_FAILED",
-                    format!("failed to rotate connector key metadata: {err}"),
+                    "failed to rotate connector key metadata",
                 ));
             }
         }

--- a/backend/crates/worker/src/job_actions/google/urgent_email.rs
+++ b/backend/crates/worker/src/job_actions/google/urgent_email.rs
@@ -46,10 +46,10 @@ pub(super) async fn build_urgent_email_alert(
     let candidates_fetched = candidates.len();
     let context = assemble_urgent_email_candidates_context(&candidates);
 
-    let raw_context_payload = serde_json::to_value(&context).map_err(|err| {
+    let raw_context_payload = serde_json::to_value(&context).map_err(|_err| {
         JobExecutionError::permanent(
             "URGENT_EMAIL_CONTEXT_SERIALIZATION_FAILED",
-            format!("failed to serialize urgent email context: {err}"),
+            "failed to serialize urgent email context",
         )
     })?;
     let context_payload = sanitize_context_payload(&raw_context_payload);

--- a/backend/crates/worker/src/privacy_delete.rs
+++ b/backend/crates/worker/src/privacy_delete.rs
@@ -192,11 +192,8 @@ async fn execute_delete_request(
     let active_connectors = store
         .list_active_connector_metadata(request.user_id)
         .await
-        .map_err(|err| {
-            DeleteRequestError::new(
-                "CONNECTOR_LOOKUP_FAILED",
-                format!("failed to load connectors: {err}"),
-            )
+        .map_err(|_err| {
+            DeleteRequestError::new("CONNECTOR_LOOKUP_FAILED", "failed to load connectors")
         })?;
 
     let revoked_connectors = revoke_active_connectors(
@@ -212,11 +209,8 @@ async fn execute_delete_request(
     store
         .purge_user_operational_data(request.user_id)
         .await
-        .map_err(|err| {
-            DeleteRequestError::new(
-                "PURGE_FAILED",
-                format!("failed to purge user operational data: {err}"),
-            )
+        .map_err(|_err| {
+            DeleteRequestError::new("PURGE_FAILED", "failed to purge user operational data")
         })?;
 
     Ok(revoked_connectors)

--- a/backend/crates/worker/src/privacy_delete_revoke.rs
+++ b/backend/crates/worker/src/privacy_delete_revoke.rs
@@ -107,9 +107,9 @@ async fn normalize_connector_metadata(
             "CONNECTOR_KEY_METADATA_MISSING",
             "connector key metadata changed during delete workflow",
         )),
-        Err(err) => Err(DeleteRequestError::new(
+        Err(_err) => Err(DeleteRequestError::new(
             "CONNECTOR_KEY_METADATA_UPDATE_FAILED",
-            format!("failed to rotate connector key metadata: {err}"),
+            "failed to rotate connector key metadata",
         )),
     }
 }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -19,11 +19,13 @@ Rules:
   - `latency_ms`
   - `outcome`
 - Never log secrets, OAuth tokens, or raw sensitive payloads.
+- Secret logging guard tests (`cargo test -p shared boundary_guards`) automatically scan API/worker/enclave-sensitive Rust modules and fail CI on forbidden tracing patterns.
 
 Sensitive field policy:
 - Forbidden in tracing fields and messages: `refresh_token`, `access_token`, `client_secret`, `apns_token`, `authorization_header`, `oauth_code`, `id_token`, `identity_token`, `bearer_token`.
 - When mapping provider/enclave/database errors in sensitive token paths, use deterministic sanitized messages and error codes.
 - Do not append upstream error text (`{err}`, `{error}`, `{message}`) to user-visible API errors, persisted worker failure reasons, or sensitive audit metadata.
+- Audit metadata persistence redacts both sensitive keys and leaked token/authorization markers in values.
 
 Backend examples:
 - Do: `warn!(user_id = %user_id, error_code = "GOOGLE_REVOKE_FAILED", "google revoke failed")`

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -111,7 +111,7 @@ Ship a private beta where iOS users can:
 | SEC-006 | P0 | Move Google API fetch/decrypt path into enclave process | SEC | 2026-03-13 | DONE | SEC-004, BE-006 | Sensitive path enclave-only (issue #126) |
 | SEC-007 | P0 | Token encryption/decryption service with key versioning | SEC | 2026-03-09 | DONE | SEC-004 | Key versioned crypto works with idempotent rotation/repair workflow |
 | SEC-008 | P1 | Add key rotation runbook + scripts | SEC | 2026-03-15 | TODO | SEC-007 | Rotation test executed |
-| SEC-009 | P0 | Secrets never logged tests and lint checks | SEC | 2026-03-10 | DONE | BE-003 | No secret leakage in logs |
+| SEC-009 | P0 | Secrets never logged tests and lint checks | SEC | 2026-03-10 | DONE | BE-003 | No secret leakage in logs (guard coverage + metadata value redaction hardening) |
 | SEC-010 | P0 | Threat model review (STRIDE) | SEC | 2026-03-17 | DONE | SEC-006 | Signed threat model doc |
 | SEC-011 | P0 | External security assessment prep | SEC | 2026-04-03 | TODO | SEC-010 | Scope + test plan ready |
 | SEC-012 | P0 | Remediate critical findings before beta | SEC | 2026-04-17 | TODO | SEC-011 | No open critical findings |


### PR DESCRIPTION
## Summary
- expand secret logging guard tests to automatically scan API/worker/enclave-sensitive modules instead of a fixed file list
- strengthen guard coverage for sensitive error interpolation (`format!(...{err|error|message}...)`) and host-boundary checks
- harden sensitive worker error messages to deterministic sanitized strings (remove upstream interpolation)
- extend audit metadata redaction to also redact leaked token/authorization markers in metadata values
- update logging guidance and phase board note for SEC-009 hardening

Closes #129

## Validation
- `just check-tools`
- `just backend-check`
- `just ios-build`
- `cd backend && cargo test -p shared boundary_guards`
- `cd backend && cargo test -p shared repos::audit`
- `just backend-deep-review`
- `just backend-eval`
- `just ios-build`

## AI Review Summary
### 1) Security Audit
- Findings: no findings after hardening (secret guard coverage, sanitized error mapping, value-based metadata redaction)
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no functional regressions observed in backend/iOS verification suite
- Repro or test evidence: backend-deep-review + targeted guard tests + mocked eval + ios-build all pass
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no boundary violations (`just backend-architecture-check` passes via deep-review)
- Performance/scalability concerns: none introduced (test-only guard expansion + lightweight metadata value checks)
- Refactor recommendations: none required for this scope

### 4) Final Status
- `just backend-deep-review`: PASS
- Merge recommendation: `APPROVE`
