### PR TITLE
[Assistant v2] #172 Privacy/eval hardening and rollout guardrails

### DIFF
--- a/agent/start.md
+++ b/agent/start.md
@@ -21,6 +21,10 @@ Use this template for required AI review reporting before merge:
 
 `docs/ai-review-template.md`
 
+Assistant v2 privacy/eval guardrails and verification checklist:
+
+`docs/assistant-v2-privacy-eval.md`
+
 ## Project Summary
 
 Alfred is a privacy-first iOS assistant product with a hosted backend.

--- a/backend/crates/api-server/src/http/assistant/query.rs
+++ b/backend/crates/api-server/src/http/assistant/query.rs
@@ -187,38 +187,34 @@ fn map_assistant_enclave_error(
             );
             bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
         }
-        EnclaveRpcError::RpcTransportUnavailable { message } => {
+        EnclaveRpcError::RpcTransportUnavailable { message: _ } => {
             warn!(
                 %user_id,
                 assistant_request_id,
-                message = %message,
                 "assistant query enclave RPC transport unavailable"
             );
             bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
         }
-        EnclaveRpcError::RpcResponseInvalid { message } => {
+        EnclaveRpcError::RpcResponseInvalid { message: _ } => {
             warn!(
                 %user_id,
                 assistant_request_id,
-                message = %message,
                 "assistant query enclave RPC response invalid"
             );
             bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
         }
-        EnclaveRpcError::DecryptNotAuthorized { message } => {
+        EnclaveRpcError::DecryptNotAuthorized { message: _ } => {
             warn!(
                 %user_id,
                 assistant_request_id,
-                message = %message,
                 "assistant query token decrypt not authorized"
             );
             bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
         }
-        EnclaveRpcError::ConnectorTokenDecryptFailed { message } => {
+        EnclaveRpcError::ConnectorTokenDecryptFailed { message: _ } => {
             warn!(
                 %user_id,
                 assistant_request_id,
-                message = %message,
                 "assistant query connector token decrypt failed"
             );
             bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
@@ -234,12 +230,14 @@ fn map_assistant_enclave_error(
                 "Google connector is not active for this account; reconnect Google and retry",
             )
         }
-        EnclaveRpcError::ProviderRequestUnavailable { operation, message } => {
+        EnclaveRpcError::ProviderRequestUnavailable {
+            operation,
+            message: _,
+        } => {
             warn!(
                 %user_id,
                 assistant_request_id,
                 operation = %operation,
-                message = %message,
                 "assistant query provider request unavailable"
             );
             bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
@@ -247,24 +245,25 @@ fn map_assistant_enclave_error(
         EnclaveRpcError::ProviderRequestFailed {
             operation,
             status,
-            oauth_error,
+            oauth_error: _,
         } => {
             warn!(
                 %user_id,
                 assistant_request_id,
                 operation = %operation,
                 status,
-                oauth_error = ?oauth_error,
                 "assistant query provider request failed"
             );
             bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")
         }
-        EnclaveRpcError::ProviderResponseInvalid { operation, message } => {
+        EnclaveRpcError::ProviderResponseInvalid {
+            operation,
+            message: _,
+        } => {
             warn!(
                 %user_id,
                 assistant_request_id,
                 operation = %operation,
-                message = %message,
                 "assistant query provider response invalid"
             );
             bad_gateway_response("enclave_rpc_failed", "Secure enclave RPC request failed")

--- a/backend/crates/llm-eval/fixtures/assistant_cases/assistant_calendar_lookup.json
+++ b/backend/crates/llm-eval/fixtures/assistant_cases/assistant_calendar_lookup.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "assistant_calendar_lookup",
+  "description": "Calendar-focused query resolves to calendar tool lane.",
+  "query": "Please check my calendar for next week",
+  "expectations": {
+    "detected_capability": "calendar_lookup",
+    "resolved_capability": "calendar_lookup",
+    "expected_response_part_types": ["chat_text", "tool_summary"]
+  }
+}

--- a/backend/crates/llm-eval/fixtures/assistant_cases/assistant_chat_general.json
+++ b/backend/crates/llm-eval/fixtures/assistant_cases/assistant_chat_general.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "assistant_chat_general",
+  "description": "General chat query resolves to chat lane when no tool intent is detected.",
+  "query": "Can you explain what you can help me with?",
+  "expectations": {
+    "detected_capability": null,
+    "resolved_capability": "general_chat",
+    "expected_response_part_types": ["chat_text"]
+  }
+}

--- a/backend/crates/llm-eval/fixtures/assistant_cases/assistant_email_lookup.json
+++ b/backend/crates/llm-eval/fixtures/assistant_cases/assistant_email_lookup.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "assistant_email_lookup",
+  "description": "Email-focused query resolves to email tool lane.",
+  "query": "Any emails from finance that need attention?",
+  "expectations": {
+    "detected_capability": "email_lookup",
+    "resolved_capability": "email_lookup",
+    "expected_response_part_types": ["chat_text", "tool_summary"]
+  }
+}

--- a/backend/crates/llm-eval/fixtures/assistant_cases/assistant_follow_up_prior_email.json
+++ b/backend/crates/llm-eval/fixtures/assistant_cases/assistant_follow_up_prior_email.json
@@ -1,0 +1,11 @@
+{
+  "case_id": "assistant_follow_up_prior_email",
+  "description": "Short follow-up query reuses prior email lane when explicit tool intent is absent.",
+  "query": "what about after that",
+  "prior_capability": "email_lookup",
+  "expectations": {
+    "detected_capability": null,
+    "resolved_capability": "email_lookup",
+    "expected_response_part_types": ["chat_text", "tool_summary"]
+  }
+}

--- a/backend/crates/llm-eval/fixtures/assistant_cases/assistant_mixed_lookup.json
+++ b/backend/crates/llm-eval/fixtures/assistant_cases/assistant_mixed_lookup.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "assistant_mixed_lookup",
+  "description": "Query that asks for both calendar and inbox resolves to mixed lane.",
+  "query": "Check my calendar and inbox for tomorrow afternoon",
+  "expectations": {
+    "detected_capability": "mixed",
+    "resolved_capability": "mixed",
+    "expected_response_part_types": ["chat_text", "tool_summary", "tool_summary"]
+  }
+}

--- a/backend/crates/llm-eval/fixtures/goldens/assistant_calendar_lookup.golden.json
+++ b/backend/crates/llm-eval/fixtures/goldens/assistant_calendar_lookup.golden.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "assistant_calendar_lookup",
+  "description": "Calendar-focused query resolves to calendar tool lane.",
+  "detected_capability": "calendar_lookup",
+  "prior_capability": null,
+  "query": "Please check my calendar for next week",
+  "resolved_capability": "calendar_lookup",
+  "response_part_types": [
+    "chat_text",
+    "tool_summary"
+  ]
+}

--- a/backend/crates/llm-eval/fixtures/goldens/assistant_chat_general.golden.json
+++ b/backend/crates/llm-eval/fixtures/goldens/assistant_chat_general.golden.json
@@ -1,0 +1,11 @@
+{
+  "case_id": "assistant_chat_general",
+  "description": "General chat query resolves to chat lane when no tool intent is detected.",
+  "detected_capability": null,
+  "prior_capability": null,
+  "query": "Can you explain what you can help me with?",
+  "resolved_capability": "general_chat",
+  "response_part_types": [
+    "chat_text"
+  ]
+}

--- a/backend/crates/llm-eval/fixtures/goldens/assistant_email_lookup.golden.json
+++ b/backend/crates/llm-eval/fixtures/goldens/assistant_email_lookup.golden.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "assistant_email_lookup",
+  "description": "Email-focused query resolves to email tool lane.",
+  "detected_capability": "email_lookup",
+  "prior_capability": null,
+  "query": "Any emails from finance that need attention?",
+  "resolved_capability": "email_lookup",
+  "response_part_types": [
+    "chat_text",
+    "tool_summary"
+  ]
+}

--- a/backend/crates/llm-eval/fixtures/goldens/assistant_follow_up_prior_email.golden.json
+++ b/backend/crates/llm-eval/fixtures/goldens/assistant_follow_up_prior_email.golden.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "assistant_follow_up_prior_email",
+  "description": "Short follow-up query reuses prior email lane when explicit tool intent is absent.",
+  "detected_capability": null,
+  "prior_capability": "email_lookup",
+  "query": "what about after that",
+  "resolved_capability": "email_lookup",
+  "response_part_types": [
+    "chat_text",
+    "tool_summary"
+  ]
+}

--- a/backend/crates/llm-eval/fixtures/goldens/assistant_mixed_lookup.golden.json
+++ b/backend/crates/llm-eval/fixtures/goldens/assistant_mixed_lookup.golden.json
@@ -1,0 +1,13 @@
+{
+  "case_id": "assistant_mixed_lookup",
+  "description": "Query that asks for both calendar and inbox resolves to mixed lane.",
+  "detected_capability": "mixed",
+  "prior_capability": null,
+  "query": "Check my calendar and inbox for tomorrow afternoon",
+  "resolved_capability": "mixed",
+  "response_part_types": [
+    "chat_text",
+    "tool_summary",
+    "tool_summary"
+  ]
+}

--- a/backend/crates/llm-eval/src/assistant_case.rs
+++ b/backend/crates/llm-eval/src/assistant_case.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+use shared::models::AssistantQueryCapability;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AssistantRoutingEvalCaseFixture {
+    pub case_id: String,
+    pub description: String,
+    pub query: String,
+    #[serde(default)]
+    pub prior_capability: Option<AssistantQueryCapability>,
+    pub expectations: AssistantRoutingExpectations,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AssistantRoutingExpectations {
+    #[serde(default)]
+    pub detected_capability: Option<AssistantQueryCapability>,
+    pub resolved_capability: AssistantQueryCapability,
+    pub expected_response_part_types: Vec<ExpectedResponsePartType>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpectedResponsePartType {
+    ChatText,
+    ToolSummary,
+}

--- a/backend/crates/llm-eval/src/main.rs
+++ b/backend/crates/llm-eval/src/main.rs
@@ -1,3 +1,4 @@
+mod assistant_case;
 mod case;
 mod cli;
 mod engine;

--- a/backend/crates/shared/src/assistant_planner.rs
+++ b/backend/crates/shared/src/assistant_planner.rs
@@ -1,0 +1,127 @@
+use crate::models::AssistantQueryCapability;
+
+pub fn detect_query_capability(query: &str) -> Option<AssistantQueryCapability> {
+    let normalized = query.to_ascii_lowercase();
+    let asks_for_today = normalized.contains("today");
+    let asks_for_calendar = normalized.contains("meeting")
+        || normalized.contains("calendar")
+        || normalized.contains("schedule")
+        || normalized.contains("event");
+    let asks_for_email = normalized.contains("email")
+        || normalized.contains("inbox")
+        || normalized.contains("mail")
+        || normalized.contains("gmail");
+
+    if asks_for_calendar && asks_for_email {
+        return Some(AssistantQueryCapability::Mixed);
+    }
+
+    if asks_for_email {
+        return Some(AssistantQueryCapability::EmailLookup);
+    }
+
+    if asks_for_today && asks_for_calendar {
+        return Some(AssistantQueryCapability::MeetingsToday);
+    }
+
+    if asks_for_calendar {
+        return Some(AssistantQueryCapability::CalendarLookup);
+    }
+
+    None
+}
+
+pub fn resolve_query_capability(
+    query: &str,
+    detected: Option<AssistantQueryCapability>,
+    prior_capability: Option<AssistantQueryCapability>,
+) -> Option<AssistantQueryCapability> {
+    detected.or_else(|| {
+        if looks_like_follow_up_query(query) {
+            return prior_capability;
+        }
+
+        None
+    })
+}
+
+fn looks_like_follow_up_query(query: &str) -> bool {
+    let normalized = query.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+
+    let token_count = normalized.split_whitespace().count();
+    if token_count > 10 {
+        return false;
+    }
+
+    let follow_up_markers = [
+        "what about",
+        "how about",
+        "and then",
+        "then",
+        "next",
+        "after that",
+        "same",
+        "again",
+        "also",
+        "those",
+        "them",
+    ];
+
+    follow_up_markers
+        .iter()
+        .any(|marker| normalized.contains(marker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_query_capability, resolve_query_capability};
+    use crate::models::AssistantQueryCapability;
+
+    #[test]
+    fn detect_capability_classifies_chat_calendar_email_and_mixed() {
+        assert_eq!(
+            detect_query_capability("What meetings do I have today?"),
+            Some(AssistantQueryCapability::MeetingsToday)
+        );
+        assert_eq!(
+            detect_query_capability("Show my schedule next week"),
+            Some(AssistantQueryCapability::CalendarLookup)
+        );
+        assert_eq!(
+            detect_query_capability("Any emails from finance?"),
+            Some(AssistantQueryCapability::EmailLookup)
+        );
+        assert_eq!(
+            detect_query_capability("Check calendar and inbox for this afternoon"),
+            Some(AssistantQueryCapability::Mixed)
+        );
+        assert_eq!(detect_query_capability("thanks"), None);
+    }
+
+    #[test]
+    fn resolve_capability_uses_prior_for_follow_up_queries() {
+        assert_eq!(
+            resolve_query_capability(
+                "what about after that",
+                None,
+                Some(AssistantQueryCapability::EmailLookup),
+            ),
+            Some(AssistantQueryCapability::EmailLookup)
+        );
+    }
+
+    #[test]
+    fn resolve_capability_preserves_explicit_tool_detection() {
+        assert_eq!(
+            resolve_query_capability(
+                "show my meetings tomorrow",
+                detect_query_capability("show my meetings tomorrow"),
+                Some(AssistantQueryCapability::GeneralChat),
+            ),
+            Some(AssistantQueryCapability::CalendarLookup)
+        );
+    }
+}

--- a/backend/crates/shared/src/lib.rs
+++ b/backend/crates/shared/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod assistant_crypto;
 pub mod assistant_memory;
+pub mod assistant_planner;
 pub mod config;
 mod config_enclave_runtime;
 mod config_env;

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -90,7 +90,7 @@ pub enum AssistantResponsePartType {
     ToolSummary,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AssistantStructuredPayload {
     pub title: String,
     pub summary: String,
@@ -98,7 +98,7 @@ pub struct AssistantStructuredPayload {
     pub follow_ups: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AssistantResponsePart {
     #[serde(rename = "type")]
     pub part_type: AssistantResponsePartType,

--- a/docs/assistant-v2-privacy-eval.md
+++ b/docs/assistant-v2-privacy-eval.md
@@ -1,0 +1,48 @@
+# Assistant v2 Privacy + Eval Guardrails
+
+- Last Updated: 2026-02-17
+- Scope: Assistant query path (`/v1/assistant/query`) with encrypted request/response envelopes and enclave-only plaintext.
+
+## 1) Privacy Boundary Invariants
+
+1. Host control-plane paths only handle encrypted assistant message envelopes.
+2. Plaintext assistant query/response content is allowed only inside attested enclave runtime paths.
+3. Host persistence in `assistant_encrypted_sessions.state_json` must remain ciphertext-only; plaintext query/response snippets must not be stored.
+4. Host assistant error logs must not include upstream enclave `message` body text.
+5. API-visible `AssistantQueryResponse` contract must remain envelope-only (`session_id` + `envelope`).
+
+## 2) Eval and Test Coverage Expectations
+
+Assistant v2 is considered guarded only when all of the following pass:
+
+1. `just backend-eval`
+2. `just backend-tests`
+3. `just backend-verify`
+4. `just backend-deep-review`
+
+### `backend-eval` assistant coverage
+
+`backend-eval` now includes deterministic assistant routing fixtures/goldens for:
+
+1. `general_chat`
+2. `calendar_lookup`
+3. `email_lookup`
+4. `mixed`
+5. follow-up routing that reuses prior capability context
+
+Fixture path:
+
+- `backend/crates/llm-eval/fixtures/assistant_cases`
+
+Goldens path:
+
+- `backend/crates/llm-eval/fixtures/goldens/assistant_*.golden.json`
+
+## 3) Operational Verification Checklist
+
+Before merge of assistant backend work:
+
+1. Confirm boundary guard tests pass for assistant request/response contracts.
+2. Confirm encrypted e2e assistant round-trip test verifies no plaintext leakage in host API payloads and DB session state.
+3. Confirm assistant error mapping logs are metadata-only (no upstream message body).
+4. Confirm PR includes AI review summary (`docs/ai-review-template.md`) with security/bug/scalability findings.


### PR DESCRIPTION
## Summary
Implements issue #172 by hardening Assistant v2 privacy boundaries and expanding deterministic eval + integration coverage for chat/calendar/email/mixed routing behavior.

## Changes
- Added shared Assistant routing planner module (`shared::assistant_planner`) and reused it in enclave assistant memory/routing.
- Extended `llm-eval` with Assistant v2 routing fixtures and goldens:
  - `general_chat`
  - `calendar_lookup`
  - `email_lookup`
  - `mixed`
  - follow-up prior-capability reuse
- Added boundary guard tests for:
  - Assistant host response contract remains encrypted-envelope-only
  - host assistant error logging cannot include upstream `message`/`oauth_error` details
- Hardened host assistant error mapping logging to metadata-only fields.
- Expanded encrypted assistant e2e test to validate v2 `response_parts` round-trip and assert no plaintext leakage into host API payload or persisted encrypted session state.
- Added documentation: `docs/assistant-v2-privacy-eval.md` and linked from `agent/start.md`.

## Validation
- `just check-tools`
- `just backend-eval-update`
- `just backend-eval`
- `just backend-tests`
- `just backend-verify`
- `just backend-deep-review`
- `just ios-build`

## AI Review Summary
### 1) Security Audit
- Findings:
  - fixed host log redaction gap in assistant error mapping (`message` and `oauth_error` were previously logged).
- Risk level:
  - medium before fix, low after fix.
- Required fixes:
  - completed in this PR.

### 2) Bug Check
- Findings:
  - none after full gate reruns.
- Repro or test evidence:
  - full backend verify/tests/eval/deep-review suite and iOS build are green locally.
- Required fixes:
  - none.

### 3) Scalability / Code Quality Review
- Layering and module ownership findings:
  - extracted planner detection/resolution into shared module to avoid duplicated drift across runtime and eval.
- Performance/scalability concerns:
  - none identified.
- Refactor recommendations:
  - none required for this issue.

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #172
