### PR TITLE
Assistant v2 email tool: bounded inbox lookup with sender/time filters (issue #169)

### DIFF
--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email.rs
@@ -1,30 +1,193 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use chrono::Utc;
+use serde_json::{Value, json};
+use shared::llm::{
+    AssistantCapability, AssistantOutputContract, LlmExecutionSource, LlmGatewayRequest,
+    SafeOutputSource, assemble_urgent_email_candidates_context, generate_with_telemetry,
+    resolve_safe_output, sanitize_context_payload, template_for_capability,
+};
 use shared::models::{AssistantQueryCapability, AssistantStructuredPayload};
+use tracing::warn;
+use uuid::Uuid;
 
-use super::{AssistantOrchestratorResult, local_attested_identity};
+use super::super::mapping::{log_telemetry, map_email_candidate_source};
+use super::super::memory::{query_context_snippet, session_memory_context};
+use super::super::notifications::non_empty;
+use super::super::session_state::EnclaveAssistantSessionState;
+use super::AssistantOrchestratorResult;
+use super::email_fallback::{
+    deterministic_email_fallback_payload, format_email_key_point, title_for_email_results,
+};
+use super::email_plan::{apply_email_filters, build_gmail_query, plan_email_query};
 use crate::RuntimeState;
+use crate::http::rpc;
 
-pub(super) fn execute_email_query(
+const EMAIL_MAX_RESULTS: usize = 20;
+const MAX_MODEL_KEY_POINTS: usize = 3;
+
+pub(super) async fn execute_email_query(
     state: &RuntimeState,
-    _query: &str,
-) -> AssistantOrchestratorResult {
-    let summary =
-        "Email lookup routing is selected. Detailed inbox retrieval lands in the next execution issue.".to_string();
+    user_id: Uuid,
+    request_id: &str,
+    query: &str,
+    prior_state: Option<&EnclaveAssistantSessionState>,
+) -> Result<AssistantOrchestratorResult, Response> {
+    let connector = match state
+        .enclave_service
+        .resolve_active_google_connector_request(user_id)
+        .await
+    {
+        Ok(connector) => connector,
+        Err(err) => {
+            return Err(
+                rpc::map_rpc_service_error(err, Some(request_id.to_string())).into_response(),
+            );
+        }
+    };
 
-    AssistantOrchestratorResult {
-        capability: AssistantQueryCapability::EmailLookup,
-        display_text: summary.clone(),
-        payload: AssistantStructuredPayload {
-            title: "Email lookup".to_string(),
-            summary,
-            key_points: vec![
-                "Intent was classified as email-focused.".to_string(),
-                "Enclave orchestrator now supports dedicated email capability routing.".to_string(),
-            ],
-            follow_ups: vec![
-                "Try: summarize my inbox for today".to_string(),
-                "Try: any emails from finance this week".to_string(),
-            ],
-        },
-        attested_identity: local_attested_identity(state),
+    let plan = plan_email_query(query);
+    let now = Utc::now();
+
+    let fetch_response = match state
+        .enclave_service
+        .fetch_google_email_candidates(connector, Some(build_gmail_query(&plan)), EMAIL_MAX_RESULTS)
+        .await
+    {
+        Ok(response) => response,
+        Err(err) => {
+            return Err(
+                rpc::map_rpc_service_error(err, Some(request_id.to_string())).into_response(),
+            );
+        }
+    };
+
+    let raw_candidates = fetch_response
+        .candidates
+        .iter()
+        .map(map_email_candidate_source)
+        .collect::<Vec<_>>();
+    let candidates = apply_email_filters(raw_candidates, &plan, now);
+
+    let context = assemble_urgent_email_candidates_context(&candidates);
+    let mut context_payload = match serde_json::to_value(&context) {
+        Ok(value) => value,
+        Err(_) => {
+            return Err(rpc::reject(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                shared::enclave::EnclaveRpcErrorEnvelope::new(
+                    Some(request_id.to_string()),
+                    "rpc_internal_error",
+                    "failed to serialize email context",
+                    true,
+                ),
+            )
+            .into_response());
+        }
+    };
+
+    if let Value::Object(entries) = &mut context_payload {
+        entries.insert(
+            "query_context".to_string(),
+            Value::String(query_context_snippet(query)),
+        );
+        entries.insert(
+            "query_plan".to_string(),
+            json!({
+                "window_label": plan.window_label,
+                "lookback_days": plan.lookback_days,
+                "sender_filter": plan.sender_filter,
+            }),
+        );
+        if let Some(memory_context) =
+            session_memory_context(prior_state.as_ref().map(|state| &state.memory))
+        {
+            entries.insert("session_memory".to_string(), memory_context);
+        }
     }
+
+    let context_payload = sanitize_context_payload(&context_payload);
+    let llm_request = LlmGatewayRequest::from_template(
+        template_for_capability(AssistantCapability::UrgentEmailSummary),
+        context_payload.clone(),
+    )
+    .with_requester_id(user_id.to_string());
+
+    let (llm_result, telemetry) = generate_with_telemetry(
+        state.llm_gateway.as_ref(),
+        LlmExecutionSource::ApiAssistantQuery,
+        llm_request,
+    )
+    .await;
+    log_telemetry(user_id, &telemetry, "assistant_query");
+
+    let model_output = match llm_result {
+        Ok(response) => response.output,
+        Err(err) => {
+            warn!(user_id = %user_id, "assistant email provider request failed: {err}");
+            Value::Null
+        }
+    };
+
+    let resolved = resolve_safe_output(
+        AssistantCapability::UrgentEmailSummary,
+        if model_output.is_null() {
+            None
+        } else {
+            Some(&model_output)
+        },
+        &context_payload,
+    );
+
+    let payload = if resolved.source == SafeOutputSource::DeterministicFallback {
+        deterministic_email_fallback_payload(&plan, &candidates)
+    } else {
+        let AssistantOutputContract::UrgentEmailSummary(contract) = resolved.contract else {
+            return Err(rpc::reject(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                shared::enclave::EnclaveRpcErrorEnvelope::new(
+                    Some(request_id.to_string()),
+                    "rpc_internal_error",
+                    "assistant email contract resolution failed",
+                    true,
+                ),
+            )
+            .into_response());
+        };
+
+        let mut key_points = Vec::new();
+        if let Some(reason) = non_empty(contract.output.reason.as_str()) {
+            key_points.push(format!("Reason: {reason}"));
+        }
+        key_points.extend(
+            candidates
+                .iter()
+                .take(MAX_MODEL_KEY_POINTS)
+                .map(format_email_key_point),
+        );
+
+        AssistantStructuredPayload {
+            title: title_for_email_results(&plan),
+            summary: non_empty(contract.output.summary.as_str())
+                .unwrap_or("Here is your inbox summary.")
+                .to_string(),
+            key_points,
+            follow_ups: if contract.output.suggested_actions.is_empty() {
+                vec!["Ask for a narrower sender or timeframe.".to_string()]
+            } else {
+                contract.output.suggested_actions
+            },
+        }
+    };
+
+    let display_text = non_empty(payload.summary.as_str())
+        .unwrap_or("Here is your inbox summary.")
+        .to_string();
+
+    Ok(AssistantOrchestratorResult {
+        capability: AssistantQueryCapability::EmailLookup,
+        display_text,
+        payload,
+        attested_identity: fetch_response.attested_identity,
+    })
 }

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email_fallback.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email_fallback.rs
@@ -1,0 +1,82 @@
+use shared::models::AssistantStructuredPayload;
+
+use super::super::notifications::non_empty;
+use super::email_plan::EmailQueryPlan;
+
+const MAX_FALLBACK_KEY_POINTS: usize = 3;
+
+pub(super) fn deterministic_email_fallback_payload(
+    plan: &EmailQueryPlan,
+    candidates: &[shared::llm::GoogleEmailCandidateSource],
+) -> AssistantStructuredPayload {
+    if candidates.is_empty() {
+        let summary = if let Some(sender_filter) = &plan.sender_filter {
+            format!(
+                "No emails from {sender_filter} were found for {}.",
+                plan.window_label
+            )
+        } else {
+            format!("No emails were found for {}.", plan.window_label)
+        };
+
+        return AssistantStructuredPayload {
+            title: "No matching emails".to_string(),
+            summary,
+            key_points: Vec::new(),
+            follow_ups: vec!["Try a broader timeframe or remove sender filters.".to_string()],
+        };
+    }
+
+    let count = candidates.len();
+    AssistantStructuredPayload {
+        title: title_for_email_results(plan),
+        summary: format!(
+            "Found {count} email{} in {}.",
+            if count == 1 { "" } else { "s" },
+            plan.window_label
+        ),
+        key_points: candidates
+            .iter()
+            .take(MAX_FALLBACK_KEY_POINTS)
+            .map(format_email_key_point)
+            .collect(),
+        follow_ups: vec!["Ask for details from a specific sender or subject.".to_string()],
+    }
+}
+
+pub(super) fn title_for_email_results(plan: &EmailQueryPlan) -> String {
+    if let Some(sender_filter) = &plan.sender_filter {
+        return format!("Emails from {sender_filter}");
+    }
+
+    "Inbox summary".to_string()
+}
+
+pub(super) fn format_email_key_point(
+    candidate: &shared::llm::GoogleEmailCandidateSource,
+) -> String {
+    let from = non_empty(candidate.from.as_deref().unwrap_or("")).unwrap_or("unknown sender");
+    let subject = non_empty(candidate.subject.as_deref().unwrap_or("")).unwrap_or("(no subject)");
+    let received = candidate
+        .received_at
+        .map(|value| value.format("%Y-%m-%d %H:%M UTC").to_string())
+        .unwrap_or_else(|| "time unknown".to_string());
+
+    format!("{received}: {from} - {subject}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::email_plan::plan_email_query;
+    use super::deterministic_email_fallback_payload;
+
+    #[test]
+    fn deterministic_fallback_reports_no_match_queries() {
+        let plan = plan_email_query("Any email from legal@example.com today?");
+        let payload = deterministic_email_fallback_payload(&plan, &[]);
+
+        assert_eq!(payload.title, "No matching emails");
+        assert!(payload.summary.contains("legal@example.com"));
+        assert!(payload.summary.contains("today"));
+    }
+}

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email_plan.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email_plan.rs
@@ -1,0 +1,173 @@
+use std::cmp::Ordering;
+
+use chrono::{DateTime, Duration, Utc};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct EmailQueryPlan {
+    pub(super) sender_filter: Option<String>,
+    pub(super) lookback_days: i64,
+    pub(super) window_label: &'static str,
+}
+
+pub(super) fn build_gmail_query(plan: &EmailQueryPlan) -> String {
+    let mut parts = vec![format!("newer_than:{}d", plan.lookback_days)];
+    if let Some(sender_filter) = &plan.sender_filter {
+        parts.push(format!("from:{sender_filter}"));
+    }
+    parts.join(" ")
+}
+
+pub(super) fn plan_email_query(query: &str) -> EmailQueryPlan {
+    let normalized = query.to_ascii_lowercase();
+
+    let (lookback_days, window_label) = if normalized.contains("today") {
+        (1, "today")
+    } else if normalized.contains("this week")
+        || normalized.contains("next 7 days")
+        || normalized.contains("last 7 days")
+        || normalized.contains("week")
+    {
+        (7, "the past 7 days")
+    } else if normalized.contains("month") || normalized.contains("30 days") {
+        (30, "the past 30 days")
+    } else {
+        (7, "the past 7 days")
+    };
+
+    EmailQueryPlan {
+        sender_filter: parse_sender_filter(query),
+        lookback_days,
+        window_label,
+    }
+}
+
+pub(super) fn apply_email_filters(
+    mut candidates: Vec<shared::llm::GoogleEmailCandidateSource>,
+    plan: &EmailQueryPlan,
+    now: DateTime<Utc>,
+) -> Vec<shared::llm::GoogleEmailCandidateSource> {
+    let min_received_at = now - Duration::days(plan.lookback_days);
+
+    candidates.retain(|candidate| {
+        let sender_match = plan
+            .sender_filter
+            .as_ref()
+            .map(|sender_filter| {
+                candidate
+                    .from
+                    .as_deref()
+                    .unwrap_or("")
+                    .to_ascii_lowercase()
+                    .contains(sender_filter)
+            })
+            .unwrap_or(true);
+
+        let time_match = candidate
+            .received_at
+            .map(|received| received >= min_received_at)
+            .unwrap_or(true);
+
+        sender_match && time_match
+    });
+
+    candidates.sort_by(|left, right| match (left.received_at, right.received_at) {
+        (Some(left_received), Some(right_received)) => right_received.cmp(&left_received),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    });
+
+    candidates
+}
+
+fn parse_sender_filter(query: &str) -> Option<String> {
+    let markers = ["from ", "sender "];
+    let normalized = query.to_ascii_lowercase();
+
+    for marker in markers {
+        if let Some(start) = normalized.find(marker) {
+            let rest = &query[start + marker.len()..];
+            let raw = rest.split_whitespace().next().unwrap_or("");
+            let cleaned = raw
+                .trim_matches(|c: char| {
+                    !c.is_ascii_alphanumeric()
+                        && c != '@'
+                        && c != '.'
+                        && c != '_'
+                        && c != '-'
+                        && c != '+'
+                })
+                .to_ascii_lowercase();
+            if !cleaned.is_empty() {
+                return Some(cleaned);
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, Utc};
+    use shared::llm::GoogleEmailCandidateSource;
+
+    use super::{apply_email_filters, plan_email_query};
+
+    fn utc(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .expect("timestamp should parse")
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn plan_email_query_extracts_sender_and_window() {
+        let plan = plan_email_query("Any email from finance@example.com today?");
+        assert_eq!(plan.sender_filter.as_deref(), Some("finance@example.com"));
+        assert_eq!(plan.lookback_days, 1);
+        assert_eq!(plan.window_label, "today");
+
+        let weekly_plan = plan_email_query("summarize my inbox this week");
+        assert_eq!(weekly_plan.sender_filter, None);
+        assert_eq!(weekly_plan.lookback_days, 7);
+    }
+
+    #[test]
+    fn apply_email_filters_supports_sender_and_time_window() {
+        let now = utc("2026-02-17T12:00:00Z");
+        let plan = plan_email_query("Any email from finance@example.com today?");
+        let candidates = vec![
+            GoogleEmailCandidateSource {
+                message_id: Some("1".to_string()),
+                from: Some("finance@example.com".to_string()),
+                subject: Some("Invoice".to_string()),
+                snippet: None,
+                received_at: Some(utc("2026-02-17T10:00:00Z")),
+                label_ids: vec![],
+                has_attachments: false,
+            },
+            GoogleEmailCandidateSource {
+                message_id: Some("2".to_string()),
+                from: Some("alerts@example.com".to_string()),
+                subject: Some("Status".to_string()),
+                snippet: None,
+                received_at: Some(utc("2026-02-17T09:00:00Z")),
+                label_ids: vec![],
+                has_attachments: false,
+            },
+            GoogleEmailCandidateSource {
+                message_id: Some("3".to_string()),
+                from: Some("finance@example.com".to_string()),
+                subject: Some("Old thread".to_string()),
+                snippet: None,
+                received_at: Some(utc("2026-02-15T10:00:00Z")),
+                label_ids: vec![],
+                has_attachments: false,
+            },
+        ];
+
+        let filtered = apply_email_filters(candidates, &plan, now);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].message_id.as_deref(), Some("1"));
+    }
+}

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mod.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mod.rs
@@ -12,6 +12,8 @@ mod calendar_fallback;
 mod calendar_range;
 mod chat;
 mod email;
+mod email_fallback;
+mod email_plan;
 mod mixed;
 
 pub(super) struct AssistantOrchestratorResult {
@@ -50,7 +52,9 @@ pub(super) async fn execute_query(
             )
             .await
         }
-        AssistantQueryCapability::EmailLookup => Ok(email::execute_email_query(state, query)),
+        AssistantQueryCapability::EmailLookup => {
+            email::execute_email_query(state, user_id, request_id, query, prior_state).await
+        }
         AssistantQueryCapability::Mixed => Ok(mixed::execute_mixed_query(state, query)),
         AssistantQueryCapability::GeneralChat => Ok(chat::execute_general_chat(state, query)),
     }


### PR DESCRIPTION
## Summary
- implement issue #169 by replacing the email-lane scaffold with a bounded enclave inbox lookup path
- add query-driven sender/time-window planning for assistant turns (sender filter + bounded lookback windows)
- keep urgent-email worker behavior compatible while enabling general assistant inbox Q&A retrieval

## Changes
- assistant orchestrator:
  - make email lane async and tool-backed (`execute_email_query`)
  - fetch Gmail candidates through enclave-only path with bounded query and max results
  - apply deterministic sender/time-window filtering for no-match/sender/time-window queries
  - retain safety/validation flow via `resolve_safe_output(AssistantCapability::UrgentEmailSummary)`
  - map validated/safe output into assistant structured payload; use deterministic fallback when needed
- modularization:
  - add `email_plan` module (query planning + gmail query builder + filtering)
  - add `email_fallback` module (grounded deterministic payload shaping)
- enclave service:
  - add `fetch_google_email_candidates(request, gmail_query, max_results)`
  - keep existing `fetch_google_urgent_email_candidates` by delegating to the new method with `newer_than:2d`

## Acceptance Criteria Mapping
- [x] Assistant can answer general inbox questions using tool-backed context
- [x] Existing urgent-email worker flow remains compatible (delegated path preserved)
- [x] Result shaping is safety-filtered and contract-validated before mapping to assistant payload
- [x] Tests cover: no-match query, sender filter query, time-window query

## Validation
- `just check-tools`
- `just backend-fmt`
- `just backend-test`
- `just backend-deep-review`
- `just ios-build`

All passed locally.

## AI Review Summary
- Security audit: no findings
- Bug check: no findings
- Scalability/code quality review: extracted planner/fallback helpers to keep assistant email lane modular and maintainable
- Merge recommendation: APPROVE

Closes #169
Part of #166
