### PR TITLE
Phase B: replace keyword-first routing with planner policy executor

### DIFF
--- a/backend/crates/enclave-runtime/src/http/assistant/orchestrator/policy.rs
+++ b/backend/crates/enclave-runtime/src/http/assistant/orchestrator/policy.rs
@@ -1,0 +1,186 @@
+use shared::assistant_semantic_plan::AssistantSemanticPlan;
+use shared::models::AssistantQueryCapability;
+
+pub(super) const MIN_CONFIDENCE_FOR_DIRECT_EXECUTION: f32 = 0.45;
+const DEFAULT_CLARIFICATION_QUESTION: &str =
+    "Could you clarify whether you want calendar details, email details, or both?";
+
+pub(super) enum PlannedRoute {
+    Execute(AssistantQueryCapability),
+    Clarify(String),
+}
+
+pub(super) fn resolve_route_policy(
+    resolution: &super::planner::SemanticPlanResolution,
+) -> PlannedRoute {
+    let capability = resolution
+        .plan
+        .capabilities
+        .first()
+        .cloned()
+        .unwrap_or(AssistantQueryCapability::GeneralChat);
+
+    if should_clarify(
+        &resolution.plan,
+        resolution.used_deterministic_fallback,
+        &capability,
+    ) {
+        return PlannedRoute::Clarify(clarification_question(&resolution.plan));
+    }
+
+    PlannedRoute::Execute(capability)
+}
+
+fn should_clarify(
+    plan: &AssistantSemanticPlan,
+    used_deterministic_fallback: bool,
+    capability: &AssistantQueryCapability,
+) -> bool {
+    if plan.needs_clarification {
+        return true;
+    }
+
+    if used_deterministic_fallback {
+        return false;
+    }
+
+    if *capability == AssistantQueryCapability::GeneralChat {
+        return false;
+    }
+
+    plan.confidence < MIN_CONFIDENCE_FOR_DIRECT_EXECUTION
+}
+
+fn clarification_question(plan: &AssistantSemanticPlan) -> String {
+    plan.clarifying_question
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_CLARIFICATION_QUESTION)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, Utc};
+    use shared::assistant_semantic_plan::AssistantSemanticPlan;
+
+    use super::{MIN_CONFIDENCE_FOR_DIRECT_EXECUTION, PlannedRoute, resolve_route_policy};
+    use crate::http::assistant::orchestrator::planner::SemanticPlanResolution;
+    use shared::models::AssistantQueryCapability;
+
+    fn utc(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .expect("timestamp should parse")
+            .with_timezone(&Utc)
+    }
+
+    fn resolution(
+        capability: AssistantQueryCapability,
+        confidence: f32,
+        needs_clarification: bool,
+        used_fallback: bool,
+    ) -> SemanticPlanResolution {
+        SemanticPlanResolution {
+            plan: AssistantSemanticPlan {
+                capabilities: vec![capability],
+                confidence,
+                needs_clarification,
+                clarifying_question: Some("can you clarify?".to_string()),
+                time_window: None,
+                email_filters: None,
+                language: Some("en".to_string()),
+                planned_at: utc("2026-02-18T00:00:00Z"),
+            },
+            used_deterministic_fallback: used_fallback,
+        }
+    }
+
+    #[test]
+    fn high_confidence_calendar_executes_calendar_lane() {
+        let planned = resolve_route_policy(&resolution(
+            AssistantQueryCapability::CalendarLookup,
+            0.9,
+            false,
+            false,
+        ));
+        assert!(matches!(
+            planned,
+            PlannedRoute::Execute(AssistantQueryCapability::CalendarLookup)
+        ));
+    }
+
+    #[test]
+    fn high_confidence_mixed_executes_mixed_lane() {
+        let planned = resolve_route_policy(&resolution(
+            AssistantQueryCapability::Mixed,
+            0.9,
+            false,
+            false,
+        ));
+        assert!(matches!(
+            planned,
+            PlannedRoute::Execute(AssistantQueryCapability::Mixed)
+        ));
+    }
+
+    #[test]
+    fn resolves_to_clarification_when_plan_requests_it() {
+        let planned = resolve_route_policy(&resolution(
+            AssistantQueryCapability::CalendarLookup,
+            0.9,
+            true,
+            false,
+        ));
+        assert!(matches!(planned, PlannedRoute::Clarify(_)));
+    }
+
+    #[test]
+    fn low_confidence_non_chat_routes_to_clarification() {
+        let planned = resolve_route_policy(&resolution(
+            AssistantQueryCapability::EmailLookup,
+            MIN_CONFIDENCE_FOR_DIRECT_EXECUTION - 0.01,
+            false,
+            false,
+        ));
+        assert!(matches!(planned, PlannedRoute::Clarify(_)));
+    }
+
+    #[test]
+    fn low_confidence_chat_stays_in_chat_lane() {
+        let planned = resolve_route_policy(&resolution(
+            AssistantQueryCapability::GeneralChat,
+            0.1,
+            false,
+            false,
+        ));
+        assert!(matches!(
+            planned,
+            PlannedRoute::Execute(AssistantQueryCapability::GeneralChat)
+        ));
+    }
+
+    #[test]
+    fn deterministic_fallback_executes_without_forcing_clarification() {
+        let planned = resolve_route_policy(&resolution(
+            AssistantQueryCapability::CalendarLookup,
+            0.1,
+            false,
+            true,
+        ));
+        assert!(matches!(
+            planned,
+            PlannedRoute::Execute(AssistantQueryCapability::CalendarLookup)
+        ));
+    }
+
+    #[test]
+    fn clarification_uses_default_question_when_missing() {
+        let mut resolution = resolution(AssistantQueryCapability::EmailLookup, 0.9, true, false);
+        resolution.plan.clarifying_question = None;
+        let planned = resolve_route_policy(&resolution);
+        assert!(
+            matches!(planned, PlannedRoute::Clarify(question) if question.contains("calendar details"))
+        );
+    }
+}

--- a/backend/crates/shared/src/enclave/tests/boundary_guards.rs
+++ b/backend/crates/shared/src/enclave/tests/boundary_guards.rs
@@ -66,6 +66,25 @@ fn host_paths_do_not_construct_plaintext_llm_context_for_migrated_flows() {
 }
 
 #[test]
+fn enclave_orchestrator_primary_route_does_not_use_keyword_router() {
+    let shared_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = shared_root.join("../enclave-runtime/src/http/assistant/orchestrator/mod.rs");
+    let content = fs::read_to_string(&path)
+        .expect("failed to read enclave assistant orchestrator source for routing guard");
+
+    assert!(
+        !content.contains("detect_query_capability("),
+        "{} must not use keyword detector in primary orchestrator route selection",
+        path.display()
+    );
+    assert!(
+        !content.contains("resolve_query_capability("),
+        "{} must not use keyword resolver in primary orchestrator route selection",
+        path.display()
+    );
+}
+
+#[test]
 fn sensitive_error_mapping_does_not_embed_upstream_messages() {
     for file in sensitive_error_message_guard_files() {
         let content = fs::read_to_string(&file)


### PR DESCRIPTION
## Summary
Phase B now routes assistant queries planner-first inside enclave orchestrator, with deterministic policy gates for execute vs clarification.

## Changes
- made `orchestrator::execute_query` planner-primary and removed keyword detector/resolver from the primary route selection path
- added `orchestrator/policy.rs` to deterministically map semantic plan -> `Execute(capability)` or `Clarify(question)`
- added explicit clarification response path via `chat::execute_clarification(...)`
- retained deterministic fallback semantics in planner path, and added follow-up continuity test coverage through prior encrypted session context
- added boundary guard test to prevent reintroducing keyword-router calls into primary orchestrator routing

## Validation
- `just backend-tests`
- `just backend-verify`
- `just backend-deep-review`
- `just ios-build`

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: all backend + integration + eval suites passed in local deep-review gate
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: planner-policy decision logic is isolated in `orchestrator/policy.rs`; no repo-layer boundary violations
- Performance/scalability concerns: no material concerns found
- Refactor recommendations: none blocking for this phase

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #182
