### PR TITLE
Assistant v2 contracts + enclave query orchestrator skeleton (issue #167)

### DIFF
--- a/alfred/Packages/AlfredAPIClient/Sources/Models.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/Models.swift
@@ -123,9 +123,13 @@ public struct AssistantPlaintextQueryRequest: Codable, Sendable {
 
 public enum AssistantQueryCapability: String, Codable, Sendable {
     case meetingsToday = "meetings_today"
+    case calendarLookup = "calendar_lookup"
+    case emailLookup = "email_lookup"
+    case generalChat = "general_chat"
+    case mixed = "mixed"
 }
 
-public struct AssistantMeetingsTodayPayload: Codable, Sendable {
+public struct AssistantStructuredPayload: Codable, Sendable {
     public let title: String
     public let summary: String
     public let keyPoints: [String]
@@ -143,7 +147,7 @@ public struct AssistantPlaintextQueryResponse: Codable, Sendable {
     public let sessionId: UUID
     public let capability: AssistantQueryCapability
     public let displayText: String
-    public let payload: AssistantMeetingsTodayPayload
+    public let payload: AssistantStructuredPayload
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -446,8 +446,15 @@ components:
           type: string
     AssistantQueryCapability:
       type: string
-      enum: [meetings_today]
-    AssistantMeetingsTodayPayload:
+      enum:
+        [
+          meetings_today,
+          calendar_lookup,
+          email_lookup,
+          general_chat,
+          mixed
+        ]
+    AssistantStructuredPayload:
       type: object
       required: [title, summary, key_points, follow_ups]
       properties:

--- a/backend/crates/enclave-runtime/src/http/assistant.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant.rs
@@ -9,6 +9,7 @@ use crate::RuntimeState;
 mod mapping;
 mod memory;
 mod notifications;
+mod orchestrator;
 mod proactive;
 mod query;
 mod session_state;

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/calendar.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/calendar.rs
@@ -1,0 +1,184 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use chrono::{Duration, Utc};
+use serde_json::Value;
+use shared::llm::{
+    AssistantCapability, AssistantOutputContract, LlmExecutionSource, LlmGatewayRequest,
+    assemble_meetings_today_context, generate_with_telemetry, resolve_safe_output,
+    sanitize_context_payload, template_for_capability,
+};
+use shared::models::{AssistantQueryCapability, AssistantStructuredPayload};
+use tracing::warn;
+use uuid::Uuid;
+
+use super::super::mapping::{log_telemetry, map_calendar_event_to_meeting_source};
+use super::super::memory::{query_context_snippet, session_memory_context};
+use super::super::notifications::non_empty;
+use super::super::session_state::EnclaveAssistantSessionState;
+use super::AssistantOrchestratorResult;
+use crate::RuntimeState;
+use crate::http::rpc;
+
+const CALENDAR_MAX_RESULTS: usize = 20;
+
+pub(super) async fn execute_calendar_query(
+    state: &RuntimeState,
+    user_id: Uuid,
+    request_id: &str,
+    query: &str,
+    capability: AssistantQueryCapability,
+    prior_state: Option<&EnclaveAssistantSessionState>,
+) -> Result<AssistantOrchestratorResult, Response> {
+    let connector = match state
+        .enclave_service
+        .resolve_active_google_connector_request(user_id)
+        .await
+    {
+        Ok(connector) => connector,
+        Err(err) => {
+            return Err(
+                rpc::map_rpc_service_error(err, Some(request_id.to_string())).into_response(),
+            );
+        }
+    };
+
+    let calendar_day = Utc::now().date_naive();
+    let time_min = match calendar_day.and_hms_opt(0, 0, 0) {
+        Some(start) => start.and_utc(),
+        None => {
+            return Err(rpc::reject(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                shared::enclave::EnclaveRpcErrorEnvelope::new(
+                    Some(request_id.to_string()),
+                    "rpc_internal_error",
+                    "failed to resolve calendar day window",
+                    true,
+                ),
+            )
+            .into_response());
+        }
+    };
+    let time_max = time_min + Duration::days(1);
+
+    let fetch_response = match state
+        .enclave_service
+        .fetch_google_calendar_events(
+            connector,
+            time_min.to_rfc3339(),
+            time_max.to_rfc3339(),
+            CALENDAR_MAX_RESULTS,
+        )
+        .await
+    {
+        Ok(response) => response,
+        Err(err) => {
+            return Err(
+                rpc::map_rpc_service_error(err, Some(request_id.to_string())).into_response(),
+            );
+        }
+    };
+
+    let meetings = fetch_response
+        .events
+        .iter()
+        .map(map_calendar_event_to_meeting_source)
+        .collect::<Vec<_>>();
+    let meetings_context = assemble_meetings_today_context(calendar_day, &meetings);
+
+    let mut context_payload = match serde_json::to_value(&meetings_context) {
+        Ok(value) => value,
+        Err(_) => {
+            return Err(rpc::reject(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                shared::enclave::EnclaveRpcErrorEnvelope::new(
+                    Some(request_id.to_string()),
+                    "rpc_internal_error",
+                    "failed to serialize meetings context",
+                    true,
+                ),
+            )
+            .into_response());
+        }
+    };
+
+    if let Value::Object(entries) = &mut context_payload {
+        entries.insert(
+            "query_context".to_string(),
+            Value::String(query_context_snippet(query)),
+        );
+        if let Some(memory_context) =
+            session_memory_context(prior_state.as_ref().map(|state| &state.memory))
+        {
+            entries.insert("session_memory".to_string(), memory_context);
+        }
+    }
+
+    let context_payload = sanitize_context_payload(&context_payload);
+    let llm_request = LlmGatewayRequest::from_template(
+        template_for_capability(AssistantCapability::MeetingsSummary),
+        context_payload.clone(),
+    )
+    .with_requester_id(user_id.to_string());
+
+    let (llm_result, telemetry) = generate_with_telemetry(
+        state.llm_gateway.as_ref(),
+        LlmExecutionSource::ApiAssistantQuery,
+        llm_request,
+    )
+    .await;
+    log_telemetry(user_id, &telemetry, "assistant_query");
+
+    let model_output = match llm_result {
+        Ok(response) => response.output,
+        Err(err) => {
+            warn!(user_id = %user_id, "assistant provider request failed: {err}");
+            Value::Null
+        }
+    };
+
+    let resolved = resolve_safe_output(
+        AssistantCapability::MeetingsSummary,
+        if model_output.is_null() {
+            None
+        } else {
+            Some(&model_output)
+        },
+        &context_payload,
+    );
+
+    let AssistantOutputContract::MeetingsSummary(summary_contract) = resolved.contract else {
+        return Err(rpc::reject(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            shared::enclave::EnclaveRpcErrorEnvelope::new(
+                Some(request_id.to_string()),
+                "rpc_internal_error",
+                "assistant contract resolution failed",
+                true,
+            ),
+        )
+        .into_response());
+    };
+
+    let display_text = non_empty(summary_contract.output.summary.as_str())
+        .unwrap_or(default_display_for_capability(&capability))
+        .to_string();
+
+    Ok(AssistantOrchestratorResult {
+        capability,
+        display_text,
+        payload: AssistantStructuredPayload {
+            title: summary_contract.output.title,
+            summary: summary_contract.output.summary,
+            key_points: summary_contract.output.key_points,
+            follow_ups: summary_contract.output.follow_ups,
+        },
+        attested_identity: fetch_response.attested_identity,
+    })
+}
+
+fn default_display_for_capability(capability: &AssistantQueryCapability) -> &'static str {
+    match capability {
+        AssistantQueryCapability::CalendarLookup => "Here is your calendar summary.",
+        _ => "Here are your meetings for today.",
+    }
+}

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/chat.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/chat.rs
@@ -1,0 +1,42 @@
+use shared::llm::safety::sanitize_untrusted_text;
+use shared::models::{AssistantQueryCapability, AssistantStructuredPayload};
+
+use super::{AssistantOrchestratorResult, local_attested_identity};
+use crate::RuntimeState;
+
+const QUERY_SNIPPET_MAX_CHARS: usize = 120;
+
+pub(super) fn execute_general_chat(
+    state: &RuntimeState,
+    query: &str,
+) -> AssistantOrchestratorResult {
+    let query_snippet = sanitize_untrusted_text(query)
+        .chars()
+        .take(QUERY_SNIPPET_MAX_CHARS)
+        .collect::<String>();
+    let summary = if query_snippet.is_empty() {
+        "I can help with general conversation and, in upcoming turns, with calendar and email lookups.".to_string()
+    } else {
+        format!(
+            "I heard: \"{query_snippet}\". I can chat generally now and will route to calendar/email tools when requested."
+        )
+    };
+
+    AssistantOrchestratorResult {
+        capability: AssistantQueryCapability::GeneralChat,
+        display_text: summary.clone(),
+        payload: AssistantStructuredPayload {
+            title: "General conversation".to_string(),
+            summary,
+            key_points: vec![
+                "General-chat lane is active in Assistant v2.".to_string(),
+                "Tool-backed calendar/email retrieval routes are capability-gated.".to_string(),
+            ],
+            follow_ups: vec![
+                "Ask: What meetings do I have today?".to_string(),
+                "Ask: Any important emails this week?".to_string(),
+            ],
+        },
+        attested_identity: local_attested_identity(state),
+    }
+}

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email.rs
@@ -1,0 +1,30 @@
+use shared::models::{AssistantQueryCapability, AssistantStructuredPayload};
+
+use super::{AssistantOrchestratorResult, local_attested_identity};
+use crate::RuntimeState;
+
+pub(super) fn execute_email_query(
+    state: &RuntimeState,
+    _query: &str,
+) -> AssistantOrchestratorResult {
+    let summary =
+        "Email lookup routing is selected. Detailed inbox retrieval lands in the next execution issue.".to_string();
+
+    AssistantOrchestratorResult {
+        capability: AssistantQueryCapability::EmailLookup,
+        display_text: summary.clone(),
+        payload: AssistantStructuredPayload {
+            title: "Email lookup".to_string(),
+            summary,
+            key_points: vec![
+                "Intent was classified as email-focused.".to_string(),
+                "Enclave orchestrator now supports dedicated email capability routing.".to_string(),
+            ],
+            follow_ups: vec![
+                "Try: summarize my inbox for today".to_string(),
+                "Try: any emails from finance this week".to_string(),
+            ],
+        },
+        attested_identity: local_attested_identity(state),
+    }
+}

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mixed.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mixed.rs
@@ -1,0 +1,30 @@
+use shared::models::{AssistantQueryCapability, AssistantStructuredPayload};
+
+use super::{AssistantOrchestratorResult, local_attested_identity};
+use crate::RuntimeState;
+
+pub(super) fn execute_mixed_query(
+    state: &RuntimeState,
+    _query: &str,
+) -> AssistantOrchestratorResult {
+    let summary = "Mixed intent detected (calendar + email). Mixed tool execution scaffolding is now in place and will be expanded in follow-up issues.".to_string();
+
+    AssistantOrchestratorResult {
+        capability: AssistantQueryCapability::Mixed,
+        display_text: summary.clone(),
+        payload: AssistantStructuredPayload {
+            title: "Mixed lookup".to_string(),
+            summary,
+            key_points: vec![
+                "Query planner selected mixed capability.".to_string(),
+                "Dedicated calendar/email tool execution layers are now separated in orchestrator."
+                    .to_string(),
+            ],
+            follow_ups: vec![
+                "Ask one focused calendar question for now.".to_string(),
+                "Ask one focused email question for now.".to_string(),
+            ],
+        },
+        attested_identity: local_attested_identity(state),
+    }
+}

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mod.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mod.rs
@@ -1,0 +1,62 @@
+use axum::response::Response;
+use shared::enclave::AttestedIdentityPayload;
+use shared::models::{AssistantQueryCapability, AssistantStructuredPayload};
+use uuid::Uuid;
+
+use super::memory::{detect_query_capability, resolve_query_capability};
+use super::session_state::EnclaveAssistantSessionState;
+use crate::RuntimeState;
+
+mod calendar;
+mod chat;
+mod email;
+mod mixed;
+
+pub(super) struct AssistantOrchestratorResult {
+    pub(super) capability: AssistantQueryCapability,
+    pub(super) display_text: String,
+    pub(super) payload: AssistantStructuredPayload,
+    pub(super) attested_identity: AttestedIdentityPayload,
+}
+
+pub(super) async fn execute_query(
+    state: &RuntimeState,
+    user_id: Uuid,
+    request_id: &str,
+    query: &str,
+    prior_state: Option<&EnclaveAssistantSessionState>,
+) -> Result<AssistantOrchestratorResult, Response> {
+    let detected_capability = detect_query_capability(query);
+    let capability = resolve_query_capability(
+        query,
+        detected_capability,
+        prior_state
+            .as_ref()
+            .map(|state| state.last_capability.clone()),
+    )
+    .unwrap_or(AssistantQueryCapability::GeneralChat);
+
+    match capability {
+        AssistantQueryCapability::MeetingsToday | AssistantQueryCapability::CalendarLookup => {
+            calendar::execute_calendar_query(
+                state,
+                user_id,
+                request_id,
+                query,
+                capability,
+                prior_state,
+            )
+            .await
+        }
+        AssistantQueryCapability::EmailLookup => Ok(email::execute_email_query(state, query)),
+        AssistantQueryCapability::Mixed => Ok(mixed::execute_mixed_query(state, query)),
+        AssistantQueryCapability::GeneralChat => Ok(chat::execute_general_chat(state, query)),
+    }
+}
+
+fn local_attested_identity(state: &RuntimeState) -> AttestedIdentityPayload {
+    AttestedIdentityPayload {
+        runtime: state.config.runtime_id.clone(),
+        measurement: state.config.measurement.clone(),
+    }
+}

--- a/backend/crates/enclave-runtime/src/http/assistant/query.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/query.rs
@@ -1,36 +1,23 @@
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use chrono::{Duration, Utc};
-use serde_json::Value;
+use chrono::Utc;
 use shared::assistant_crypto::{decrypt_assistant_request, encrypt_assistant_response};
 use shared::assistant_memory::ASSISTANT_SESSION_MEMORY_VERSION_V1;
 use shared::enclave::{
     ENCLAVE_RPC_CONTRACT_VERSION, EnclaveRpcProcessAssistantQueryRequest,
     EnclaveRpcProcessAssistantQueryResponse,
 };
-use shared::llm::{
-    AssistantCapability, AssistantOutputContract, LlmExecutionSource, LlmGatewayRequest,
-    assemble_meetings_today_context, generate_with_telemetry, resolve_safe_output,
-    sanitize_context_payload, template_for_capability,
-};
-use shared::models::{AssistantMeetingsTodayPayload, AssistantPlaintextQueryResponse};
-use tracing::warn;
+use shared::models::AssistantPlaintextQueryResponse;
 use uuid::Uuid;
 
-use super::mapping::{log_telemetry, map_calendar_event_to_meeting_source};
-use super::memory::{
-    build_updated_memory, detect_query_capability, query_context_snippet, resolve_query_capability,
-    session_memory_context,
-};
-use super::notifications::non_empty;
+use super::memory::build_updated_memory;
+use super::orchestrator;
 use super::session_state::{
     EnclaveAssistantSessionState, decrypt_session_state, encrypt_session_state,
 };
 use crate::RuntimeState;
 use crate::http::rpc;
-
-const CALENDAR_MAX_RESULTS: usize = 20;
 
 pub(super) async fn process_assistant_query(
     state: RuntimeState,
@@ -128,156 +115,24 @@ pub(super) async fn process_assistant_query(
         .or(plaintext.session_id)
         .unwrap_or_else(Uuid::new_v4);
 
-    let detected_capability = detect_query_capability(query);
-    let capability = resolve_query_capability(
+    let execution = match orchestrator::execute_query(
+        &state,
+        request.user_id,
+        request.request_id.as_str(),
         query,
-        detected_capability,
-        prior_state
-            .as_ref()
-            .map(|state| state.last_capability.clone()),
+        prior_state.as_ref(),
     )
-    .unwrap_or(shared::models::AssistantQueryCapability::MeetingsToday);
-
-    let connector = match state
-        .enclave_service
-        .resolve_active_google_connector_request(request.user_id)
-        .await
+    .await
     {
-        Ok(connector) => connector,
-        Err(err) => {
-            return rpc::map_rpc_service_error(err, Some(request.request_id)).into_response();
-        }
+        Ok(execution) => execution,
+        Err(response) => return response,
     };
-
-    let calendar_day = Utc::now().date_naive();
-    let time_min = match calendar_day.and_hms_opt(0, 0, 0) {
-        Some(start) => start.and_utc(),
-        None => {
-            return rpc::reject(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                shared::enclave::EnclaveRpcErrorEnvelope::new(
-                    Some(request.request_id),
-                    "rpc_internal_error",
-                    "failed to resolve calendar day window",
-                    true,
-                ),
-            )
-            .into_response();
-        }
-    };
-    let time_max = time_min + Duration::days(1);
-
-    let fetch_response = match state
-        .enclave_service
-        .fetch_google_calendar_events(
-            connector,
-            time_min.to_rfc3339(),
-            time_max.to_rfc3339(),
-            CALENDAR_MAX_RESULTS,
-        )
-        .await
-    {
-        Ok(response) => response,
-        Err(err) => {
-            return rpc::map_rpc_service_error(err, Some(request.request_id)).into_response();
-        }
-    };
-
-    let meetings = fetch_response
-        .events
-        .iter()
-        .map(map_calendar_event_to_meeting_source)
-        .collect::<Vec<_>>();
-    let meetings_context = assemble_meetings_today_context(calendar_day, &meetings);
-
-    let mut context_payload = match serde_json::to_value(&meetings_context) {
-        Ok(value) => value,
-        Err(_) => {
-            return rpc::reject(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                shared::enclave::EnclaveRpcErrorEnvelope::new(
-                    Some(request.request_id),
-                    "rpc_internal_error",
-                    "failed to serialize meetings context",
-                    true,
-                ),
-            )
-            .into_response();
-        }
-    };
-
-    if let Value::Object(entries) = &mut context_payload {
-        entries.insert(
-            "query_context".to_string(),
-            Value::String(query_context_snippet(query)),
-        );
-        if let Some(memory_context) =
-            session_memory_context(prior_state.as_ref().map(|state| &state.memory))
-        {
-            entries.insert("session_memory".to_string(), memory_context);
-        }
-    }
-
-    let context_payload = sanitize_context_payload(&context_payload);
-    let llm_request = LlmGatewayRequest::from_template(
-        template_for_capability(AssistantCapability::MeetingsSummary),
-        context_payload.clone(),
-    )
-    .with_requester_id(request.user_id.to_string());
-
-    let (llm_result, telemetry) = generate_with_telemetry(
-        state.llm_gateway.as_ref(),
-        LlmExecutionSource::ApiAssistantQuery,
-        llm_request,
-    )
-    .await;
-    log_telemetry(request.user_id, &telemetry, "assistant_query");
-
-    let model_output = match llm_result {
-        Ok(response) => response.output,
-        Err(err) => {
-            warn!(user_id = %request.user_id, "assistant provider request failed: {err}");
-            Value::Null
-        }
-    };
-
-    let resolved = resolve_safe_output(
-        AssistantCapability::MeetingsSummary,
-        if model_output.is_null() {
-            None
-        } else {
-            Some(&model_output)
-        },
-        &context_payload,
-    );
-
-    let AssistantOutputContract::MeetingsSummary(summary_contract) = resolved.contract else {
-        return rpc::reject(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            shared::enclave::EnclaveRpcErrorEnvelope::new(
-                Some(request.request_id),
-                "rpc_internal_error",
-                "assistant contract resolution failed",
-                true,
-            ),
-        )
-        .into_response();
-    };
-
-    let display_text = non_empty(summary_contract.output.summary.as_str())
-        .unwrap_or("Here are your meetings for today.")
-        .to_string();
 
     let response_contract = AssistantPlaintextQueryResponse {
         session_id,
-        capability: capability.clone(),
-        display_text: display_text.clone(),
-        payload: AssistantMeetingsTodayPayload {
-            title: summary_contract.output.title,
-            summary: summary_contract.output.summary,
-            key_points: summary_contract.output.key_points,
-            follow_ups: summary_contract.output.follow_ups,
-        },
+        capability: execution.capability.clone(),
+        display_text: execution.display_text.clone(),
+        payload: execution.payload,
     };
 
     let encrypted_response = match encrypt_assistant_response(
@@ -305,14 +160,14 @@ pub(super) async fn process_assistant_query(
         prior_state.as_ref().map(|state| &state.memory),
         query,
         response_contract.display_text.as_str(),
-        capability.clone(),
+        execution.capability.clone(),
         now,
     );
     let encrypted_session_state = match encrypt_session_state(
         &state,
         &EnclaveAssistantSessionState {
             version: ASSISTANT_SESSION_MEMORY_VERSION_V1.to_string(),
-            last_capability: capability,
+            last_capability: execution.capability,
             memory: updated_memory,
         },
         request.user_id,
@@ -340,7 +195,7 @@ pub(super) async fn process_assistant_query(
         session_id,
         envelope: encrypted_response,
         session_state: Some(encrypted_session_state),
-        attested_identity: fetch_response.attested_identity,
+        attested_identity: execution.attested_identity,
     })
     .into_response()
 }

--- a/backend/crates/integration-tests/tests/api_assistant_content_blind_e2e.rs
+++ b/backend/crates/integration-tests/tests/api_assistant_content_blind_e2e.rs
@@ -215,9 +215,9 @@ async fn start_assistant_mock_enclave(
 
                             let response_payload = AssistantPlaintextQueryResponse {
                                 session_id: Uuid::new_v4(),
-                                capability: AssistantQueryCapability::MeetingsToday,
+                                capability: AssistantQueryCapability::GeneralChat,
                                 display_text: "Encrypted response from enclave".to_string(),
-                                payload: shared::models::AssistantMeetingsTodayPayload {
+                                payload: shared::models::AssistantStructuredPayload {
                                     title: "Encrypted".to_string(),
                                     summary: "Host cannot read plaintext".to_string(),
                                     key_points: vec!["Enclave-only decrypt path".to_string()],

--- a/backend/crates/shared/src/assistant_crypto.rs
+++ b/backend/crates/shared/src/assistant_crypto.rs
@@ -239,8 +239,8 @@ mod tests {
         derive_public_key_b64, encrypt_assistant_response,
     };
     use crate::models::{
-        AssistantEncryptedRequestEnvelope, AssistantMeetingsTodayPayload,
-        AssistantPlaintextQueryRequest, AssistantPlaintextQueryResponse, AssistantQueryCapability,
+        AssistantEncryptedRequestEnvelope, AssistantPlaintextQueryRequest,
+        AssistantPlaintextQueryResponse, AssistantQueryCapability, AssistantStructuredPayload,
     };
 
     #[test]
@@ -278,7 +278,7 @@ mod tests {
             session_id: uuid::Uuid::new_v4(),
             capability: AssistantQueryCapability::MeetingsToday,
             display_text: "encrypted ingress accepted".to_string(),
-            payload: AssistantMeetingsTodayPayload {
+            payload: AssistantStructuredPayload {
                 title: "Encrypted ingress active".to_string(),
                 summary: "encrypted ingress accepted".to_string(),
                 key_points: vec!["phase 1 route live".to_string()],

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -77,10 +77,14 @@ pub struct AssistantSessionStateEnvelope {
 #[serde(rename_all = "snake_case")]
 pub enum AssistantQueryCapability {
     MeetingsToday,
+    CalendarLookup,
+    EmailLookup,
+    GeneralChat,
+    Mixed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssistantMeetingsTodayPayload {
+pub struct AssistantStructuredPayload {
     pub title: String,
     pub summary: String,
     pub key_points: Vec<String>,
@@ -105,7 +109,7 @@ pub struct AssistantPlaintextQueryResponse {
     pub session_id: Uuid,
     pub capability: AssistantQueryCapability,
     pub display_text: String,
-    pub payload: AssistantMeetingsTodayPayload,
+    pub payload: AssistantStructuredPayload,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- implement issue #167 by introducing assistant v2 capability contracts across backend, OpenAPI, and iOS API models
- refactor enclave assistant query execution into an explicit orchestrator with lanes for calendar, email, general chat, and mixed intent
- preserve current calendar "meetings today" functionality while adding scaffolded non-calendar lanes for next issues
- expand capability detection and memory behavior for calendar/email/mixed follow-up handling

## Changes
- add new capabilities: `calendar_lookup`, `email_lookup`, `general_chat`, `mixed` (keep `meetings_today` for compatibility)
- replace legacy payload type with `AssistantStructuredPayload` in shared models + iOS API package + OpenAPI
- split execution flow in enclave runtime into `orchestrator/{calendar,email,chat,mixed}.rs`
- update integration tests and crypto tests for new contracts
- add memory unit tests for capability detection + follow-up resolution

## Validation
- `just check-tools`
- `just backend-fmt`
- `just backend-test`
- `just backend-integration-test`
- `just backend-eval`
- `just backend-tests`
- `just backend-verify`
- `just backend-deep-review`
- `just ios-build`
- `just ios-test`

All commands passed locally.

Closes #167
Part of #166
