### PR TITLE
Simplify connectors UI and fix post-merge backend validation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -12,7 +12,32 @@ jobs:
   backend:
     name: Backend Checks (master)
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: alfred_ci
+        options: >-
+          --health-cmd "pg_isready -U postgres -d alfred_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:7
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     env:
+      DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/alfred_ci
+      REDIS_URL: redis://127.0.0.1:6379/0
       SQLX_CLI_ROOT: ${{ github.workspace }}/.cargo-sqlx-cli
       SQLX_CLI_VERSION: 0.8.6
     defaults:
@@ -54,14 +79,31 @@ jobs:
           path: ${{ env.SQLX_CLI_ROOT }}
           key: ${{ steps.cache-sqlx-cli.outputs.cache-primary-key }}
 
+      - name: Add sqlx-cli to PATH
+        run: echo "$SQLX_CLI_ROOT/bin" >> "$GITHUB_PATH"
+
+      - name: Migration Check
+        run: |
+          sqlx migrate run --source ../db/migrations
+          sqlx migrate info --source ../db/migrations
+
       - name: Fmt (check)
         run: cargo fmt --all --check
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: Test
-        run: cargo test
+      - name: Secret Logging Guard Tests
+        run: cargo test -p shared boundary_guards
+
+      - name: Unit and Module Tests
+        run: cargo test --workspace --exclude integration-tests
+
+      - name: Integration Tests (Auth/Privacy)
+        run: cargo test -p integration-tests
+
+      - name: LLM Eval (mocked)
+        run: cargo run -p llm-eval -- --mode mocked
 
       - name: Build
         run: cargo build --workspace

--- a/Justfile
+++ b/Justfile
@@ -184,11 +184,11 @@ worker: backend-worker
 
 # Run API server.
 backend-api:
-    cd {{ backend_dir }} && cargo run -p api-server
+    bacon --project {{ backend_dir }} --job api
 
 # Run background worker.
 backend-worker:
-    cd {{ backend_dir }} && cargo run -p worker
+    bacon --project {{ backend_dir }} --job worker
 
 # Run API and worker together in one terminal session.
 dev:
@@ -204,7 +204,7 @@ enclave-runtime: backend-enclave-runtime
 
 # Run enclave runtime baseline service.
 backend-enclave-runtime:
-    cd {{ backend_dir }} && cargo run -p enclave-runtime
+    bacon --project {{ backend_dir }} --job enclave-runtime
 
 # Show key project docs.
 docs:

--- a/alfred/alfred.xcodeproj/project.pbxproj
+++ b/alfred/alfred.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -387,6 +388,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -412,7 +414,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GNQ3HY2357;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.prodata.alfredTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -434,7 +436,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = GNQ3HY2357;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.prodata.alfredTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/alfred/alfred/ContentView.swift
+++ b/alfred/alfred/ContentView.swift
@@ -46,7 +46,7 @@ struct ContentView: View {
         .sheet(isPresented: $authIsPresented) {
             AuthView()
         }
-        .onChange(of: model.startupRoute) { route in
+        .onChange(of: model.startupRoute, initial: false) { _, route in
             if case .signedIn = route {
                 authIsPresented = false
             }

--- a/backend/README.md
+++ b/backend/README.md
@@ -65,6 +65,8 @@ just api
 just worker
 ```
 
+The three commands above now run through `bacon` with restart-on-change enabled.
+
 4. Verify health:
 
 ```bash

--- a/backend/bacon.toml
+++ b/backend/bacon.toml
@@ -1,0 +1,33 @@
+#:schema https://dystroy.org/bacon/.bacon.schema.json
+
+default_job = "api"
+env.CARGO_TERM_COLOR = "always"
+
+[jobs.api]
+command = ["cargo", "run", "-p", "api-server"]
+need_stdout = true
+allow_warnings = true
+background = false
+on_change_strategy = "kill_then_restart"
+watch = ["Cargo.toml", "Cargo.lock", "crates/api-server", "crates/shared"]
+
+[jobs.worker]
+command = ["cargo", "run", "-p", "worker"]
+need_stdout = true
+allow_warnings = true
+background = false
+on_change_strategy = "kill_then_restart"
+watch = ["Cargo.toml", "Cargo.lock", "crates/worker", "crates/shared"]
+
+[jobs.enclave-runtime]
+command = ["cargo", "run", "-p", "enclave-runtime"]
+need_stdout = true
+allow_warnings = true
+background = false
+on_change_strategy = "kill_then_restart"
+watch = ["Cargo.toml", "Cargo.lock", "crates/enclave-runtime", "crates/shared"]
+
+[keybindings]
+a = "job:api"
+w = "job:worker"
+e = "job:enclave-runtime"


### PR DESCRIPTION
## Summary\n- simplify Connectors screen to a minimal Google toggle flow with confirmation + browser handoff\n- remove repeated connected-state messaging and keep native iOS switch styling\n- create issue #160 to track durable connector-state hydration via backend read endpoint\n- fix merge-only backend CI failure by aligning Post Merge Validation backend job with PR CI (DB/Redis services, migrations, split test stages)\n- include existing workspace updates in this branch as requested\n\n## Validation\n- just ios-build\n- just backend-tests\n\n## Tracking\n- Closes #160