### PR TITLE
Simplify profile UX and fix auth/session + connector disconnect flows

### DIFF
--- a/alfred/alfred/AppTab.swift
+++ b/alfred/alfred/AppTab.swift
@@ -4,7 +4,6 @@ enum AppTab: Hashable, CaseIterable {
     case home
     case activity
     case connectors
-    case profile
 
     var title: String {
         switch self {
@@ -14,8 +13,6 @@ enum AppTab: Hashable, CaseIterable {
             return "Activity"
         case .connectors:
             return "Connectors"
-        case .profile:
-            return "Profile"
         }
     }
 
@@ -27,8 +24,6 @@ enum AppTab: Hashable, CaseIterable {
             return "clock.arrow.circlepath"
         case .connectors:
             return "link"
-        case .profile:
-            return "person.crop.circle"
         }
     }
 }

--- a/alfred/alfred/Views/AppTabShellView.swift
+++ b/alfred/alfred/Views/AppTabShellView.swift
@@ -52,8 +52,6 @@ struct AppTabShellView: View {
             ActivityView(model: model)
         case .connectors:
             ConnectorsView(model: model)
-        case .profile:
-            ProfileView(model: model)
         }
     }
 }

--- a/alfred/alfred/Views/HomeView.swift
+++ b/alfred/alfred/Views/HomeView.swift
@@ -122,8 +122,8 @@ struct HomeView: View {
                     subtitle: "Calendar-driven nudges",
                     status: ("Scheduled", .success),
                     detail: "Remind \(model.meetingReminderMinutes) minutes before meetings.",
-                    actionTitle: "Adjust Preferences",
-                    action: { model.selectedTab = .profile }
+                    actionTitle: "Open Connectors",
+                    action: { model.selectedTab = .connectors }
                 )
 
                 HomeStatusCard(
@@ -131,8 +131,8 @@ struct HomeView: View {
                     subtitle: "Brief and priority-email migration",
                     status: ("Migrating", .warning),
                     detail: "Legacy brief and urgent rule logic is removed while LLM orchestration is being rolled out.",
-                    actionTitle: "Review Settings",
-                    action: { model.selectedTab = .profile }
+                    actionTitle: "View Activity",
+                    action: { model.selectedTab = .activity }
                 )
             }
         }
@@ -160,11 +160,6 @@ struct HomeView: View {
 
             Button("View Activity") {
                 model.selectedTab = .activity
-            }
-            .buttonStyle(.appSecondary)
-
-            Button("Profile & Preferences") {
-                model.selectedTab = .profile
             }
             .buttonStyle(.appSecondary)
 

--- a/alfred/alfred/Views/ProfileView.swift
+++ b/alfred/alfred/Views/ProfileView.swift
@@ -5,210 +5,46 @@ struct ProfileView: View {
     @Environment(Clerk.self) private var clerk
     @ObservedObject var model: AppModel
     @State private var showSignOutConfirmation = false
-    @State private var showRevokeConfirmation = false
-    @State private var showDeleteConfirmation = false
 
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: AppTheme.Layout.sectionSpacing) {
-                accountSection
-                preferencesSection
-                privacySection
-            }
-            .padding(.horizontal, AppTheme.Layout.screenPadding)
-            .padding(.vertical, AppTheme.Layout.sectionSpacing)
-        }
-        .appScreenBackground()
-    }
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Profile moved")
+                .font(.title2.weight(.bold))
+                .foregroundStyle(AppTheme.Colors.textPrimary)
 
-    private var accountSection: some View {
-        AppCard {
-            AppSectionHeader("Account", subtitle: "Signed-in identity and session") {
-                AppStatusBadge(title: accountBadge.title, style: accountBadge.style)
+            Text("Use the top-right account button for profile and account controls.")
+                .font(.subheadline)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+
+            if let accountDisplayName {
+                Text(accountDisplayName)
+                    .font(.headline)
+                    .foregroundStyle(AppTheme.Colors.textPrimary)
             }
 
-            VStack(alignment: .leading, spacing: 12) {
-                if let name = accountDisplayName {
-                    Text(name)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(AppTheme.Colors.textPrimary)
-                }
-
-                if let email = accountEmail {
-                    Text(email)
-                        .font(.subheadline)
-                        .foregroundStyle(AppTheme.Colors.textSecondary)
-                }
-
-                ProfileInfoRow(title: "Session", value: clerk.user == nil ? "Inactive" : "Active")
-                ProfileInfoRow(title: "Account ID", value: accountID ?? "Unavailable")
+            if let accountEmail {
+                Text(accountEmail)
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
             }
 
             Button("Sign out") {
                 showSignOutConfirmation = true
             }
             .buttonStyle(.appSecondary)
-            .confirmationDialog("Sign out of Alfred?", isPresented: $showSignOutConfirmation) {
-                Button("Sign out", role: .destructive) {
-                    Task {
-                        await model.signOut()
-                    }
-                }
-                Button("Cancel", role: .cancel) {}
-            } message: {
-                Text("You will need to sign in again to manage connectors, preferences, and privacy settings.")
-            }
+
+            Spacer()
         }
-    }
-
-    private var preferencesSection: some View {
-        AppCard {
-            AppSectionHeader("Preferences", subtitle: "Reminders, assistant schedule, and quiet hours") {
-                AppStatusBadge(title: model.preferencesStatusBadge.title, style: model.preferencesStatusBadge.style)
-            }
-
-            Text("Tune when Alfred reaches out and how confirmations behave.")
-                .font(.footnote)
-                .foregroundStyle(AppTheme.Colors.textSecondary)
-
-            PreferenceField(
-                title: "Meeting reminder lead time",
-                helper: "Minutes before a meeting starts",
-                placeholder: "15",
-                text: $model.meetingReminderMinutes,
-                keyboard: .numberPad
-            )
-
-            PreferenceField(
-                title: "Morning brief time",
-                helper: "Local time (24-hour format)",
-                placeholder: "08:00",
-                text: $model.morningBriefLocalTime,
-                keyboard: .numbersAndPunctuation
-            )
-
-            PreferenceField(
-                title: "Quiet hours start",
-                helper: "Start time (24-hour format)",
-                placeholder: "22:00",
-                text: $model.quietHoursStart,
-                keyboard: .numbersAndPunctuation
-            )
-
-            PreferenceField(
-                title: "Quiet hours end",
-                helper: "End time (24-hour format)",
-                placeholder: "07:00",
-                text: $model.quietHoursEnd,
-                keyboard: .numbersAndPunctuation
-            )
-
-            Toggle("High-risk actions require confirmation", isOn: $model.highRiskRequiresConfirm)
-                .tint(AppTheme.Colors.accent)
-
-            HStack(spacing: 12) {
-                Button("Load") {
-                    Task {
-                        await model.loadPreferences()
-                    }
-                }
-                .buttonStyle(.appSecondary)
-                .disabled(model.isLoading(.loadPreferences))
-
-                Button("Save") {
-                    Task {
-                        await model.savePreferences()
-                    }
-                }
-                .buttonStyle(.appPrimary)
-                .disabled(model.isLoading(.savePreferences))
-            }
-
-            if model.isLoading(.loadPreferences) || model.isLoading(.savePreferences) {
-                ProgressView()
-                    .tint(AppTheme.Colors.accent)
-            }
-
-            Text(model.preferencesStatus.isEmpty ? "No preference updates yet." : model.preferencesStatus)
-                .font(.footnote)
-                .foregroundStyle(AppTheme.Colors.textSecondary)
-        }
-    }
-
-    private var privacySection: some View {
-        AppCard {
-            AppSectionHeader("Privacy", subtitle: "Revoke access or delete data") {
-                AppStatusBadge(title: model.privacyStatusBadge.title, style: model.privacyStatusBadge.style)
-            }
-
-            Text("Privacy actions affect stored data and connected services. Each step includes a confirmation.")
-                .font(.footnote)
-                .foregroundStyle(AppTheme.Colors.textSecondary)
-
-            PreferenceField(
-                title: "Connector ID",
-                helper: "Use the Google connector ID when revoking access",
-                placeholder: "connector_xxx",
-                text: $model.connectorID,
-                keyboard: .default
-            )
-
-            PrivacyActionRow(
-                title: "Revoke Google access",
-                detail: "Stops Alfred from fetching Google data and revokes the connector.",
-                buttonTitle: "Revoke Connector",
-                isPrimary: false,
-                isDisabled: model.isLoading(.revokeConnector)
-            ) {
-                showRevokeConfirmation = true
-            }
-
-            if !model.revokeStatus.isEmpty {
-                Text(model.revokeStatus)
-                    .font(.footnote)
-                    .foregroundStyle(AppTheme.Colors.textSecondary)
-            }
-
-            PrivacyActionRow(
-                title: "Request delete-all",
-                detail: "Deletes stored Alfred data and disconnects all providers. This cannot be undone.",
-                buttonTitle: "Request Delete-All",
-                isPrimary: true,
-                isDisabled: model.isLoading(.requestDeleteAll)
-            ) {
-                showDeleteConfirmation = true
-            }
-
-            if !model.deleteAllStatus.isEmpty {
-                Text(model.deleteAllStatus)
-                    .font(.footnote)
-                    .foregroundStyle(AppTheme.Colors.textSecondary)
-            }
-
-            if model.isLoading(.revokeConnector) || model.isLoading(.requestDeleteAll) {
-                ProgressView()
-                    .tint(AppTheme.Colors.accent)
-            }
-        }
-        .confirmationDialog("Revoke Google access?", isPresented: $showRevokeConfirmation) {
-            Button("Revoke access", role: .destructive) {
+        .padding(.horizontal, AppTheme.Layout.screenPadding)
+        .padding(.vertical, AppTheme.Layout.sectionSpacing)
+        .appScreenBackground()
+        .confirmationDialog("Sign out of Alfred?", isPresented: $showSignOutConfirmation) {
+            Button("Sign out", role: .destructive) {
                 Task {
-                    await model.revokeConnector()
+                    await model.signOut()
                 }
             }
             Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This disconnects Google and stops Alfred notifications until you reconnect.")
-        }
-        .confirmationDialog("Request delete-all?", isPresented: $showDeleteConfirmation) {
-            Button("Delete all data", role: .destructive) {
-                Task {
-                    await model.requestDeleteAll()
-                }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This permanently deletes Alfred data and revokes all connectors. This action cannot be undone.")
         }
     }
 
@@ -234,102 +70,6 @@ struct ProfileView: View {
 
     private var accountEmail: String? {
         clerk.user?.primaryEmailAddress?.emailAddress
-    }
-
-    private var accountID: String? {
-        clerk.user?.id
-    }
-
-    private var accountBadge: (title: String, style: AppStatusBadge.Style) {
-        clerk.user == nil ? ("Signed out", .neutral) : ("Active", .success)
-    }
-}
-
-private struct PreferenceField: View {
-    let title: String
-    let helper: String?
-    let placeholder: String
-    let text: Binding<String>
-    let keyboard: UIKeyboardType
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(AppTheme.Colors.textPrimary)
-
-            if let helper {
-                Text(helper)
-                    .font(.caption)
-                    .foregroundStyle(AppTheme.Colors.textSecondary)
-            }
-
-            TextField(placeholder, text: text)
-                .keyboardType(keyboard)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .appFieldStyle()
-        }
-    }
-}
-
-private struct ProfileInfoRow: View {
-    let title: String
-    let value: String
-
-    var body: some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(title)
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(AppTheme.Colors.textSecondary)
-
-            Spacer(minLength: 12)
-
-            Text(value)
-                .font(.footnote)
-                .foregroundStyle(AppTheme.Colors.textPrimary)
-                .multilineTextAlignment(.trailing)
-        }
-    }
-}
-
-private struct PrivacyActionRow: View {
-    let title: String
-    let detail: String
-    let buttonTitle: String
-    let isPrimary: Bool
-    let isDisabled: Bool
-    let action: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(AppTheme.Colors.textPrimary)
-
-                Text(detail)
-                    .font(.caption)
-                    .foregroundStyle(AppTheme.Colors.textSecondary)
-            }
-
-            if isPrimary {
-                Button(buttonTitle, action: action)
-                    .buttonStyle(.appPrimary)
-                    .disabled(isDisabled)
-            } else {
-                Button(buttonTitle, action: action)
-                    .buttonStyle(.appSecondary)
-                    .disabled(isDisabled)
-            }
-        }
-        .padding(12)
-        .background(AppTheme.Colors.surfaceElevated)
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(AppTheme.Colors.outline, lineWidth: 1)
-        )
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the dedicated Profile tab and simplify `ProfileView` to a minimal fallback
- route profile/account management to the top-right Clerk `UserButton` entry point
- prevent redundant auth session refresh events from forcing app-shell bootstrap (fixes account popover auto-close)
- enable connector disconnect from the toggle with a destructive confirmation alert and revoke action wiring

## Validation
- `just ios-build`
- `just ios-test`

## Notes
- this PR intentionally keeps profile/actions lightweight in-app and relies on top-right account controls for primary profile management
