### PR TITLE
Issue #147: attested ciphertext-only assistant ingress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,14 @@ TEE_ATTESTATION_DOCUMENT={}
 TEE_ALLOWED_MEASUREMENTS=dev-local-enclave
 KMS_KEY_ID=kms/local/alfred-refresh-token
 KMS_KEY_VERSION=1
+ASSISTANT_INGRESS_ACTIVE_KEY_ID=assistant-ingress-v1
+# Optional in local dev-shim; required outside local.
+# ASSISTANT_INGRESS_ACTIVE_PRIVATE_KEY=<base64 32-byte x25519 private key>
+# Optional previous key pair for rotation grace window.
+# ASSISTANT_INGRESS_PREVIOUS_KEY_ID=assistant-ingress-v0
+# ASSISTANT_INGRESS_PREVIOUS_PRIVATE_KEY=<base64 32-byte x25519 private key>
+ASSISTANT_INGRESS_KEY_TTL_SECONDS=900
+ASSISTANT_INGRESS_SESSION_TTL_SECONDS=3600
 
 # Worker defaults (optional)
 WORKER_TICK_SECONDS=30

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Implemented now:
 
 1. Clerk-authenticated API surface for connectors, preferences, audit events, and privacy delete-all.
 2. LLM-first backend paths for:
-   1. `/v1/assistant/query` (meetings-today capability)
+   1. `/v1/assistant/attested-key` + encrypted `/v1/assistant/query` (meetings-today capability)
    2. Worker morning brief generation
    3. Worker urgent-email prioritization
 3. OpenRouter model routing/fallback plus reliability guardrails (rate limits, circuit breaker, cache, budget controls).
@@ -120,6 +120,9 @@ just check-infra-tools
 ```bash
 cp .env.example .env
 ```
+
+Assistant note:
+`ASSISTANT_INGRESS_*` defaults in `.env.example` are set for local development so encrypted assistant queries can run end-to-end without extra setup.
 
 3. Start local infra and apply DB migrations:
 

--- a/alfred/Packages/AlfredAPIClient/Sources/AssistantEncryption.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/AssistantEncryption.swift
@@ -1,0 +1,300 @@
+import CryptoKit
+import Foundation
+import Security
+
+public struct AssistantAttestationVerificationConfig: Sendable {
+    public let expectedRuntime: String
+    public let allowedMeasurements: Set<String>
+    public let attestationPublicKeyBase64: String
+    public let maxAttestationAgeSeconds: Int64
+    public let challengeWindowSeconds: Int
+
+    public init(
+        expectedRuntime: String,
+        allowedMeasurements: Set<String>,
+        attestationPublicKeyBase64: String,
+        maxAttestationAgeSeconds: Int64 = 300,
+        challengeWindowSeconds: Int = 30
+    ) {
+        self.expectedRuntime = expectedRuntime
+        self.allowedMeasurements = allowedMeasurements
+        self.attestationPublicKeyBase64 = attestationPublicKeyBase64
+        self.maxAttestationAgeSeconds = maxAttestationAgeSeconds
+        self.challengeWindowSeconds = challengeWindowSeconds
+    }
+}
+
+struct EncryptedAssistantRequestPayload {
+    let envelope: AssistantEncryptedRequestEnvelope
+    let clientEphemeralPrivateKey: Data
+}
+
+enum AssistantEnvelopeCrypto {
+    static let versionV1 = "v1"
+    static let algorithmX25519ChaCha20Poly1305 = "x25519-chacha20poly1305"
+
+    static func verifyAttestedKeyResponse(
+        _ response: AssistantAttestedKeyResponse,
+        expectedChallengeNonce: String,
+        expectedRequestID: String,
+        config: AssistantAttestationVerificationConfig
+    ) throws {
+        guard response.algorithm == algorithmX25519ChaCha20Poly1305 else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "unsupported key algorithm")
+        }
+        guard response.attestation.challengeNonce == expectedChallengeNonce else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "challenge nonce mismatch")
+        }
+        guard response.attestation.requestId == expectedRequestID else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "request_id mismatch")
+        }
+        guard response.attestation.expiresAt > response.attestation.issuedAt else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "invalid attestation challenge window")
+        }
+        guard response.attestation.runtime.caseInsensitiveCompare(config.expectedRuntime) == .orderedSame else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "unexpected enclave runtime")
+        }
+        guard config.allowedMeasurements.contains(response.attestation.measurement) else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "measurement is not allowed")
+        }
+
+        let now = Int64(Date().timeIntervalSince1970)
+        guard now <= response.attestation.expiresAt else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "challenge expired")
+        }
+        guard response.attestation.evidenceIssuedAt >= response.attestation.issuedAt,
+              response.attestation.evidenceIssuedAt <= response.attestation.expiresAt else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "evidence is not challenge-bound")
+        }
+        guard abs(now - response.attestation.evidenceIssuedAt) <= config.maxAttestationAgeSeconds else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "attestation evidence is stale")
+        }
+        guard response.keyExpiresAt >= now else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "attested key has expired")
+        }
+
+        guard let encodedPublicKey = Data(base64Encoded: config.attestationPublicKeyBase64),
+              encodedPublicKey.count == 32 else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "attestation verification key is invalid")
+        }
+        guard let signatureB64 = response.attestation.signature,
+              let signature = Data(base64Encoded: signatureB64) else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "attestation signature missing")
+        }
+
+        let payload = assistantKeyAttestationSigningPayload(response)
+        let publicKey: Curve25519.Signing.PublicKey
+        do {
+            publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: encodedPublicKey)
+        } catch {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "attestation verification key parse failed")
+        }
+
+        guard publicKey.isValidSignature(signature, for: Data(payload.utf8)) else {
+            throw AlfredAPIClientError.assistantAttestationFailed(reason: "attestation signature is invalid")
+        }
+    }
+
+    static func encryptRequest(
+        plaintextRequest: AssistantPlaintextQueryRequest,
+        requestID: String,
+        attestedKey: AssistantAttestedKeyResponse
+    ) throws -> EncryptedAssistantRequestPayload {
+        guard attestedKey.algorithm == algorithmX25519ChaCha20Poly1305 else {
+            throw AlfredAPIClientError.assistantEncryptionFailed(reason: "unsupported key algorithm")
+        }
+        guard let enclavePublicKeyRaw = Data(base64Encoded: attestedKey.publicKey), enclavePublicKeyRaw.count == 32 else {
+            throw AlfredAPIClientError.assistantEncryptionFailed(reason: "invalid enclave public key")
+        }
+
+        let clientEphemeralPrivateKey = Curve25519.KeyAgreement.PrivateKey()
+        let enclavePublicKey: Curve25519.KeyAgreement.PublicKey
+        do {
+            enclavePublicKey = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: enclavePublicKeyRaw)
+        } catch {
+            throw AlfredAPIClientError.assistantEncryptionFailed(reason: "failed to parse enclave key")
+        }
+
+        let sharedSecret: SharedSecret
+        do {
+            sharedSecret = try clientEphemeralPrivateKey.sharedSecretFromKeyAgreement(with: enclavePublicKey)
+        } catch {
+            throw AlfredAPIClientError.assistantEncryptionFailed(reason: "key agreement failed")
+        }
+
+        let symmetricKey = deriveDirectionalSymmetricKey(
+            sharedSecret: sharedSecret,
+            requestID: requestID,
+            direction: "request"
+        )
+        let requestNonce = try randomNonceData()
+        let nonce: ChaChaPoly.Nonce
+        do {
+            nonce = try ChaChaPoly.Nonce(data: requestNonce)
+        } catch {
+            throw AlfredAPIClientError.assistantEncryptionFailed(reason: "failed to create nonce")
+        }
+
+        let plaintext: Data
+        do {
+            plaintext = try JSONEncoder().encode(plaintextRequest)
+        } catch {
+            throw AlfredAPIClientError.assistantEncryptionFailed(reason: "failed to encode plaintext request")
+        }
+
+        let sealedBox: ChaChaPoly.SealedBox
+        do {
+            sealedBox = try ChaChaPoly.seal(
+                plaintext,
+                using: symmetricKey,
+                nonce: nonce,
+                authenticating: Data(requestID.utf8)
+            )
+        } catch {
+            throw AlfredAPIClientError.assistantEncryptionFailed(reason: "request encryption failed")
+        }
+
+        return EncryptedAssistantRequestPayload(
+            envelope: AssistantEncryptedRequestEnvelope(
+                version: versionV1,
+                algorithm: algorithmX25519ChaCha20Poly1305,
+                keyId: attestedKey.keyId,
+                requestId: requestID,
+                clientEphemeralPublicKey: clientEphemeralPrivateKey.publicKey.rawRepresentation.base64EncodedString(),
+                nonce: requestNonce.base64EncodedString(),
+                ciphertext: sealedBox.combined.base64EncodedString()
+            ),
+            clientEphemeralPrivateKey: clientEphemeralPrivateKey.rawRepresentation
+        )
+    }
+
+    static func decryptResponse(
+        envelope: AssistantEncryptedResponseEnvelope,
+        requestID: String,
+        clientEphemeralPrivateKey: Data,
+        attestedKey: AssistantAttestedKeyResponse
+    ) throws -> AssistantPlaintextQueryResponse {
+        guard envelope.version == versionV1 else {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "unsupported envelope version")
+        }
+        guard envelope.algorithm == algorithmX25519ChaCha20Poly1305 else {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "unsupported envelope algorithm")
+        }
+        guard envelope.keyId == attestedKey.keyId else {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "key_id mismatch")
+        }
+        guard envelope.requestId == requestID else {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "request_id mismatch")
+        }
+
+        guard let nonceData = Data(base64Encoded: envelope.nonce), nonceData.count == 12 else {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "response nonce is invalid")
+        }
+        guard let ciphertext = Data(base64Encoded: envelope.ciphertext) else {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "response ciphertext is invalid")
+        }
+        guard let enclavePublicKeyRaw = Data(base64Encoded: attestedKey.publicKey), enclavePublicKeyRaw.count == 32 else {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "enclave public key is invalid")
+        }
+
+        let clientPrivateKey: Curve25519.KeyAgreement.PrivateKey // gitleaks:allow
+        do {
+            clientPrivateKey = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: clientEphemeralPrivateKey)
+        } catch {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "client ephemeral key is invalid")
+        }
+
+        let enclavePublicKey: Curve25519.KeyAgreement.PublicKey
+        do {
+            enclavePublicKey = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: enclavePublicKeyRaw)
+        } catch {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "enclave key parse failed")
+        }
+
+        let sharedSecret: SharedSecret
+        do {
+            sharedSecret = try clientPrivateKey.sharedSecretFromKeyAgreement(with: enclavePublicKey)
+        } catch {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "key agreement failed")
+        }
+
+        let symmetricKey = deriveDirectionalSymmetricKey(
+            sharedSecret: sharedSecret,
+            requestID: requestID,
+            direction: "response"
+        )
+
+        let nonce: ChaChaPoly.Nonce
+        do {
+            nonce = try ChaChaPoly.Nonce(data: nonceData)
+        } catch {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "nonce parse failed")
+        }
+
+        let sealedBox: ChaChaPoly.SealedBox
+        do {
+            sealedBox = try ChaChaPoly.SealedBox(combined: ciphertext)
+        } catch {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "sealed box parse failed")
+        }
+
+        let plaintext: Data
+        do {
+            plaintext = try ChaChaPoly.open(
+                sealedBox,
+                using: symmetricKey,
+                authenticating: Data(requestID.utf8)
+            )
+        } catch {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "response decryption failed")
+        }
+
+        do {
+            return try JSONDecoder().decode(AssistantPlaintextQueryResponse.self, from: plaintext)
+        } catch {
+            throw AlfredAPIClientError.assistantDecryptionFailed(reason: "response payload decode failed")
+        }
+    }
+
+    private static func deriveDirectionalSymmetricKey(
+        sharedSecret: SharedSecret,
+        requestID: String,
+        direction: String
+    ) -> SymmetricKey {
+        let sharedSecretData = sharedSecret.withUnsafeBytes { Data($0) }
+        var digestInput = Data()
+        digestInput.append(sharedSecretData)
+        digestInput.append(Data("|".utf8))
+        digestInput.append(Data(requestID.utf8))
+        digestInput.append(Data("|".utf8))
+        digestInput.append(Data(direction.utf8))
+        let digest = SHA256.hash(data: digestInput)
+        return SymmetricKey(data: Data(digest))
+    }
+
+    private static func assistantKeyAttestationSigningPayload(_ response: AssistantAttestedKeyResponse) -> String {
+        [
+            response.attestation.runtime,
+            response.attestation.measurement,
+            response.attestation.challengeNonce,
+            String(response.attestation.issuedAt),
+            String(response.attestation.expiresAt),
+            response.attestation.requestId,
+            String(response.attestation.evidenceIssuedAt),
+            response.keyId,
+            response.algorithm,
+            response.publicKey,
+            String(response.keyExpiresAt)
+        ]
+        .joined(separator: "|")
+    }
+
+    private static func randomNonceData() throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: 12)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw AlfredAPIClientError.assistantEncryptionFailed(reason: "random nonce generation failed")
+        }
+        return Data(bytes)
+    }
+}

--- a/alfred/Packages/AlfredAPIClient/Sources/Models.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/Models.swift
@@ -44,6 +44,69 @@ public struct SendTestNotificationResponse: Codable, Sendable {
 }
 
 public struct AssistantQueryRequest: Codable, Sendable {
+    public let envelope: AssistantEncryptedRequestEnvelope
+    public let sessionId: UUID?
+
+    enum CodingKeys: String, CodingKey {
+        case envelope
+        case sessionId = "session_id"
+    }
+
+    public init(envelope: AssistantEncryptedRequestEnvelope, sessionId: UUID? = nil) {
+        self.envelope = envelope
+        self.sessionId = sessionId
+    }
+}
+
+public struct AssistantEncryptedRequestEnvelope: Codable, Sendable {
+    public let version: String
+    public let algorithm: String
+    public let keyId: String
+    public let requestId: String
+    public let clientEphemeralPublicKey: String
+    public let nonce: String
+    public let ciphertext: String
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case algorithm
+        case keyId = "key_id"
+        case requestId = "request_id"
+        case clientEphemeralPublicKey = "client_ephemeral_public_key"
+        case nonce
+        case ciphertext
+    }
+}
+
+public struct AssistantEncryptedResponseEnvelope: Codable, Sendable {
+    public let version: String
+    public let algorithm: String
+    public let keyId: String
+    public let requestId: String
+    public let nonce: String
+    public let ciphertext: String
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case algorithm
+        case keyId = "key_id"
+        case requestId = "request_id"
+        case nonce
+        case ciphertext
+    }
+}
+
+public struct AssistantQueryResponse: Codable, Sendable {
+    public let sessionId: UUID
+    public let envelope: AssistantEncryptedResponseEnvelope
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case envelope
+    }
+}
+
+public struct AssistantPlaintextQueryRequest: Codable, Sendable {
     public let query: String
     public let sessionId: UUID?
 
@@ -76,7 +139,7 @@ public struct AssistantMeetingsTodayPayload: Codable, Sendable {
     }
 }
 
-public struct AssistantQueryResponse: Codable, Sendable {
+public struct AssistantPlaintextQueryResponse: Codable, Sendable {
     public let sessionId: UUID
     public let capability: AssistantQueryCapability
     public let displayText: String
@@ -87,6 +150,65 @@ public struct AssistantQueryResponse: Codable, Sendable {
         case capability
         case displayText = "display_text"
         case payload
+    }
+}
+
+public struct AssistantAttestedKeyRequest: Codable, Sendable {
+    public let challengeNonce: String
+    public let issuedAt: Int64
+    public let expiresAt: Int64
+    public let requestId: String
+
+    enum CodingKeys: String, CodingKey {
+        case challengeNonce = "challenge_nonce"
+        case issuedAt = "issued_at"
+        case expiresAt = "expires_at"
+        case requestId = "request_id"
+    }
+
+    public init(challengeNonce: String, issuedAt: Int64, expiresAt: Int64, requestId: String) {
+        self.challengeNonce = challengeNonce
+        self.issuedAt = issuedAt
+        self.expiresAt = expiresAt
+        self.requestId = requestId
+    }
+}
+
+public struct AssistantAttestedKeyAttestation: Codable, Sendable {
+    public let runtime: String
+    public let measurement: String
+    public let challengeNonce: String
+    public let issuedAt: Int64
+    public let expiresAt: Int64
+    public let requestId: String
+    public let evidenceIssuedAt: Int64
+    public let signature: String?
+
+    enum CodingKeys: String, CodingKey {
+        case runtime
+        case measurement
+        case challengeNonce = "challenge_nonce"
+        case issuedAt = "issued_at"
+        case expiresAt = "expires_at"
+        case requestId = "request_id"
+        case evidenceIssuedAt = "evidence_issued_at"
+        case signature
+    }
+}
+
+public struct AssistantAttestedKeyResponse: Codable, Sendable {
+    public let keyId: String
+    public let algorithm: String
+    public let publicKey: String
+    public let keyExpiresAt: Int64
+    public let attestation: AssistantAttestedKeyAttestation
+
+    enum CodingKeys: String, CodingKey {
+        case keyId = "key_id"
+        case algorithm
+        case publicKey = "public_key"
+        case keyExpiresAt = "key_expires_at"
+        case attestation
     }
 }
 

--- a/alfred/alfred/AppModel+Utilities.swift
+++ b/alfred/alfred/AppModel+Utilities.swift
@@ -19,6 +19,12 @@ extension AppModel {
                 return "Server error (\(statusCode)): \(details)"
             case .decodingError:
                 return "Failed to decode API response."
+            case .assistantAttestationFailed(let reason):
+                return "Assistant attestation verification failed: \(reason)"
+            case .assistantEncryptionFailed(let reason):
+                return "Assistant request encryption failed: \(reason)"
+            case .assistantDecryptionFailed(let reason):
+                return "Assistant response decryption failed: \(reason)"
             }
         }
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -62,7 +62,7 @@ paths:
   /v1/assistant/query:
     post:
       tags: [Assistant]
-      summary: Query assistant with natural language
+      summary: Query assistant with encrypted envelope
       operationId: queryAssistant
       security:
         - bearerAuth: []
@@ -79,6 +79,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AssistantQueryResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "502":
+          $ref: "#/components/responses/BadGateway"
+  /v1/assistant/attested-key:
+    post:
+      tags: [Assistant]
+      summary: Fetch attested enclave assistant encryption key
+      operationId: fetchAssistantAttestedKey
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssistantAttestedKeyRequest"
+      responses:
+        "200":
+          description: Attested assistant encryption key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssistantAttestedKeyResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -346,14 +374,60 @@ components:
           enum: [QUEUED]
     AssistantQueryRequest:
       type: object
-      required: [query]
+      required: [envelope]
       properties:
-        query:
-          type: string
-          minLength: 1
+        envelope:
+          $ref: "#/components/schemas/AssistantEncryptedRequestEnvelope"
         session_id:
           type: string
           format: uuid
+    AssistantEncryptedRequestEnvelope:
+      type: object
+      required:
+        [
+          version,
+          algorithm,
+          key_id,
+          request_id,
+          client_ephemeral_public_key,
+          nonce,
+          ciphertext
+        ]
+      properties:
+        version:
+          type: string
+          enum: [v1]
+        algorithm:
+          type: string
+          enum: [x25519-chacha20poly1305]
+        key_id:
+          type: string
+        request_id:
+          type: string
+        client_ephemeral_public_key:
+          type: string
+        nonce:
+          type: string
+        ciphertext:
+          type: string
+    AssistantEncryptedResponseEnvelope:
+      type: object
+      required: [version, algorithm, key_id, request_id, nonce, ciphertext]
+      properties:
+        version:
+          type: string
+          enum: [v1]
+        algorithm:
+          type: string
+          enum: [x25519-chacha20poly1305]
+        key_id:
+          type: string
+        request_id:
+          type: string
+        nonce:
+          type: string
+        ciphertext:
+          type: string
     AssistantQueryCapability:
       type: string
       enum: [meetings_today]
@@ -375,17 +449,76 @@ components:
             type: string
     AssistantQueryResponse:
       type: object
-      required: [session_id, capability, display_text, payload]
+      required: [session_id, envelope]
       properties:
         session_id:
           type: string
           format: uuid
-        capability:
-          $ref: "#/components/schemas/AssistantQueryCapability"
-        display_text:
+        envelope:
+          $ref: "#/components/schemas/AssistantEncryptedResponseEnvelope"
+    AssistantAttestedKeyRequest:
+      type: object
+      required: [challenge_nonce, issued_at, expires_at, request_id]
+      properties:
+        challenge_nonce:
           type: string
-        payload:
-          $ref: "#/components/schemas/AssistantMeetingsTodayPayload"
+        issued_at:
+          type: integer
+          format: int64
+        expires_at:
+          type: integer
+          format: int64
+        request_id:
+          type: string
+    AssistantAttestedKeyAttestation:
+      type: object
+      required:
+        [
+          runtime,
+          measurement,
+          challenge_nonce,
+          issued_at,
+          expires_at,
+          request_id,
+          evidence_issued_at
+        ]
+      properties:
+        runtime:
+          type: string
+        measurement:
+          type: string
+        challenge_nonce:
+          type: string
+        issued_at:
+          type: integer
+          format: int64
+        expires_at:
+          type: integer
+          format: int64
+        request_id:
+          type: string
+        evidence_issued_at:
+          type: integer
+          format: int64
+        signature:
+          type: string
+          nullable: true
+    AssistantAttestedKeyResponse:
+      type: object
+      required: [key_id, algorithm, public_key, key_expires_at, attestation]
+      properties:
+        key_id:
+          type: string
+        algorithm:
+          type: string
+          enum: [x25519-chacha20poly1305]
+        public_key:
+          type: string
+        key_expires_at:
+          type: integer
+          format: int64
+        attestation:
+          $ref: "#/components/schemas/AssistantAttestedKeyAttestation"
     StartGoogleConnectRequest:
       type: object
       required: [redirect_uri]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +319,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +364,17 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -471,6 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -639,6 +685,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -1205,6 +1252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1627,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1766,17 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2272,6 +2345,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "base64",
+ "chacha20poly1305",
  "chrono",
  "chrono-tz",
  "dotenvy",
@@ -2289,6 +2363,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -2960,6 +3035,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,6 +3676,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,6 +3756,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,6 +16,7 @@ license = "UNLICENSED"
 [workspace.dependencies]
 axum = "0.8"
 base64 = "0.22"
+chacha20poly1305 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 dotenvy = "0.15"
@@ -36,3 +37,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = "2"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
+x25519-dalek = { version = "2", features = ["static_secrets"] }

--- a/backend/README.md
+++ b/backend/README.md
@@ -117,6 +117,12 @@ These vars control TEE/KMS-bound decrypt policy for connector refresh tokens:
 20. `TEE_ATTESTATION_DOCUMENT` (inline remote-mode attestation identity source for local smoke setups)
 21. `ENCLAVE_RPC_SHARED_SECRET` (shared secret for signed host↔enclave RPC request authentication; required outside local)
 22. `ENCLAVE_RPC_AUTH_MAX_SKEW_SECONDS` (default: `30`; max allowed timestamp skew for signed RPC requests)
+23. `ASSISTANT_INGRESS_ACTIVE_KEY_ID` (default: `assistant-ingress-v1`; key id advertised to clients for assistant ingress encryption)
+24. `ASSISTANT_INGRESS_ACTIVE_PRIVATE_KEY` (base64 X25519 private key for active assistant ingress decryption key; required outside local)
+25. `ASSISTANT_INGRESS_PREVIOUS_KEY_ID` (optional previous key id accepted for decrypt during key rotation grace windows)
+26. `ASSISTANT_INGRESS_PREVIOUS_PRIVATE_KEY` (optional previous base64 X25519 private key paired with previous key id)
+27. `ASSISTANT_INGRESS_KEY_TTL_SECONDS` (default: `900`; attested key expiry horizon returned to clients)
+28. `ASSISTANT_INGRESS_SESSION_TTL_SECONDS` (default: `3600`; encrypted assistant session-state persistence TTL)
 
 Non-local (`ALFRED_ENV=staging|production`) security guards:
 

--- a/backend/crates/api-server/Cargo.toml
+++ b/backend/crates/api-server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 axum.workspace = true
+base64.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
 redis.workspace = true

--- a/backend/crates/api-server/src/http/assistant/attested_key.rs
+++ b/backend/crates/api-server/src/http/assistant/attested_key.rs
@@ -1,0 +1,83 @@
+use axum::Json;
+use axum::extract::{Extension, State};
+use axum::response::{IntoResponse, Response};
+use shared::models::{
+    AssistantAttestedKeyAttestation, AssistantAttestedKeyRequest, AssistantAttestedKeyResponse,
+};
+
+use super::super::errors::{bad_gateway_response, bad_request_response};
+use super::super::{AppState, AuthUser};
+
+pub(crate) async fn fetch_attested_key(
+    State(state): State<AppState>,
+    Extension(_user): Extension<AuthUser>,
+    Json(request): Json<AssistantAttestedKeyRequest>,
+) -> Response {
+    if request.challenge_nonce.trim().is_empty() {
+        return bad_request_response("invalid_challenge_nonce", "challenge_nonce is required");
+    }
+    if request.request_id.trim().is_empty() {
+        return bad_request_response("invalid_request_id", "request_id is required");
+    }
+    if request.expires_at <= request.issued_at {
+        return bad_request_response(
+            "invalid_challenge_window",
+            "expires_at must be greater than issued_at",
+        );
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    if now > request.expires_at {
+        return bad_request_response("challenge_expired", "challenge has expired");
+    }
+
+    let enclave_client = shared::enclave::EnclaveRpcClient::new(
+        state.enclave_rpc.base_url.clone(),
+        state.enclave_rpc.auth.clone(),
+        state.http_client.clone(),
+    );
+    let response = match enclave_client
+        .fetch_assistant_attested_key(
+            request.challenge_nonce.clone(),
+            request.issued_at,
+            request.expires_at,
+            request.request_id.clone(),
+        )
+        .await
+    {
+        Ok(response) => response,
+        Err(_) => {
+            return bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed");
+        }
+    };
+
+    if response.challenge_nonce != request.challenge_nonce
+        || response.request_id != request.request_id
+    {
+        return bad_gateway_response(
+            "attestation_challenge_mismatch",
+            "Attested key response did not match challenge",
+        );
+    }
+
+    (
+        axum::http::StatusCode::OK,
+        Json(AssistantAttestedKeyResponse {
+            key_id: response.key_id,
+            algorithm: response.algorithm,
+            public_key: response.public_key,
+            key_expires_at: response.key_expires_at,
+            attestation: AssistantAttestedKeyAttestation {
+                runtime: response.runtime,
+                measurement: response.measurement,
+                challenge_nonce: response.challenge_nonce,
+                issued_at: response.issued_at,
+                expires_at: response.expires_at,
+                request_id: response.request_id,
+                evidence_issued_at: response.evidence_issued_at,
+                signature: response.signature,
+            },
+        }),
+    )
+        .into_response()
+}

--- a/backend/crates/api-server/src/http/assistant/mod.rs
+++ b/backend/crates/api-server/src/http/assistant/mod.rs
@@ -1,7 +1,5 @@
-mod ai_observability;
-mod fetch;
-mod memory;
+mod attested_key;
 mod query;
-mod session;
 
+pub(crate) use attested_key::fetch_attested_key;
 pub(crate) use query::query_assistant;

--- a/backend/crates/api-server/src/http/assistant/query.rs
+++ b/backend/crates/api-server/src/http/assistant/query.rs
@@ -1,285 +1,178 @@
 use axum::Json;
 use axum::extract::{Extension, State};
-use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use base64::Engine as _;
 use chrono::Utc;
-use serde_json::Value;
-use shared::llm::{
-    AssistantCapability, AssistantOutputContract, LlmExecutionSource, LlmGatewayRequest,
-    SafeOutputSource, assemble_meetings_today_context, generate_with_telemetry,
-    resolve_safe_output, sanitize_context_payload, template_for_capability,
+use shared::assistant_crypto::{
+    ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305, ASSISTANT_ENVELOPE_VERSION_V1,
 };
-use shared::models::{
-    AssistantMeetingsTodayPayload, AssistantQueryCapability, AssistantQueryRequest,
-    AssistantQueryResponse,
-};
-use shared::repos::{AssistantSessionRecord, AuditResult};
-use shared::timezone::user_local_date;
-use tracing::warn;
-use uuid::Uuid;
+use shared::enclave::EnclaveRpcError;
+use shared::models::{AssistantQueryRequest, AssistantQueryResponse};
 
 use super::super::errors::{bad_gateway_response, bad_request_response, store_error_response};
-use super::super::observability::RequestContext;
 use super::super::{AppState, AuthUser};
-use super::ai_observability::{
-    append_llm_telemetry_metadata, log_llm_telemetry, record_ai_audit_event,
-};
-use super::fetch::fetch_meetings_for_day;
-use super::memory::{
-    ASSISTANT_SESSION_TTL_SECONDS, build_updated_memory, detect_query_capability,
-    query_context_snippet, resolve_query_capability, session_memory_context,
-};
-use super::session::{build_enclave_client, build_google_session};
 
 pub(crate) async fn query_assistant(
     State(state): State<AppState>,
     Extension(user): Extension<AuthUser>,
-    Extension(request_context): Extension<RequestContext>,
-    Json(req): Json<AssistantQueryRequest>,
+    Json(request): Json<AssistantQueryRequest>,
 ) -> Response {
-    let trimmed_query = req.query.trim();
-    if trimmed_query.is_empty() {
-        return bad_request_response("invalid_query", "Query must not be empty");
+    if let Some(response) = validate_envelope_shape(&request) {
+        return response;
     }
 
     let now = Utc::now();
-    let session_id = req.session_id.unwrap_or_else(Uuid::new_v4);
-    let session_record = match state
-        .store
-        .load_assistant_session(user.user_id, session_id, now)
+    let prior_session_state = match request.session_id {
+        Some(session_id) => {
+            match state
+                .store
+                .load_assistant_encrypted_session(user.user_id, session_id, now)
+                .await
+            {
+                Ok(record) => record.map(|record| record.state),
+                Err(err) => return store_error_response(err),
+            }
+        }
+        None => None,
+    };
+
+    let enclave_client = shared::enclave::EnclaveRpcClient::new(
+        state.enclave_rpc.base_url.clone(),
+        state.enclave_rpc.auth.clone(),
+        state.http_client.clone(),
+    );
+    let response = match enclave_client
+        .process_assistant_query(user.user_id, request, prior_session_state)
         .await
     {
-        Ok(record) => record,
-        Err(err) => return store_error_response(err),
+        Ok(response) => response,
+        Err(err) => return map_assistant_enclave_error(err),
     };
 
-    let capability = match resolve_query_capability(
-        trimmed_query,
-        detect_query_capability(trimmed_query),
-        session_record
-            .as_ref()
-            .map(|record| record.last_capability.clone()),
-    ) {
-        Some(capability) => capability,
-        None => {
-            return bad_request_response(
-                "unsupported_assistant_query",
-                "Only meetings-today queries are currently supported",
+    if let Some(session_state) = &response.session_state {
+        let ttl_seconds = (session_state.expires_at - now).num_seconds();
+        if ttl_seconds <= 0 {
+            return bad_gateway_response(
+                "invalid_enclave_session_state",
+                "Secure enclave session state has expired",
             );
         }
-    };
 
-    match capability {
-        AssistantQueryCapability::MeetingsToday => {
-            handle_meetings_today_query(
-                &state,
+        if let Err(err) = state
+            .store
+            .upsert_assistant_encrypted_session(
                 user.user_id,
-                &request_context.request_id,
-                session_id,
-                trimmed_query,
-                session_record.as_ref(),
+                response.session_id,
+                session_state,
                 now,
+                ttl_seconds,
             )
             .await
+        {
+            return store_error_response(err);
         }
     }
-}
-
-async fn handle_meetings_today_query(
-    state: &AppState,
-    user_id: uuid::Uuid,
-    request_id: &str,
-    session_id: Uuid,
-    query: &str,
-    session_record: Option<&AssistantSessionRecord>,
-    now: chrono::DateTime<Utc>,
-) -> Response {
-    let session = match build_google_session(state, user_id).await {
-        Ok(session) => session,
-        Err(response) => return response,
-    };
-    let enclave_client = build_enclave_client(state);
-
-    let preferences = match state.store.get_or_create_preferences(user_id).await {
-        Ok(preferences) => preferences,
-        Err(err) => return store_error_response(err),
-    };
-
-    let calendar_day = user_local_date(Utc::now(), &preferences.time_zone);
-    let meetings = match fetch_meetings_for_day(
-        &enclave_client,
-        session.connector_request,
-        calendar_day,
-        &preferences.time_zone,
-    )
-    .await
-    {
-        Ok(meetings) => meetings,
-        Err(response) => return response,
-    };
-
-    let context = assemble_meetings_today_context(calendar_day, &meetings);
-    let raw_context_payload = match serde_json::to_value(&context) {
-        Ok(value) => value,
-        Err(_) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(shared::models::ErrorResponse {
-                    error: shared::models::ErrorBody {
-                        code: "internal_error".to_string(),
-                        message: "Unexpected server error".to_string(),
-                    },
-                }),
-            )
-                .into_response();
-        }
-    };
-    let mut context_payload = sanitize_context_payload(&raw_context_payload);
-    if context_payload != raw_context_payload {
-        warn!(user_id = %user_id, "assistant context payload sanitized by safety policy");
-    }
-    if let Value::Object(payload_object) = &mut context_payload {
-        payload_object.insert(
-            "current_query".to_string(),
-            Value::String(query_context_snippet(query)),
-        );
-    }
-    if let Some(memory_context) =
-        session_memory_context(session_record.map(|record| &record.memory))
-        && let Value::Object(payload_object) = &mut context_payload
-    {
-        payload_object.insert("session_memory".to_string(), memory_context);
-    }
-    let sanitized_context_payload = sanitize_context_payload(&context_payload);
-    if sanitized_context_payload != context_payload {
-        warn!(
-            user_id = %user_id,
-            "assistant session memory context sanitized by safety policy"
-        );
-    }
-    context_payload = sanitized_context_payload;
-
-    let request = LlmGatewayRequest::from_template(
-        template_for_capability(AssistantCapability::MeetingsSummary),
-        context_payload.clone(),
-    )
-    .with_requester_id(user_id.to_string());
-
-    let (llm_result, telemetry) = generate_with_telemetry(
-        &state.llm_gateway,
-        LlmExecutionSource::ApiAssistantQuery,
-        request,
-    )
-    .await;
-    log_llm_telemetry(user_id, request_id, &telemetry);
-
-    let mut audit_metadata = std::collections::HashMap::new();
-    audit_metadata.insert(
-        "action_source".to_string(),
-        "assistant_query_llm_orchestrator".to_string(),
-    );
-    audit_metadata.insert("request_id".to_string(), request_id.to_string());
-    audit_metadata.insert("assistant_session_id".to_string(), session_id.to_string());
-    if let Some(record) = session_record {
-        audit_metadata.insert(
-            "assistant_session_turn_count".to_string(),
-            record.turn_count.to_string(),
-        );
-        audit_metadata.insert(
-            "assistant_session_expires_at".to_string(),
-            record.expires_at.to_rfc3339(),
-        );
-    }
-    append_llm_telemetry_metadata(&mut audit_metadata, &telemetry);
-
-    let model_output = match llm_result {
-        Ok(response) => Some(response.output),
-        Err(err) => {
-            warn!(user_id = %user_id, "assistant provider request failed: {err}");
-            audit_metadata.insert("llm_error".to_string(), err.to_string());
-            None
-        }
-    };
-
-    let resolved = resolve_safe_output(
-        AssistantCapability::MeetingsSummary,
-        model_output.as_ref(),
-        &context_payload,
-    );
-    let output_source = match resolved.source {
-        SafeOutputSource::ModelOutput => "model_output",
-        SafeOutputSource::DeterministicFallback => {
-            warn!(user_id = %user_id, "assistant returned deterministic fallback output");
-            "deterministic_fallback"
-        }
-    };
-    audit_metadata.insert("llm_output_source".to_string(), output_source.to_string());
-
-    let AssistantOutputContract::MeetingsSummary(contract) = resolved.contract else {
-        return bad_gateway_response(
-            "assistant_invalid_output",
-            "Assistant provider returned invalid output",
-        );
-    };
-
-    let payload = AssistantMeetingsTodayPayload {
-        title: contract.output.title,
-        summary: contract.output.summary.clone(),
-        key_points: contract.output.key_points,
-        follow_ups: contract.output.follow_ups,
-    };
-
-    let updated_memory = build_updated_memory(
-        session_record.map(|record| &record.memory),
-        query,
-        &payload.summary,
-        AssistantQueryCapability::MeetingsToday,
-        now,
-    );
-
-    let session_persisted = match state
-        .store
-        .upsert_assistant_session(
-            user_id,
-            session_id,
-            AssistantQueryCapability::MeetingsToday,
-            &updated_memory,
-            now,
-            ASSISTANT_SESSION_TTL_SECONDS,
-        )
-        .await
-    {
-        Ok(()) => true,
-        Err(err) => {
-            warn!(
-                user_id = %user_id,
-                session_id = %session_id,
-                "failed to persist assistant session memory: {err}"
-            );
-            false
-        }
-    };
-    audit_metadata.insert(
-        "assistant_session_persisted".to_string(),
-        session_persisted.to_string(),
-    );
-
-    let audit_result =
-        if telemetry.outcome == "success" && output_source == "model_output" && session_persisted {
-            AuditResult::Success
-        } else {
-            AuditResult::Failure
-        };
-    record_ai_audit_event(state, user_id, request_id, audit_result, &audit_metadata).await;
 
     (
-        StatusCode::OK,
+        axum::http::StatusCode::OK,
         Json(AssistantQueryResponse {
-            session_id,
-            capability: AssistantQueryCapability::MeetingsToday,
-            display_text: payload.summary.clone(),
-            payload,
+            session_id: response.session_id,
+            envelope: response.envelope,
         }),
     )
         .into_response()
+}
+
+fn validate_envelope_shape(request: &AssistantQueryRequest) -> Option<Response> {
+    let envelope = &request.envelope;
+    if envelope.version != ASSISTANT_ENVELOPE_VERSION_V1 {
+        return Some(bad_request_response(
+            "invalid_envelope_version",
+            "assistant envelope version is not supported",
+        ));
+    }
+
+    if envelope.algorithm != ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305 {
+        return Some(bad_request_response(
+            "invalid_envelope_algorithm",
+            "assistant envelope algorithm is not supported",
+        ));
+    }
+
+    if envelope.key_id.trim().is_empty() {
+        return Some(bad_request_response("invalid_key_id", "key_id is required"));
+    }
+
+    if envelope.request_id.trim().is_empty() {
+        return Some(bad_request_response(
+            "invalid_request_id",
+            "request_id is required",
+        ));
+    }
+
+    let client_public_key = match base64::engine::general_purpose::STANDARD
+        .decode(envelope.client_ephemeral_public_key.as_bytes())
+    {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return Some(bad_request_response(
+                "invalid_client_public_key",
+                "client_ephemeral_public_key must be valid base64",
+            ));
+        }
+    };
+    if client_public_key.len() != 32 {
+        return Some(bad_request_response(
+            "invalid_client_public_key",
+            "client_ephemeral_public_key must decode to 32 bytes",
+        ));
+    }
+
+    let nonce = match base64::engine::general_purpose::STANDARD.decode(envelope.nonce.as_bytes()) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return Some(bad_request_response(
+                "invalid_nonce",
+                "nonce must be valid base64",
+            ));
+        }
+    };
+    if nonce.len() != 12 {
+        return Some(bad_request_response(
+            "invalid_nonce",
+            "nonce must decode to 12 bytes",
+        ));
+    }
+
+    if base64::engine::general_purpose::STANDARD
+        .decode(envelope.ciphertext.as_bytes())
+        .is_err()
+    {
+        return Some(bad_request_response(
+            "invalid_ciphertext",
+            "ciphertext must be valid base64",
+        ));
+    }
+
+    None
+}
+
+fn map_assistant_enclave_error(err: EnclaveRpcError) -> Response {
+    match err {
+        EnclaveRpcError::RpcContractRejected { .. } => bad_request_response(
+            "invalid_enclave_request",
+            "Encrypted assistant request rejected",
+        ),
+        EnclaveRpcError::RpcUnauthorized { .. }
+        | EnclaveRpcError::RpcTransportUnavailable { .. }
+        | EnclaveRpcError::RpcResponseInvalid { .. }
+        | EnclaveRpcError::DecryptNotAuthorized { .. }
+        | EnclaveRpcError::ConnectorTokenDecryptFailed { .. }
+        | EnclaveRpcError::ConnectorTokenUnavailable
+        | EnclaveRpcError::ProviderRequestUnavailable { .. }
+        | EnclaveRpcError::ProviderRequestFailed { .. }
+        | EnclaveRpcError::ProviderResponseInvalid { .. } => {
+            bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
+        }
+    }
 }

--- a/backend/crates/enclave-runtime/Cargo.toml
+++ b/backend/crates/enclave-runtime/Cargo.toml
@@ -14,4 +14,5 @@ reqwest.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true
 shared = { path = "../shared" }

--- a/backend/crates/enclave-runtime/src/main.rs
+++ b/backend/crates/enclave-runtime/src/main.rs
@@ -120,6 +120,14 @@ async fn main() {
             "/v1/rpc/google/gmail/urgent-candidates",
             post(http::fetch_google_urgent_email_candidates),
         )
+        .route(
+            "/v1/rpc/assistant/attested-key",
+            post(http::fetch_assistant_attested_key),
+        )
+        .route(
+            "/v1/rpc/assistant/query",
+            post(http::process_assistant_query),
+        )
         .with_state(RuntimeState {
             config: config.clone(),
             enclave_service,

--- a/backend/crates/shared/Cargo.toml
+++ b/backend/crates/shared/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 base64.workspace = true
+chacha20poly1305.workspace = true
 chrono.workspace = true
 chrono-tz.workspace = true
 dotenvy.workspace = true
@@ -22,6 +23,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 uuid.workspace = true
+x25519-dalek.workspace = true
 
 [dev-dependencies]
 axum.workspace = true

--- a/backend/crates/shared/src/assistant_crypto.rs
+++ b/backend/crates/shared/src/assistant_crypto.rs
@@ -1,0 +1,408 @@
+use base64::Engine as _;
+use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+use chacha20poly1305::{ChaCha20Poly1305, Nonce};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+use crate::models::{
+    AssistantEncryptedRequestEnvelope, AssistantEncryptedResponseEnvelope,
+    AssistantPlaintextQueryRequest, AssistantPlaintextQueryResponse,
+};
+
+pub const ASSISTANT_ENVELOPE_VERSION_V1: &str = "v1";
+pub const ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305: &str = "x25519-chacha20poly1305";
+
+#[derive(Debug, Clone)]
+pub struct AssistantIngressKeyMaterial {
+    pub key_id: String,
+    pub private_key: [u8; 32],
+    pub public_key: String,
+    pub key_expires_at: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct AssistantIngressKeyring {
+    pub active: AssistantIngressKeyMaterial,
+    pub previous: Option<AssistantIngressKeyMaterial>,
+}
+
+impl AssistantIngressKeyring {
+    pub fn key_for_id(&self, key_id: &str) -> Option<&AssistantIngressKeyMaterial> {
+        if self.active.key_id == key_id {
+            return Some(&self.active);
+        }
+
+        self.previous.as_ref().filter(|key| key.key_id == key_id)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AssistantCryptoError {
+    #[error("assistant envelope version is unsupported")]
+    UnsupportedVersion,
+    #[error("assistant envelope algorithm is unsupported")]
+    UnsupportedAlgorithm,
+    #[error("assistant request_id is required")]
+    MissingRequestId,
+    #[error("assistant ingress key_id is not recognized")]
+    UnknownKeyId,
+    #[error("assistant envelope field is invalid base64: {field}")]
+    InvalidBase64Field { field: &'static str },
+    #[error("assistant envelope nonce must be exactly 12 bytes")]
+    InvalidNonceLength,
+    #[error("assistant public key is invalid")]
+    InvalidPublicKey,
+    #[error("assistant ciphertext failed authentication")]
+    DecryptFailed,
+    #[error("assistant plaintext payload is invalid: {0}")]
+    InvalidPlaintextPayload(String),
+    #[error("assistant response encryption failed")]
+    EncryptFailed,
+}
+
+pub fn decrypt_assistant_request(
+    keyring: &AssistantIngressKeyring,
+    envelope: &AssistantEncryptedRequestEnvelope,
+) -> Result<(AssistantPlaintextQueryRequest, AssistantIngressKeyMaterial), AssistantCryptoError> {
+    validate_common_envelope_fields(
+        envelope.version.as_str(),
+        envelope.algorithm.as_str(),
+        envelope.request_id.as_str(),
+    )?;
+
+    let key = keyring
+        .key_for_id(envelope.key_id.as_str())
+        .ok_or(AssistantCryptoError::UnknownKeyId)?
+        .clone();
+
+    let client_public_key_bytes = decode_base64_field(
+        envelope.client_ephemeral_public_key.as_str(),
+        "client_ephemeral_public_key",
+    )?;
+    let client_public_key_bytes: [u8; 32] = client_public_key_bytes
+        .try_into()
+        .map_err(|_| AssistantCryptoError::InvalidPublicKey)?;
+    let client_public_key = PublicKey::from(client_public_key_bytes);
+
+    let nonce_bytes = decode_base64_field(envelope.nonce.as_str(), "nonce")?;
+    if nonce_bytes.len() != 12 {
+        return Err(AssistantCryptoError::InvalidNonceLength);
+    }
+
+    let ciphertext = decode_base64_field(envelope.ciphertext.as_str(), "ciphertext")?;
+    let decrypt_key = derive_directional_key(
+        key.private_key,
+        client_public_key,
+        envelope.request_id.as_str(),
+        b"request",
+    );
+
+    let cipher = ChaCha20Poly1305::new_from_slice(&decrypt_key)
+        .map_err(|_| AssistantCryptoError::DecryptFailed)?;
+    let plaintext = cipher
+        .decrypt(
+            Nonce::from_slice(&nonce_bytes),
+            Payload {
+                msg: ciphertext.as_slice(),
+                aad: envelope.request_id.as_bytes(),
+            },
+        )
+        .map_err(|_| AssistantCryptoError::DecryptFailed)?;
+
+    let parsed = serde_json::from_slice::<AssistantPlaintextQueryRequest>(&plaintext)
+        .map_err(|err| AssistantCryptoError::InvalidPlaintextPayload(err.to_string()))?;
+
+    Ok((parsed, key))
+}
+
+pub fn encrypt_assistant_response(
+    key: &AssistantIngressKeyMaterial,
+    request_id: &str,
+    client_ephemeral_public_key_b64: &str,
+    response: &AssistantPlaintextQueryResponse,
+) -> Result<AssistantEncryptedResponseEnvelope, AssistantCryptoError> {
+    validate_common_envelope_fields(
+        ASSISTANT_ENVELOPE_VERSION_V1,
+        ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305,
+        request_id,
+    )?;
+
+    let client_public_key_bytes = decode_base64_field(
+        client_ephemeral_public_key_b64,
+        "client_ephemeral_public_key",
+    )?;
+    let client_public_key_bytes: [u8; 32] = client_public_key_bytes
+        .try_into()
+        .map_err(|_| AssistantCryptoError::InvalidPublicKey)?;
+    let client_public_key = PublicKey::from(client_public_key_bytes);
+
+    let encrypt_key =
+        derive_directional_key(key.private_key, client_public_key, request_id, b"response");
+    let cipher = ChaCha20Poly1305::new_from_slice(&encrypt_key)
+        .map_err(|_| AssistantCryptoError::EncryptFailed)?;
+
+    let plaintext = serde_json::to_vec(response)
+        .map_err(|err| AssistantCryptoError::InvalidPlaintextPayload(err.to_string()))?;
+    let nonce_bytes = build_nonce_bytes();
+    let ciphertext = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce_bytes),
+            Payload {
+                msg: plaintext.as_slice(),
+                aad: request_id.as_bytes(),
+            },
+        )
+        .map_err(|_| AssistantCryptoError::EncryptFailed)?;
+
+    Ok(AssistantEncryptedResponseEnvelope {
+        version: ASSISTANT_ENVELOPE_VERSION_V1.to_string(),
+        algorithm: ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305.to_string(),
+        key_id: key.key_id.clone(),
+        request_id: request_id.to_string(),
+        nonce: base64::engine::general_purpose::STANDARD.encode(nonce_bytes),
+        ciphertext: base64::engine::general_purpose::STANDARD.encode(ciphertext),
+    })
+}
+
+pub fn derive_public_key_b64(private_key: [u8; 32]) -> String {
+    let secret = StaticSecret::from(private_key);
+    let public = PublicKey::from(&secret);
+    base64::engine::general_purpose::STANDARD.encode(public.as_bytes())
+}
+
+fn decode_base64_field(value: &str, field: &'static str) -> Result<Vec<u8>, AssistantCryptoError> {
+    base64::engine::general_purpose::STANDARD
+        .decode(value.as_bytes())
+        .map_err(|_| AssistantCryptoError::InvalidBase64Field { field })
+}
+
+fn validate_common_envelope_fields(
+    version: &str,
+    algorithm: &str,
+    request_id: &str,
+) -> Result<(), AssistantCryptoError> {
+    if version != ASSISTANT_ENVELOPE_VERSION_V1 {
+        return Err(AssistantCryptoError::UnsupportedVersion);
+    }
+    if algorithm != ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305 {
+        return Err(AssistantCryptoError::UnsupportedAlgorithm);
+    }
+    if request_id.trim().is_empty() {
+        return Err(AssistantCryptoError::MissingRequestId);
+    }
+    Ok(())
+}
+
+fn derive_directional_key(
+    server_private_key_bytes: [u8; 32],
+    client_public_key: PublicKey,
+    request_id: &str,
+    direction: &[u8],
+) -> [u8; 32] {
+    let secret = StaticSecret::from(server_private_key_bytes);
+    let shared_secret = secret.diffie_hellman(&client_public_key);
+
+    let mut hasher = Sha256::new();
+    hasher.update(shared_secret.as_bytes());
+    hasher.update(b"|");
+    hasher.update(request_id.as_bytes());
+    hasher.update(b"|");
+    hasher.update(direction);
+    hasher.finalize().into()
+}
+
+fn build_nonce_bytes() -> [u8; 12] {
+    let uuid_bytes = uuid::Uuid::new_v4();
+    let mut nonce = [0_u8; 12];
+    nonce.copy_from_slice(&uuid_bytes.as_bytes()[..12]);
+    nonce
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+    use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+    use chacha20poly1305::{ChaCha20Poly1305, Nonce};
+    use sha2::Digest;
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    use super::{
+        ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305, ASSISTANT_ENVELOPE_VERSION_V1,
+        AssistantIngressKeyMaterial, AssistantIngressKeyring, decrypt_assistant_request,
+        derive_public_key_b64, encrypt_assistant_response,
+    };
+    use crate::models::{
+        AssistantEncryptedRequestEnvelope, AssistantMeetingsTodayPayload,
+        AssistantPlaintextQueryRequest, AssistantPlaintextQueryResponse, AssistantQueryCapability,
+    };
+
+    #[test]
+    fn decrypt_request_and_encrypt_response_round_trip() {
+        let server_private_key = [9_u8; 32];
+        let client_private_key = StaticSecret::from([5_u8; 32]);
+        let request_id = "req-123";
+        let request = AssistantPlaintextQueryRequest {
+            query: "meetings today".to_string(),
+            session_id: Some(uuid::Uuid::new_v4()),
+        };
+        let request_envelope = encrypt_request_for_test(
+            server_private_key,
+            &client_private_key,
+            request_id,
+            &request,
+        );
+
+        let keyring = AssistantIngressKeyring {
+            active: AssistantIngressKeyMaterial {
+                key_id: "assistant-ingress-v1".to_string(),
+                private_key: server_private_key,
+                public_key: derive_public_key_b64(server_private_key),
+                key_expires_at: chrono::Utc::now().timestamp() + 3600,
+            },
+            previous: None,
+        };
+
+        let (decrypted, selected_key) =
+            decrypt_assistant_request(&keyring, &request_envelope).expect("decrypt should pass");
+        assert_eq!(decrypted.query, request.query);
+        assert_eq!(selected_key.key_id, "assistant-ingress-v1");
+
+        let plaintext_response = AssistantPlaintextQueryResponse {
+            session_id: uuid::Uuid::new_v4(),
+            capability: AssistantQueryCapability::MeetingsToday,
+            display_text: "encrypted ingress accepted".to_string(),
+            payload: AssistantMeetingsTodayPayload {
+                title: "Encrypted ingress active".to_string(),
+                summary: "encrypted ingress accepted".to_string(),
+                key_points: vec!["phase 1 route live".to_string()],
+                follow_ups: vec![],
+            },
+        };
+        let response_envelope = encrypt_assistant_response(
+            &keyring.active,
+            request_id,
+            request_envelope.client_ephemeral_public_key.as_str(),
+            &plaintext_response,
+        )
+        .expect("encrypt response should pass");
+
+        let decrypted_response = decrypt_response_for_test(
+            &client_private_key,
+            request_id,
+            response_envelope.nonce.as_str(),
+            response_envelope.ciphertext.as_str(),
+            server_private_key,
+        );
+        assert_eq!(
+            decrypted_response.display_text,
+            "encrypted ingress accepted"
+        );
+    }
+
+    #[test]
+    fn decrypt_rejects_unknown_key_id() {
+        let keyring = AssistantIngressKeyring {
+            active: AssistantIngressKeyMaterial {
+                key_id: "assistant-ingress-v1".to_string(),
+                private_key: [9_u8; 32],
+                public_key: derive_public_key_b64([9_u8; 32]),
+                key_expires_at: chrono::Utc::now().timestamp() + 3600,
+            },
+            previous: None,
+        };
+
+        let envelope = AssistantEncryptedRequestEnvelope {
+            version: ASSISTANT_ENVELOPE_VERSION_V1.to_string(),
+            algorithm: ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305.to_string(),
+            key_id: "missing-key".to_string(),
+            request_id: "req-1".to_string(),
+            client_ephemeral_public_key: base64::engine::general_purpose::STANDARD
+                .encode([1_u8; 32]),
+            nonce: base64::engine::general_purpose::STANDARD.encode([1_u8; 12]),
+            ciphertext: base64::engine::general_purpose::STANDARD.encode([1_u8; 16]),
+        };
+
+        assert!(decrypt_assistant_request(&keyring, &envelope).is_err());
+    }
+
+    fn encrypt_request_for_test(
+        server_private_key: [u8; 32],
+        client_private_key: &StaticSecret,
+        request_id: &str,
+        request: &AssistantPlaintextQueryRequest,
+    ) -> AssistantEncryptedRequestEnvelope {
+        let server_public_key = PublicKey::from(&StaticSecret::from(server_private_key));
+        let shared_secret = client_private_key.diffie_hellman(&server_public_key);
+
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(shared_secret.as_bytes());
+        hasher.update(b"|");
+        hasher.update(request_id.as_bytes());
+        hasher.update(b"|");
+        hasher.update(b"request");
+        let derived_key: [u8; 32] = hasher.finalize().into();
+
+        let cipher = ChaCha20Poly1305::new_from_slice(&derived_key).expect("cipher should init");
+        let nonce = [3_u8; 12];
+        let plaintext = serde_json::to_vec(request).expect("request should serialize");
+        let ciphertext = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: plaintext.as_slice(),
+                    aad: request_id.as_bytes(),
+                },
+            )
+            .expect("request encryption should pass");
+
+        AssistantEncryptedRequestEnvelope {
+            version: ASSISTANT_ENVELOPE_VERSION_V1.to_string(),
+            algorithm: ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305.to_string(),
+            key_id: "assistant-ingress-v1".to_string(),
+            request_id: request_id.to_string(),
+            client_ephemeral_public_key: base64::engine::general_purpose::STANDARD
+                .encode(PublicKey::from(client_private_key).as_bytes()),
+            nonce: base64::engine::general_purpose::STANDARD.encode(nonce),
+            ciphertext: base64::engine::general_purpose::STANDARD.encode(ciphertext),
+        }
+    }
+
+    fn decrypt_response_for_test(
+        client_private_key: &StaticSecret,
+        request_id: &str,
+        nonce_b64: &str,
+        ciphertext_b64: &str,
+        server_private_key: [u8; 32],
+    ) -> AssistantPlaintextQueryResponse {
+        let server_public_key = PublicKey::from(&StaticSecret::from(server_private_key));
+        let shared_secret = client_private_key.diffie_hellman(&server_public_key);
+
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(shared_secret.as_bytes());
+        hasher.update(b"|");
+        hasher.update(request_id.as_bytes());
+        hasher.update(b"|");
+        hasher.update(b"response");
+        let derived_key: [u8; 32] = hasher.finalize().into();
+
+        let cipher = ChaCha20Poly1305::new_from_slice(&derived_key).expect("cipher should init");
+        let nonce = base64::engine::general_purpose::STANDARD
+            .decode(nonce_b64.as_bytes())
+            .expect("nonce should decode");
+        let ciphertext = base64::engine::general_purpose::STANDARD
+            .decode(ciphertext_b64.as_bytes())
+            .expect("ciphertext should decode");
+        let plaintext = cipher
+            .decrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: ciphertext.as_slice(),
+                    aad: request_id.as_bytes(),
+                },
+            )
+            .expect("response decryption should pass");
+
+        serde_json::from_slice(&plaintext).expect("response should parse")
+    }
+}

--- a/backend/crates/shared/src/enclave/client.rs
+++ b/backend/crates/shared/src/enclave/client.rs
@@ -4,15 +4,19 @@ use super::{
     ENCLAVE_RPC_AUTH_NONCE_HEADER, ENCLAVE_RPC_AUTH_SIGNATURE_HEADER,
     ENCLAVE_RPC_AUTH_TIMESTAMP_HEADER, ENCLAVE_RPC_CONTRACT_VERSION,
     ENCLAVE_RPC_CONTRACT_VERSION_HEADER, ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
-    ENCLAVE_RPC_PATH_FETCH_GOOGLE_CALENDAR_EVENTS,
-    ENCLAVE_RPC_PATH_FETCH_GOOGLE_URGENT_EMAIL_CANDIDATES, ENCLAVE_RPC_PATH_REVOKE_GOOGLE_TOKEN,
+    ENCLAVE_RPC_PATH_FETCH_ASSISTANT_ATTESTED_KEY, ENCLAVE_RPC_PATH_FETCH_GOOGLE_CALENDAR_EVENTS,
+    ENCLAVE_RPC_PATH_FETCH_GOOGLE_URGENT_EMAIL_CANDIDATES,
+    ENCLAVE_RPC_PATH_PROCESS_ASSISTANT_QUERY, ENCLAVE_RPC_PATH_REVOKE_GOOGLE_TOKEN,
     EnclaveRpcAuthConfig, EnclaveRpcError, EnclaveRpcErrorEnvelope,
     EnclaveRpcExchangeGoogleTokenRequest, EnclaveRpcExchangeGoogleTokenResponse,
+    EnclaveRpcFetchAssistantAttestedKeyRequest, EnclaveRpcFetchAssistantAttestedKeyResponse,
     EnclaveRpcFetchGoogleCalendarEventsRequest, EnclaveRpcFetchGoogleCalendarEventsResponse,
     EnclaveRpcFetchGoogleUrgentEmailCandidatesRequest,
-    EnclaveRpcFetchGoogleUrgentEmailCandidatesResponse, EnclaveRpcRevokeGoogleTokenRequest,
+    EnclaveRpcFetchGoogleUrgentEmailCandidatesResponse, EnclaveRpcProcessAssistantQueryRequest,
+    EnclaveRpcProcessAssistantQueryResponse, EnclaveRpcRevokeGoogleTokenRequest,
     EnclaveRpcRevokeGoogleTokenResponse, ExchangeGoogleTokenResponse,
-    FetchGoogleCalendarEventsResponse, FetchGoogleUrgentEmailCandidatesResponse, ProviderOperation,
+    FetchAssistantAttestedKeyResponse, FetchGoogleCalendarEventsResponse,
+    FetchGoogleUrgentEmailCandidatesResponse, ProcessAssistantQueryResponse, ProviderOperation,
     RevokeGoogleTokenResponse, sign_rpc_request,
 };
 
@@ -142,6 +146,71 @@ impl EnclaveRpcClient {
         if response.request_id != payload.request_id {
             return Err(EnclaveRpcError::RpcResponseInvalid {
                 message: "enclave rpc response request_id mismatch for gmail fetch".to_string(),
+            });
+        }
+
+        response.try_into()
+    }
+
+    pub async fn fetch_assistant_attested_key(
+        &self,
+        challenge_nonce: String,
+        issued_at: i64,
+        expires_at: i64,
+        request_id: String,
+    ) -> Result<FetchAssistantAttestedKeyResponse, EnclaveRpcError> {
+        let payload = EnclaveRpcFetchAssistantAttestedKeyRequest {
+            contract_version: ENCLAVE_RPC_CONTRACT_VERSION.to_string(),
+            request_id,
+            challenge_nonce,
+            issued_at,
+            expires_at,
+        };
+
+        let response: EnclaveRpcFetchAssistantAttestedKeyResponse = self
+            .send_enclave_rpc(
+                ProviderOperation::AssistantAttestedKey,
+                ENCLAVE_RPC_PATH_FETCH_ASSISTANT_ATTESTED_KEY,
+                &payload,
+            )
+            .await?;
+
+        if response.request_id != payload.request_id {
+            return Err(EnclaveRpcError::RpcResponseInvalid {
+                message: "enclave rpc response request_id mismatch for assistant key fetch"
+                    .to_string(),
+            });
+        }
+
+        response.try_into()
+    }
+
+    pub async fn process_assistant_query(
+        &self,
+        user_id: uuid::Uuid,
+        request: crate::models::AssistantQueryRequest,
+        prior_session_state: Option<crate::models::AssistantSessionStateEnvelope>,
+    ) -> Result<ProcessAssistantQueryResponse, EnclaveRpcError> {
+        let payload = EnclaveRpcProcessAssistantQueryRequest {
+            contract_version: ENCLAVE_RPC_CONTRACT_VERSION.to_string(),
+            request_id: uuid::Uuid::new_v4().to_string(),
+            user_id,
+            envelope: request.envelope,
+            session_id: request.session_id,
+            prior_session_state,
+        };
+
+        let response: EnclaveRpcProcessAssistantQueryResponse = self
+            .send_enclave_rpc(
+                ProviderOperation::AssistantQuery,
+                ENCLAVE_RPC_PATH_PROCESS_ASSISTANT_QUERY,
+                &payload,
+            )
+            .await?;
+
+        if response.request_id != payload.request_id {
+            return Err(EnclaveRpcError::RpcResponseInvalid {
+                message: "enclave rpc response request_id mismatch for assistant query".to_string(),
             });
         }
 
@@ -335,6 +404,70 @@ impl TryFrom<EnclaveRpcFetchGoogleUrgentEmailCandidatesResponse>
 
         Ok(Self {
             candidates: value.candidates,
+            attested_identity: value.attested_identity,
+        })
+    }
+}
+
+impl TryFrom<EnclaveRpcFetchAssistantAttestedKeyResponse> for FetchAssistantAttestedKeyResponse {
+    type Error = EnclaveRpcError;
+
+    fn try_from(value: EnclaveRpcFetchAssistantAttestedKeyResponse) -> Result<Self, Self::Error> {
+        if value.contract_version != ENCLAVE_RPC_CONTRACT_VERSION {
+            return Err(EnclaveRpcError::RpcResponseInvalid {
+                message: format!(
+                    "enclave rpc contract mismatch: expected={}, got={}",
+                    ENCLAVE_RPC_CONTRACT_VERSION, value.contract_version
+                ),
+            });
+        }
+
+        if value.request_id.trim().is_empty() {
+            return Err(EnclaveRpcError::RpcResponseInvalid {
+                message: "missing request_id in assistant key response".to_string(),
+            });
+        }
+
+        Ok(Self {
+            request_id: value.request_id,
+            runtime: value.runtime,
+            measurement: value.measurement,
+            challenge_nonce: value.challenge_nonce,
+            issued_at: value.issued_at,
+            expires_at: value.expires_at,
+            evidence_issued_at: value.evidence_issued_at,
+            key_id: value.key_id,
+            algorithm: value.algorithm,
+            public_key: value.public_key,
+            key_expires_at: value.key_expires_at,
+            signature: value.signature,
+        })
+    }
+}
+
+impl TryFrom<EnclaveRpcProcessAssistantQueryResponse> for ProcessAssistantQueryResponse {
+    type Error = EnclaveRpcError;
+
+    fn try_from(value: EnclaveRpcProcessAssistantQueryResponse) -> Result<Self, Self::Error> {
+        if value.contract_version != ENCLAVE_RPC_CONTRACT_VERSION {
+            return Err(EnclaveRpcError::RpcResponseInvalid {
+                message: format!(
+                    "enclave rpc contract mismatch: expected={}, got={}",
+                    ENCLAVE_RPC_CONTRACT_VERSION, value.contract_version
+                ),
+            });
+        }
+
+        if value.request_id.trim().is_empty() {
+            return Err(EnclaveRpcError::RpcResponseInvalid {
+                message: "missing request_id in assistant query response".to_string(),
+            });
+        }
+
+        Ok(Self {
+            session_id: value.session_id,
+            envelope: value.envelope,
+            session_state: value.session_state,
             attested_identity: value.attested_identity,
         })
     }

--- a/backend/crates/shared/src/enclave/contract.rs
+++ b/backend/crates/shared/src/enclave/contract.rs
@@ -6,6 +6,8 @@ pub const ENCLAVE_RPC_PATH_REVOKE_GOOGLE_TOKEN: &str = "/v1/rpc/google/token/rev
 pub const ENCLAVE_RPC_PATH_FETCH_GOOGLE_CALENDAR_EVENTS: &str = "/v1/rpc/google/calendar/events";
 pub const ENCLAVE_RPC_PATH_FETCH_GOOGLE_URGENT_EMAIL_CANDIDATES: &str =
     "/v1/rpc/google/gmail/urgent-candidates";
+pub const ENCLAVE_RPC_PATH_FETCH_ASSISTANT_ATTESTED_KEY: &str = "/v1/rpc/assistant/attested-key";
+pub const ENCLAVE_RPC_PATH_PROCESS_ASSISTANT_QUERY: &str = "/v1/rpc/assistant/query";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AttestedIdentityPayload {
@@ -94,6 +96,55 @@ pub struct EnclaveRpcFetchGoogleUrgentEmailCandidatesResponse {
     pub contract_version: String,
     pub request_id: String,
     pub candidates: Vec<EnclaveGoogleEmailCandidate>,
+    pub attested_identity: AttestedIdentityPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveRpcFetchAssistantAttestedKeyRequest {
+    pub contract_version: String,
+    pub request_id: String,
+    pub challenge_nonce: String,
+    pub issued_at: i64,
+    pub expires_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveRpcFetchAssistantAttestedKeyResponse {
+    pub contract_version: String,
+    pub request_id: String,
+    pub runtime: String,
+    pub measurement: String,
+    pub challenge_nonce: String,
+    pub issued_at: i64,
+    pub expires_at: i64,
+    pub evidence_issued_at: i64,
+    pub key_id: String,
+    pub algorithm: String,
+    pub public_key: String,
+    pub key_expires_at: i64,
+    pub signature: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveRpcProcessAssistantQueryRequest {
+    pub contract_version: String,
+    pub request_id: String,
+    pub user_id: uuid::Uuid,
+    pub envelope: crate::models::AssistantEncryptedRequestEnvelope,
+    #[serde(default)]
+    pub session_id: Option<uuid::Uuid>,
+    #[serde(default)]
+    pub prior_session_state: Option<crate::models::AssistantSessionStateEnvelope>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnclaveRpcProcessAssistantQueryResponse {
+    pub contract_version: String,
+    pub request_id: String,
+    pub session_id: uuid::Uuid,
+    pub envelope: crate::models::AssistantEncryptedResponseEnvelope,
+    #[serde(default)]
+    pub session_state: Option<crate::models::AssistantSessionStateEnvelope>,
     pub attested_identity: AttestedIdentityPayload,
 }
 

--- a/backend/crates/shared/src/enclave/mod.rs
+++ b/backend/crates/shared/src/enclave/mod.rs
@@ -14,14 +14,17 @@ use uuid::Uuid;
 pub use client::EnclaveRpcClient;
 pub use contract::{
     AttestedIdentityPayload, ENCLAVE_RPC_CONTRACT_VERSION, ENCLAVE_RPC_PATH_EXCHANGE_GOOGLE_TOKEN,
-    ENCLAVE_RPC_PATH_FETCH_GOOGLE_CALENDAR_EVENTS,
-    ENCLAVE_RPC_PATH_FETCH_GOOGLE_URGENT_EMAIL_CANDIDATES, ENCLAVE_RPC_PATH_REVOKE_GOOGLE_TOKEN,
+    ENCLAVE_RPC_PATH_FETCH_ASSISTANT_ATTESTED_KEY, ENCLAVE_RPC_PATH_FETCH_GOOGLE_CALENDAR_EVENTS,
+    ENCLAVE_RPC_PATH_FETCH_GOOGLE_URGENT_EMAIL_CANDIDATES,
+    ENCLAVE_RPC_PATH_PROCESS_ASSISTANT_QUERY, ENCLAVE_RPC_PATH_REVOKE_GOOGLE_TOKEN,
     EnclaveGoogleCalendarAttendee, EnclaveGoogleCalendarEvent, EnclaveGoogleCalendarEventDateTime,
     EnclaveGoogleEmailCandidate, EnclaveRpcErrorEnvelope, EnclaveRpcErrorPayload,
     EnclaveRpcExchangeGoogleTokenRequest, EnclaveRpcExchangeGoogleTokenResponse,
+    EnclaveRpcFetchAssistantAttestedKeyRequest, EnclaveRpcFetchAssistantAttestedKeyResponse,
     EnclaveRpcFetchGoogleCalendarEventsRequest, EnclaveRpcFetchGoogleCalendarEventsResponse,
     EnclaveRpcFetchGoogleUrgentEmailCandidatesRequest,
-    EnclaveRpcFetchGoogleUrgentEmailCandidatesResponse, EnclaveRpcRevokeGoogleTokenRequest,
+    EnclaveRpcFetchGoogleUrgentEmailCandidatesResponse, EnclaveRpcProcessAssistantQueryRequest,
+    EnclaveRpcProcessAssistantQueryResponse, EnclaveRpcRevokeGoogleTokenRequest,
     EnclaveRpcRevokeGoogleTokenResponse,
 };
 pub use service::EnclaveOperationService;
@@ -68,12 +71,38 @@ pub struct FetchGoogleUrgentEmailCandidatesResponse {
     pub attested_identity: AttestedIdentityPayload,
 }
 
+#[derive(Debug, Clone)]
+pub struct FetchAssistantAttestedKeyResponse {
+    pub request_id: String,
+    pub runtime: String,
+    pub measurement: String,
+    pub challenge_nonce: String,
+    pub issued_at: i64,
+    pub expires_at: i64,
+    pub evidence_issued_at: i64,
+    pub key_id: String,
+    pub algorithm: String,
+    pub public_key: String,
+    pub key_expires_at: i64,
+    pub signature: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProcessAssistantQueryResponse {
+    pub session_id: Uuid,
+    pub envelope: crate::models::AssistantEncryptedResponseEnvelope,
+    pub session_state: Option<crate::models::AssistantSessionStateEnvelope>,
+    pub attested_identity: AttestedIdentityPayload,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderOperation {
     TokenRefresh,
     TokenRevoke,
     CalendarFetch,
     GmailFetch,
+    AssistantAttestedKey,
+    AssistantQuery,
 }
 
 impl fmt::Display for ProviderOperation {
@@ -83,6 +112,8 @@ impl fmt::Display for ProviderOperation {
             Self::TokenRevoke => write!(f, "token_revoke"),
             Self::CalendarFetch => write!(f, "calendar_fetch"),
             Self::GmailFetch => write!(f, "gmail_fetch"),
+            Self::AssistantAttestedKey => write!(f, "assistant_attested_key"),
+            Self::AssistantQuery => write!(f, "assistant_query"),
         }
     }
 }

--- a/backend/crates/shared/src/enclave_runtime.rs
+++ b/backend/crates/shared/src/enclave_runtime.rs
@@ -101,6 +101,30 @@ pub struct AttestationChallengeResponse {
     pub signature: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantAttestedKeyChallengeRequest {
+    pub challenge_nonce: String,
+    pub issued_at: i64,
+    pub expires_at: i64,
+    pub request_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantAttestedKeyChallengeResponse {
+    pub runtime: String,
+    pub measurement: String,
+    pub challenge_nonce: String,
+    pub issued_at: i64,
+    pub expires_at: i64,
+    pub request_id: String,
+    pub evidence_issued_at: i64,
+    pub key_id: String,
+    pub algorithm: String,
+    pub public_key: String,
+    pub key_expires_at: i64,
+    pub signature: Option<String>,
+}
+
 pub fn attestation_signing_payload(response: &AttestationChallengeResponse) -> String {
     format!(
         "{}|{}|{}|{}|{}|{}|{}|{}",
@@ -112,6 +136,25 @@ pub fn attestation_signing_payload(response: &AttestationChallengeResponse) -> S
         response.operation_purpose,
         response.request_id,
         response.evidence_issued_at
+    )
+}
+
+pub fn assistant_key_attestation_signing_payload(
+    response: &AssistantAttestedKeyChallengeResponse,
+) -> String {
+    format!(
+        "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+        response.runtime,
+        response.measurement,
+        response.challenge_nonce,
+        response.issued_at,
+        response.expires_at,
+        response.request_id,
+        response.evidence_issued_at,
+        response.key_id,
+        response.algorithm,
+        response.public_key,
+        response.key_expires_at
     )
 }
 

--- a/backend/crates/shared/src/lib.rs
+++ b/backend/crates/shared/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod assistant_crypto;
 pub mod config;
 mod config_enclave_runtime;
 mod config_env;

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -34,9 +34,43 @@ pub struct SendTestNotificationResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssistantQueryRequest {
-    pub query: String,
+    pub envelope: AssistantEncryptedRequestEnvelope,
     #[serde(default)]
     pub session_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssistantEncryptedRequestEnvelope {
+    pub version: String,
+    pub algorithm: String,
+    pub key_id: String,
+    pub request_id: String,
+    pub client_ephemeral_public_key: String,
+    pub nonce: String,
+    pub ciphertext: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssistantEncryptedResponseEnvelope {
+    pub version: String,
+    pub algorithm: String,
+    pub key_id: String,
+    pub request_id: String,
+    pub nonce: String,
+    pub ciphertext: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssistantSessionStateEnvelope {
+    pub version: String,
+    pub algorithm: String,
+    pub key_id: String,
+    pub nonce: String,
+    pub ciphertext: String,
+    pub expires_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,9 +90,54 @@ pub struct AssistantMeetingsTodayPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssistantQueryResponse {
     pub session_id: Uuid,
+    pub envelope: AssistantEncryptedResponseEnvelope,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantPlaintextQueryRequest {
+    pub query: String,
+    #[serde(default)]
+    pub session_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantPlaintextQueryResponse {
+    pub session_id: Uuid,
     pub capability: AssistantQueryCapability,
     pub display_text: String,
     pub payload: AssistantMeetingsTodayPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssistantAttestedKeyRequest {
+    pub challenge_nonce: String,
+    pub issued_at: i64,
+    pub expires_at: i64,
+    pub request_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssistantAttestedKeyResponse {
+    pub key_id: String,
+    pub algorithm: String,
+    pub public_key: String,
+    pub key_expires_at: i64,
+    pub attestation: AssistantAttestedKeyAttestation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssistantAttestedKeyAttestation {
+    pub runtime: String,
+    pub measurement: String,
+    pub challenge_nonce: String,
+    pub issued_at: i64,
+    pub expires_at: i64,
+    pub request_id: String,
+    pub evidence_issued_at: i64,
+    pub signature: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/crates/shared/src/repos/assistant_encrypted_sessions.rs
+++ b/backend/crates/shared/src/repos/assistant_encrypted_sessions.rs
@@ -1,0 +1,121 @@
+use chrono::{DateTime, Duration, Utc};
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::models::AssistantSessionStateEnvelope;
+
+use super::{Store, StoreError};
+
+#[derive(Debug, Clone)]
+pub struct AssistantEncryptedSessionRecord {
+    pub session_id: Uuid,
+    pub state: AssistantSessionStateEnvelope,
+    pub expires_at: DateTime<Utc>,
+}
+
+impl Store {
+    pub async fn load_assistant_encrypted_session(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        now: DateTime<Utc>,
+    ) -> Result<Option<AssistantEncryptedSessionRecord>, StoreError> {
+        self.purge_expired_assistant_encrypted_sessions(user_id, now)
+            .await?;
+
+        let row = sqlx::query(
+            "SELECT session_id, expires_at, state_json
+             FROM assistant_encrypted_sessions
+             WHERE user_id = $1
+               AND session_id = $2
+               AND expires_at > $3",
+        )
+        .bind(user_id)
+        .bind(session_id)
+        .bind(now)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(|row| {
+            let state_json: String = row.try_get("state_json")?;
+            let state = serde_json::from_str::<AssistantSessionStateEnvelope>(&state_json)
+                .map_err(|err| {
+                    StoreError::InvalidData(format!("assistant encrypted session invalid: {err}"))
+                })?;
+
+            Ok(AssistantEncryptedSessionRecord {
+                session_id: row.try_get("session_id")?,
+                state,
+                expires_at: row.try_get("expires_at")?,
+            })
+        })
+        .transpose()
+    }
+
+    pub async fn upsert_assistant_encrypted_session(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        state: &AssistantSessionStateEnvelope,
+        now: DateTime<Utc>,
+        ttl_seconds: i64,
+    ) -> Result<(), StoreError> {
+        if ttl_seconds <= 0 {
+            return Err(StoreError::InvalidData(
+                "assistant encrypted session ttl_seconds must be > 0".to_string(),
+            ));
+        }
+
+        self.ensure_user(user_id).await?;
+        self.purge_expired_assistant_encrypted_sessions(user_id, now)
+            .await?;
+
+        let state_json = serde_json::to_string(state).map_err(|err| {
+            StoreError::InvalidData(format!("assistant encrypted session invalid: {err}"))
+        })?;
+        let expires_at = now + Duration::seconds(ttl_seconds);
+
+        sqlx::query(
+            "INSERT INTO assistant_encrypted_sessions (
+                user_id,
+                session_id,
+                state_json,
+                created_at,
+                updated_at,
+                expires_at
+             ) VALUES ($1, $2, $3, $4, $4, $5)
+             ON CONFLICT (user_id, session_id)
+             DO UPDATE SET
+               state_json = EXCLUDED.state_json,
+               updated_at = $4,
+               expires_at = $5",
+        )
+        .bind(user_id)
+        .bind(session_id)
+        .bind(state_json)
+        .bind(now)
+        .bind(expires_at)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn purge_expired_assistant_encrypted_sessions(
+        &self,
+        user_id: Uuid,
+        now: DateTime<Utc>,
+    ) -> Result<(), StoreError> {
+        sqlx::query(
+            "DELETE FROM assistant_encrypted_sessions
+             WHERE user_id = $1
+               AND expires_at <= $2",
+        )
+        .bind(user_id)
+        .bind(now)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/backend/crates/shared/src/repos/mod.rs
+++ b/backend/crates/shared/src/repos/mod.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 use crate::models::ApnsEnvironment;
 
+mod assistant_encrypted_sessions;
 mod assistant_sessions;
 mod audit;
 mod auth;
@@ -15,6 +16,7 @@ mod preferences;
 mod privacy;
 mod users;
 
+pub use assistant_encrypted_sessions::AssistantEncryptedSessionRecord;
 pub use assistant_sessions::{
     ASSISTANT_SESSION_MEMORY_VERSION_V1, AssistantSessionMemory, AssistantSessionRecord,
     AssistantSessionTurn,

--- a/backend/crates/shared/src/repos/privacy.rs
+++ b/backend/crates/shared/src/repos/privacy.rs
@@ -254,6 +254,10 @@ impl Store {
             .bind(user_id)
             .execute(&mut *tx)
             .await?;
+        sqlx::query("DELETE FROM assistant_encrypted_sessions WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
         sqlx::query("DELETE FROM connectors WHERE user_id = $1")
             .bind(user_id)
             .execute(&mut *tx)

--- a/backend/crates/worker/src/job_actions/google/fetch.rs
+++ b/backend/crates/worker/src/job_actions/google/fetch.rs
@@ -108,7 +108,9 @@ fn map_enclave_fetch_error(
             ProviderOperation::CalendarFetch | ProviderOperation::GmailFetch => {
                 JobExecutionError::transient(provider_unavailable_code, "provider request failed")
             }
-            ProviderOperation::TokenRevoke => {
+            ProviderOperation::TokenRevoke
+            | ProviderOperation::AssistantAttestedKey
+            | ProviderOperation::AssistantQuery => {
                 JobExecutionError::transient(provider_unavailable_code, "provider request failed")
             }
         },
@@ -126,7 +128,9 @@ fn map_enclave_fetch_error(
                 }
                 ProviderOperation::CalendarFetch
                 | ProviderOperation::GmailFetch
-                | ProviderOperation::TokenRevoke => {
+                | ProviderOperation::TokenRevoke
+                | ProviderOperation::AssistantAttestedKey
+                | ProviderOperation::AssistantQuery => {
                     classified_http_error(status, provider_failed_code, message)
                 }
             }
@@ -138,7 +142,9 @@ fn map_enclave_fetch_error(
             ),
             ProviderOperation::CalendarFetch
             | ProviderOperation::GmailFetch
-            | ProviderOperation::TokenRevoke => {
+            | ProviderOperation::TokenRevoke
+            | ProviderOperation::AssistantAttestedKey
+            | ProviderOperation::AssistantQuery => {
                 JobExecutionError::transient(provider_parse_code, "provider response was invalid")
             }
         },

--- a/db/migrations/0010_assistant_encrypted_sessions.sql
+++ b/db/migrations/0010_assistant_encrypted_sessions.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS assistant_encrypted_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  session_id UUID NOT NULL,
+  state_json TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  UNIQUE (user_id, session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_assistant_encrypted_sessions_user_updated
+  ON assistant_encrypted_sessions (user_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_assistant_encrypted_sessions_user_expires_at
+  ON assistant_encrypted_sessions (user_id, expires_at);

--- a/docs/assistant-attested-encryption-v1.md
+++ b/docs/assistant-attested-encryption-v1.md
@@ -1,0 +1,73 @@
+# Assistant Encrypted Ingress Protocol v1
+
+Last updated: 2026-02-16
+Issue scope: #147
+
+## Goal
+
+Assistant message content enters backend as ciphertext and is decrypted only in enclave runtime.
+
+## API Flow
+
+1. Client sends `POST /v1/assistant/attested-key` with challenge fields:
+   - `challenge_nonce`
+   - `issued_at`
+   - `expires_at`
+   - `request_id`
+2. API forwards challenge to enclave RPC endpoint `/v1/rpc/assistant/attested-key`.
+3. Enclave responds with:
+   - `key_id`
+   - `algorithm` (`x25519-chacha20poly1305`)
+   - `public_key` (X25519)
+   - `key_expires_at`
+   - attestation evidence (`runtime`, `measurement`, challenge echo fields, `evidence_issued_at`, `signature`)
+4. Client verifies attestation and key binding.
+5. Client encrypts assistant plaintext request and sends `POST /v1/assistant/query` with envelope-only payload.
+6. API validates envelope shape/metadata, forwards to enclave RPC `/v1/rpc/assistant/query`, and returns encrypted response envelope.
+
+## Attestation + Key Binding Verification Rules (Client)
+
+The client must fail closed unless all checks pass:
+
+1. `algorithm` equals `x25519-chacha20poly1305`.
+2. Challenge echo fields match exactly:
+   - `challenge_nonce`
+   - `request_id`
+3. Challenge window is valid:
+   - `expires_at > issued_at`
+   - current time `<= expires_at`
+4. Runtime identity checks:
+   - `runtime` equals expected runtime
+   - `measurement` is in allowed enclave measurement allowlist
+5. Evidence freshness and challenge binding:
+   - `issued_at <= evidence_issued_at <= expires_at`
+   - `abs(now - evidence_issued_at) <= max_attestation_age_seconds`
+6. Key freshness:
+   - `key_expires_at >= now`
+7. Signature verification:
+   - verify Ed25519 signature over payload:
+     `runtime|measurement|challenge_nonce|issued_at|expires_at|request_id|evidence_issued_at|key_id|algorithm|public_key|key_expires_at`
+
+## Envelope v1
+
+Request envelope (`AssistantEncryptedRequestEnvelope`):
+
+- `version` = `v1`
+- `algorithm` = `x25519-chacha20poly1305`
+- `key_id`
+- `request_id`
+- `client_ephemeral_public_key` (base64 X25519 public key)
+- `nonce` (base64 12-byte nonce)
+- `ciphertext` (base64 ChaCha20-Poly1305 combined ciphertext)
+
+Response envelope (`AssistantEncryptedResponseEnvelope`) mirrors version/algo/key/request metadata and contains encrypted payload fields (`nonce`, `ciphertext`).
+
+## Host Privacy Boundary (Phase 1)
+
+Host API is limited to:
+
+1. Envelope metadata validation.
+2. Opaque ciphertext forwarding to enclave runtime.
+3. Opaque encrypted session-state persistence for continuity primitives.
+
+Host API does not parse assistant plaintext request content.

--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -235,7 +235,7 @@ Ship a private beta where iOS users can:
 
 | ID | Pri | Task | Owner | ETA | Status | Depends On | Exit Criteria |
 |---|---|---|---|---|---|---|---|
-| CB-001 | P0 | Define enclave-only message-content architecture and attested key agreement (`#147`) | BE | 2026-02-20 | TODO | SEC-006, AI-004 | Approved protocol/spec defines ciphertext-only server relay and enclave-only plaintext boundary |
+| CB-001 | P0 | Define enclave-only message-content architecture and attested key agreement (`#147`) | BE | 2026-02-20 | DONE | SEC-006, AI-004 | Approved protocol/spec defines ciphertext-only server relay and enclave-only plaintext boundary (`docs/assistant-attested-encryption-v1.md`) |
 | CB-002 | P0 | Implement encrypted message transport + enclave decryption/processing path (`#148`) | BE | 2026-02-27 | TODO | CB-001 | `/v1/assistant/query`-class flows carry ciphertext through control plane; plaintext exists only in enclave runtime |
 | CB-003 | P0 | Add privacy verification gates, redaction tests, and rollout hardening (`#149`) | BE | 2026-03-03 | TODO | CB-002 | Automated checks and audit evidence confirm message-body server blindness with metadata-only server observability |
 


### PR DESCRIPTION
## Summary
Implements issue #147 for the content-blindness migration by moving assistant ingress to attested, ciphertext-only transport.

## Changes
- Added assistant attested-key handshake endpoint (`/v1/assistant/attested-key`) and enclave RPC path.
- Reworked `/v1/assistant/query` to accept encrypted envelopes only, decrypt/process in enclave runtime, and return encrypted envelopes.
- Added shared assistant crypto helpers (X25519 + ChaCha20-Poly1305), attestation signing payloads, and RPC contract updates.
- Added encrypted assistant session persistence (`assistant_encrypted_sessions`) with migration `0010_assistant_encrypted_sessions.sql`.
- Updated OpenAPI + iOS API client models/flow for attested key verification and encrypted query/response handling.
- Updated docs (`docs/assistant-attested-encryption-v1.md`, env docs, and Phase I TODO tracker) and added plaintext-regression guard tests.
- Cleanup fixes from deep review:
  - Pass through client `request_id` to enclave attested-key RPC (prevents challenge mismatch failure).
  - Use enclave-provided session expiry when persisting encrypted session state.
  - Ensure privacy purge deletes `assistant_encrypted_sessions`.
  - Updated root `README.md` local-run notes for attested/encrypted assistant flow.

## Validation
- `just check-tools` ✅
- `just backend-check` ✅
- `just ios-build` ✅
- `just backend-verify` ✅
- `just ios-test` ✅
- `just backend-deep-review` ✅

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: fixed attested-key request id mismatch, fixed encrypted session TTL alignment, fixed privacy purge gap for encrypted sessions
- Repro or test evidence: validated via `just backend-verify`, `just backend-deep-review`, and `just ios-test`
- Required fixes: completed in this PR

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no layering violations detected; new repo logic remains in `shared/src/repos`, handlers remain under `api-server/src/http/*`
- Performance/scalability concerns: none blocking
- Refactor recommendations: none required for this issue scope

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #147
