### PR TITLE
[Assistant v2] #170 General chat lane + mixed tool orchestration

### DIFF
--- a/backend/crates/enclave-runtime/src/http/assistant/memory.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/memory.rs
@@ -175,4 +175,21 @@ mod tests {
             Some(AssistantQueryCapability::EmailLookup)
         );
     }
+
+    #[test]
+    fn resolve_capability_switches_between_chat_and_tool_lanes() {
+        assert_eq!(
+            resolve_query_capability(
+                "show my meetings tomorrow",
+                detect_query_capability("show my meetings tomorrow"),
+                Some(AssistantQueryCapability::GeneralChat),
+            ),
+            Some(AssistantQueryCapability::CalendarLookup)
+        );
+
+        assert_eq!(
+            resolve_query_capability("thanks", detect_query_capability("thanks"), None),
+            None
+        );
+    }
 }

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/calendar.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/calendar.rs
@@ -6,7 +6,7 @@ use shared::llm::{
     SafeOutputSource, generate_with_telemetry, resolve_safe_output, sanitize_context_payload,
     template_for_capability,
 };
-use shared::models::AssistantQueryCapability;
+use shared::models::{AssistantQueryCapability, AssistantResponsePart};
 use tracing::warn;
 use uuid::Uuid;
 
@@ -160,11 +160,16 @@ pub(super) async fn execute_calendar_query(
     let display_text = super::super::notifications::non_empty(payload.summary.as_str())
         .unwrap_or(default_display_for_window(&capability, &window))
         .to_string();
+    let response_parts = vec![
+        AssistantResponsePart::chat_text(display_text.clone()),
+        AssistantResponsePart::tool_summary(capability.clone(), payload.clone()),
+    ];
 
     Ok(AssistantOrchestratorResult {
         capability,
         display_text,
         payload,
+        response_parts,
         attested_identity: fetch_response.attested_identity,
     })
 }

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/chat.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/chat.rs
@@ -1,6 +1,7 @@
 use shared::llm::safety::sanitize_untrusted_text;
-use shared::models::{AssistantQueryCapability, AssistantStructuredPayload};
+use shared::models::{AssistantQueryCapability, AssistantResponsePart, AssistantStructuredPayload};
 
+use super::super::session_state::EnclaveAssistantSessionState;
 use super::{AssistantOrchestratorResult, local_attested_identity};
 use crate::RuntimeState;
 
@@ -9,25 +10,16 @@ const QUERY_SNIPPET_MAX_CHARS: usize = 120;
 pub(super) fn execute_general_chat(
     state: &RuntimeState,
     query: &str,
+    prior_state: Option<&EnclaveAssistantSessionState>,
 ) -> AssistantOrchestratorResult {
-    let query_snippet = sanitize_untrusted_text(query)
-        .chars()
-        .take(QUERY_SNIPPET_MAX_CHARS)
-        .collect::<String>();
-    let summary = if query_snippet.is_empty() {
-        "I can help with general conversation and, in upcoming turns, with calendar and email lookups.".to_string()
-    } else {
-        format!(
-            "I heard: \"{query_snippet}\". I can chat generally now and will route to calendar/email tools when requested."
-        )
-    };
+    let summary = general_chat_summary(query, prior_state);
 
     AssistantOrchestratorResult {
         capability: AssistantQueryCapability::GeneralChat,
         display_text: summary.clone(),
         payload: AssistantStructuredPayload {
             title: "General conversation".to_string(),
-            summary,
+            summary: summary.clone(),
             key_points: vec![
                 "General-chat lane is active in Assistant v2.".to_string(),
                 "Tool-backed calendar/email retrieval routes are capability-gated.".to_string(),
@@ -37,6 +29,73 @@ pub(super) fn execute_general_chat(
                 "Ask: Any important emails this week?".to_string(),
             ],
         },
+        response_parts: vec![AssistantResponsePart::chat_text(summary)],
         attested_identity: local_attested_identity(state),
+    }
+}
+
+fn general_chat_summary(query: &str, prior_state: Option<&EnclaveAssistantSessionState>) -> String {
+    let query_snippet = sanitize_untrusted_text(query)
+        .chars()
+        .take(QUERY_SNIPPET_MAX_CHARS)
+        .collect::<String>();
+    let follow_up_context = prior_state
+        .and_then(|state| state.memory.turns.last())
+        .map(|turn| {
+            format!(
+                "Following up on your previous {} request: ",
+                capability_label(&turn.capability)
+            )
+        })
+        .unwrap_or_default();
+
+    if query_snippet.is_empty() {
+        "I can help with general conversation and, in upcoming turns, with calendar and email lookups.".to_string()
+    } else {
+        format!(
+            "{follow_up_context}I heard: \"{query_snippet}\". I can chat generally now and will route to calendar/email tools when requested."
+        )
+    }
+}
+
+fn capability_label(capability: &AssistantQueryCapability) -> &'static str {
+    match capability {
+        AssistantQueryCapability::MeetingsToday => "meetings",
+        AssistantQueryCapability::CalendarLookup => "calendar",
+        AssistantQueryCapability::EmailLookup => "email",
+        AssistantQueryCapability::GeneralChat => "chat",
+        AssistantQueryCapability::Mixed => "calendar and email",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use shared::assistant_memory::{
+        ASSISTANT_SESSION_MEMORY_VERSION_V1, AssistantSessionMemory, AssistantSessionTurn,
+    };
+    use shared::models::AssistantQueryCapability;
+
+    use super::general_chat_summary;
+    use crate::http::assistant::session_state::EnclaveAssistantSessionState;
+
+    #[test]
+    fn general_chat_summary_includes_follow_up_context_when_memory_exists() {
+        let prior_state = EnclaveAssistantSessionState {
+            version: ASSISTANT_SESSION_MEMORY_VERSION_V1.to_string(),
+            last_capability: AssistantQueryCapability::EmailLookup,
+            memory: AssistantSessionMemory {
+                version: ASSISTANT_SESSION_MEMORY_VERSION_V1.to_string(),
+                turns: vec![AssistantSessionTurn {
+                    user_query_snippet: "anything from finance?".to_string(),
+                    assistant_summary_snippet: "One urgent email matched.".to_string(),
+                    capability: AssistantQueryCapability::EmailLookup,
+                    created_at: Utc::now(),
+                }],
+            },
+        };
+
+        let summary = general_chat_summary("thanks", Some(&prior_state));
+        assert!(summary.starts_with("Following up on your previous email request:"));
     }
 }

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/email.rs
@@ -7,7 +7,7 @@ use shared::llm::{
     SafeOutputSource, assemble_urgent_email_candidates_context, generate_with_telemetry,
     output_schema, resolve_safe_output, sanitize_context_payload,
 };
-use shared::models::{AssistantQueryCapability, AssistantStructuredPayload};
+use shared::models::{AssistantQueryCapability, AssistantResponsePart, AssistantStructuredPayload};
 use tracing::warn;
 use uuid::Uuid;
 
@@ -196,11 +196,16 @@ pub(super) async fn execute_email_query(
     let display_text = non_empty(payload.summary.as_str())
         .unwrap_or("Here is your inbox summary.")
         .to_string();
+    let response_parts = vec![
+        AssistantResponsePart::chat_text(display_text.clone()),
+        AssistantResponsePart::tool_summary(AssistantQueryCapability::EmailLookup, payload.clone()),
+    ];
 
     Ok(AssistantOrchestratorResult {
         capability: AssistantQueryCapability::EmailLookup,
         display_text,
         payload,
+        response_parts,
         attested_identity: fetch_response.attested_identity,
     })
 }

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mixed/mixed_tests.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mixed/mixed_tests.rs
@@ -1,0 +1,136 @@
+use shared::models::{
+    AssistantQueryCapability, AssistantResponsePartType, AssistantStructuredPayload,
+};
+
+use super::{
+    combine_follow_ups, compose_full_mixed_payload, compose_full_response_parts,
+    compose_partial_response_parts,
+};
+
+#[test]
+fn compose_full_mixed_payload_prefixes_calendar_and_email_points() {
+    let calendar = AssistantStructuredPayload {
+        title: "Calendar".to_string(),
+        summary: "Calendar summary".to_string(),
+        key_points: vec!["10:00 Team sync".to_string()],
+        follow_ups: vec!["Ask for tomorrow.".to_string()],
+    };
+    let email = AssistantStructuredPayload {
+        title: "Email".to_string(),
+        summary: "Email summary".to_string(),
+        key_points: vec!["finance@example.com - Invoice".to_string()],
+        follow_ups: vec!["Filter by sender.".to_string()],
+    };
+
+    let payload = compose_full_mixed_payload(
+        "what do i need from calendar and email today?",
+        &calendar,
+        &email,
+    );
+    assert_eq!(payload.title, "Calendar and inbox summary");
+    assert!(
+        payload
+            .summary
+            .contains("combined summary from your calendar and inbox"),
+        "mixed summary should include combined explanation"
+    );
+    assert_eq!(
+        payload.key_points,
+        vec![
+            "Calendar: 10:00 Team sync".to_string(),
+            "Email: finance@example.com - Invoice".to_string(),
+        ]
+    );
+    assert_eq!(
+        payload.follow_ups,
+        vec![
+            "Ask for tomorrow.".to_string(),
+            "Filter by sender.".to_string()
+        ]
+    );
+}
+
+#[test]
+fn combine_follow_ups_deduplicates_and_limits_results() {
+    let follow_ups = combine_follow_ups(
+        &[
+            "Ask for tomorrow.".to_string(),
+            "Filter by sender.".to_string(),
+            "Filter by sender.".to_string(),
+        ],
+        &[
+            "Ask for tomorrow.".to_string(),
+            "Show this week.".to_string(),
+            "Show next week.".to_string(),
+            "Extra item".to_string(),
+        ],
+    );
+
+    assert_eq!(
+        follow_ups,
+        vec![
+            "Ask for tomorrow.".to_string(),
+            "Filter by sender.".to_string(),
+            "Show this week.".to_string(),
+            "Show next week.".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn compose_full_response_parts_emits_chat_and_two_tool_summaries() {
+    let calendar = AssistantStructuredPayload {
+        title: "Calendar".to_string(),
+        summary: "Calendar summary".to_string(),
+        key_points: vec![],
+        follow_ups: vec![],
+    };
+    let email = AssistantStructuredPayload {
+        title: "Email".to_string(),
+        summary: "Email summary".to_string(),
+        key_points: vec![],
+        follow_ups: vec![],
+    };
+
+    let parts = compose_full_response_parts(
+        "Combined summary".to_string(),
+        &AssistantQueryCapability::CalendarLookup,
+        &calendar,
+        &AssistantQueryCapability::EmailLookup,
+        &email,
+    );
+
+    assert_eq!(parts.len(), 3);
+    assert_eq!(parts[0].part_type, AssistantResponsePartType::ChatText);
+    assert_eq!(
+        parts[1].capability,
+        Some(AssistantQueryCapability::CalendarLookup)
+    );
+    assert_eq!(
+        parts[2].capability,
+        Some(AssistantQueryCapability::EmailLookup)
+    );
+}
+
+#[test]
+fn compose_partial_response_parts_emits_single_tool_summary() {
+    let payload = AssistantStructuredPayload {
+        title: "Calendar".to_string(),
+        summary: "Calendar summary".to_string(),
+        key_points: vec![],
+        follow_ups: vec![],
+    };
+
+    let parts = compose_partial_response_parts(
+        "Partial summary".to_string(),
+        &AssistantQueryCapability::CalendarLookup,
+        &payload,
+    );
+
+    assert_eq!(parts.len(), 2);
+    assert_eq!(parts[0].part_type, AssistantResponsePartType::ChatText);
+    assert_eq!(
+        parts[1].capability,
+        Some(AssistantQueryCapability::CalendarLookup)
+    );
+}

--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mod.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/mod.rs
@@ -1,6 +1,6 @@
 use axum::response::Response;
 use shared::enclave::AttestedIdentityPayload;
-use shared::models::{AssistantQueryCapability, AssistantStructuredPayload};
+use shared::models::{AssistantQueryCapability, AssistantResponsePart, AssistantStructuredPayload};
 use shared::timezone::DEFAULT_USER_TIME_ZONE;
 use tracing::warn;
 use uuid::Uuid;
@@ -22,6 +22,7 @@ pub(super) struct AssistantOrchestratorResult {
     pub(super) capability: AssistantQueryCapability,
     pub(super) display_text: String,
     pub(super) payload: AssistantStructuredPayload,
+    pub(super) response_parts: Vec<AssistantResponsePart>,
     pub(super) attested_identity: AttestedIdentityPayload,
 }
 
@@ -80,7 +81,9 @@ pub(super) async fn execute_query(
             )
             .await
         }
-        AssistantQueryCapability::GeneralChat => Ok(chat::execute_general_chat(state, query)),
+        AssistantQueryCapability::GeneralChat => {
+            Ok(chat::execute_general_chat(state, query, prior_state))
+        }
     }
 }
 

--- a/backend/crates/enclave-runtime/src/http/assistant/query.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/query.rs
@@ -133,6 +133,7 @@ pub(super) async fn process_assistant_query(
         capability: execution.capability.clone(),
         display_text: execution.display_text.clone(),
         payload: execution.payload,
+        response_parts: execution.response_parts,
     };
 
     let encrypted_response = match encrypt_assistant_response(

--- a/backend/crates/integration-tests/tests/api_assistant_content_blind_e2e.rs
+++ b/backend/crates/integration-tests/tests/api_assistant_content_blind_e2e.rs
@@ -223,6 +223,7 @@ async fn start_assistant_mock_enclave(
                                     key_points: vec!["Enclave-only decrypt path".to_string()],
                                     follow_ups: vec![],
                                 },
+                                response_parts: vec![],
                             };
 
                             let response_envelope = encrypt_assistant_response(

--- a/backend/crates/shared/src/assistant_crypto.rs
+++ b/backend/crates/shared/src/assistant_crypto.rs
@@ -284,6 +284,7 @@ mod tests {
                 key_points: vec!["phase 1 route live".to_string()],
                 follow_ups: vec![],
             },
+            response_parts: vec![],
         };
         let response_envelope = encrypt_assistant_response(
             &keyring.active,

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -83,12 +83,54 @@ pub enum AssistantQueryCapability {
     Mixed,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssistantResponsePartType {
+    ChatText,
+    ToolSummary,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssistantStructuredPayload {
     pub title: String,
     pub summary: String,
     pub key_points: Vec<String>,
     pub follow_ups: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantResponsePart {
+    #[serde(rename = "type")]
+    pub part_type: AssistantResponsePartType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability: Option<AssistantQueryCapability>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<AssistantStructuredPayload>,
+}
+
+impl AssistantResponsePart {
+    pub fn chat_text(text: impl Into<String>) -> Self {
+        Self {
+            part_type: AssistantResponsePartType::ChatText,
+            text: Some(text.into()),
+            capability: None,
+            payload: None,
+        }
+    }
+
+    pub fn tool_summary(
+        capability: AssistantQueryCapability,
+        payload: AssistantStructuredPayload,
+    ) -> Self {
+        Self {
+            part_type: AssistantResponsePartType::ToolSummary,
+            text: None,
+            capability: Some(capability),
+            payload: Some(payload),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,6 +152,8 @@ pub struct AssistantPlaintextQueryResponse {
     pub capability: AssistantQueryCapability,
     pub display_text: String,
     pub payload: AssistantStructuredPayload,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub response_parts: Vec<AssistantResponsePart>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
Implements issue #170 in the Assistant v2 tracker by completing general-chat + mixed-tool orchestration behavior in enclave responses while preserving encrypted session continuity.

## Changes
- Added structured assistant response parts to shared backend models:
  - `AssistantResponsePartType` (`chat_text`, `tool_summary`)
  - `AssistantResponsePart`
  - `response_parts` on `AssistantPlaintextQueryResponse`
- Updated orchestrator result contract so each lane emits response parts:
  - General chat emits `chat_text`
  - Calendar/email emit `chat_text` + lane `tool_summary`
  - Mixed emits `chat_text` + separate calendar/email `tool_summary` parts
- Improved general-chat continuity to include prior encrypted session-memory context in chat summaries.
- Updated query pipeline to return `response_parts` in encrypted response payloads.
- Added/updated tests:
  - capability switching between chat/tool lanes
  - mixed response-parts composition and dedupe behavior
  - encrypted e2e mock payload compatibility with new field
- Refactored mixed-lane tests into `backend/crates/enclave-runtime/src/http/assistant/orchestrator/mixed/mixed_tests.rs` to keep `mixed.rs` size modular.

## Validation
- `just ios-build` ✅
- `just backend-tests` ✅
- `just backend-verify` ✅
- `just backend-eval` ✅
- `just backend-deep-review` ✅

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: new/updated unit + integration coverage and full backend gates green
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no boundary violations
- Performance/scalability concerns: no material regressions
- Refactor recommendations: applied in this PR by extracting mixed tests module

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #170