### PR TITLE
docs: codify plan sync update policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,9 @@ Code must remain modular by default. Do not keep adding logic to a single large 
 2. Planning board: `docs/phase1-master-todo.md`
 3. Rule:
    1. If a GitHub issue and board item conflict, treat GitHub issue as immediate execution source and update docs in the same change.
+4. Plan update policy:
+   1. When an execution plan changes issue status, sequencing, dependencies, or scope, update the GitHub issue first and keep `docs/phase1-master-todo.md` aligned in the same work cycle.
+   2. Update `AGENTS.md` and `agent/start.md` only when workflow or policy itself changes (not for normal task/status progress).
 
 ## GitHub Issue Workflow (Required)
 

--- a/agent/start.md
+++ b/agent/start.md
@@ -147,6 +147,8 @@ Phase I labels currently in use:
 2. `docs/phase1-master-todo.md` is the planning/control board.
 3. If either side changes, keep them aligned in the same work cycle.
 4. Do not start untracked work; create/obtain an issue first.
+5. When an execution plan changes issue status, sequencing, dependencies, or scope, update the issue first and keep the board aligned in the same work cycle.
+6. Update `AGENTS.md` and this file only when workflow/policy changes (not for normal issue progress).
 
 ## Security and Privacy Constraints
 

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -52,6 +52,12 @@ Ship a private beta where iOS users can:
 3. Rule-based urgent-email logic has been removed from production worker paths (`#91`).
 4. Execution queue for this migration is GitHub issues `#91` through `#103` (`ai-backend` label).
 
+## Plan Sync Update (2026-02-16)
+
+1. GitHub issues remain the immediate execution source of truth.
+2. Keep this board aligned in the same work cycle whenever issue status, sequencing, dependencies, or scope changes.
+3. `AGENTS.md` and `agent/start.md` should be updated only for workflow/policy changes, not normal issue progress updates.
+
 ## 5) Execution Board
 
 ### A) Product and Scope Control


### PR DESCRIPTION
## Summary
- add explicit plan update policy in `AGENTS.md`
- mirror the same rule in `agent/start.md`
- add a dated plan-sync note in `docs/phase1-master-todo.md`

## Validation
- docs-only change; no runtime checks executed