### PR TITLE
Fix encrypted assistant envelope interop and harden session/key validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,8 @@ ASSISTANT_INGRESS_ACTIVE_KEY_ID=assistant-ingress-v1
 # Optional previous key pair for rotation grace window.
 # ASSISTANT_INGRESS_PREVIOUS_KEY_ID=assistant-ingress-v0
 # ASSISTANT_INGRESS_PREVIOUS_PRIVATE_KEY=<base64 32-byte x25519 private key>
+# Optional in local dev-shim. Required outside local when previous key is set.
+# ASSISTANT_INGRESS_PREVIOUS_KEY_EXPIRES_AT=<unix timestamp>
 ASSISTANT_INGRESS_KEY_TTL_SECONDS=900
 ASSISTANT_INGRESS_SESSION_TTL_SECONDS=3600
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -121,8 +121,9 @@ These vars control TEE/KMS-bound decrypt policy for connector refresh tokens:
 24. `ASSISTANT_INGRESS_ACTIVE_PRIVATE_KEY` (base64 X25519 private key for active assistant ingress decryption key; required outside local)
 25. `ASSISTANT_INGRESS_PREVIOUS_KEY_ID` (optional previous key id accepted for decrypt during key rotation grace windows)
 26. `ASSISTANT_INGRESS_PREVIOUS_PRIVATE_KEY` (optional previous base64 X25519 private key paired with previous key id)
-27. `ASSISTANT_INGRESS_KEY_TTL_SECONDS` (default: `900`; attested key expiry horizon returned to clients)
-28. `ASSISTANT_INGRESS_SESSION_TTL_SECONDS` (default: `3600`; encrypted assistant session-state persistence TTL)
+27. `ASSISTANT_INGRESS_PREVIOUS_KEY_EXPIRES_AT` (unix timestamp for previous key expiry; required outside local when previous key is configured)
+28. `ASSISTANT_INGRESS_KEY_TTL_SECONDS` (default: `900`; attested key expiry horizon returned to clients)
+29. `ASSISTANT_INGRESS_SESSION_TTL_SECONDS` (default: `3600`; encrypted assistant session-state persistence TTL)
 
 Non-local (`ALFRED_ENV=staging|production`) security guards:
 


### PR DESCRIPTION
## Summary
This PR fixes follow-up defects in the content-blindness rollout (`#146`-`#149`) with emphasis on encrypted assistant protocol correctness and boundary hardening.

## What changed
- Fixed iOS assistant envelope wire-format interop:
  - Request ciphertext now sends `ciphertext || tag` (nonce remains a separate field).
  - Response decrypt now reconstructs `SealedBox(nonce:ciphertext:tag:)` from separate nonce + payload bytes.
- Hardened enclave session-state integrity:
  - Added AAD binding for encrypted session state using `version|user_id|session_id|expires_at`.
  - Enforced session-state `expires_at` validation before decrypt.
  - Enforced key-expiry validation before decrypting session state.
  - Rejects requests where envelope/session plaintext `session_id` values disagree.
  - Requires `session_id` when `prior_session_state` is provided.
- Hardened assistant ingress key validation:
  - Rejects decrypt when the selected ingress key is expired.
  - Added regression test for expired-key rejection.
- Tightened previous-key rotation semantics:
  - Added `ASSISTANT_INGRESS_PREVIOUS_KEY_EXPIRES_AT`.
  - Required outside local when previous key is configured.
  - Documented in `.env.example` and `backend/README.md`.

## Validation
- `just check-tools` ✅
- `just backend-check` ✅
- `just backend-fmt` ✅
- `just backend-test` ✅
- `just backend-verify` ✅
- `just backend-architecture-check` ✅
- `just ios-build` ✅

## Security / Privacy impact
- Eliminates protocol mismatch that could break encrypted ingress/egress processing.
- Prevents stale/cross-context session-state ciphertext replay/substitution by binding decrypt to identity/session/expiry metadata.
- Enforces ingress key expiry on decrypt path and stronger previous-key expiry configuration for rotations.
