### PR TITLE
Phase C: English-only planner hardening and temporal eval coverage

### DIFF
--- a/backend/crates/llm-eval/fixtures/assistant_cases/assistant_calendar_agenda_afternoon.json
+++ b/backend/crates/llm-eval/fixtures/assistant_cases/assistant_calendar_agenda_afternoon.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "assistant_calendar_agenda_afternoon",
+  "description": "English temporal paraphrase using agenda routes to calendar today lane.",
+  "query": "What is on my agenda this afternoon?",
+  "expectations": {
+    "detected_capability": "meetings_today",
+    "resolved_capability": "meetings_today",
+    "expected_response_part_types": ["chat_text", "tool_summary"]
+  }
+}

--- a/backend/crates/llm-eval/fixtures/assistant_cases/assistant_email_mailbox_messages.json
+++ b/backend/crates/llm-eval/fixtures/assistant_cases/assistant_email_mailbox_messages.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "assistant_email_mailbox_messages",
+  "description": "English inbox paraphrase using mailbox/messages routes to email lane.",
+  "query": "Any messages from finance in my mailbox this week?",
+  "expectations": {
+    "detected_capability": "email_lookup",
+    "resolved_capability": "email_lookup",
+    "expected_response_part_types": ["chat_text", "tool_summary"]
+  }
+}

--- a/backend/crates/llm-eval/fixtures/assistant_cases/assistant_follow_up_prior_calendar_temporal.json
+++ b/backend/crates/llm-eval/fixtures/assistant_cases/assistant_follow_up_prior_calendar_temporal.json
@@ -1,0 +1,11 @@
+{
+  "case_id": "assistant_follow_up_prior_calendar_temporal",
+  "description": "English follow-up temporal reference reuses prior calendar lane.",
+  "query": "what else afterwards",
+  "prior_capability": "calendar_lookup",
+  "expectations": {
+    "detected_capability": null,
+    "resolved_capability": "calendar_lookup",
+    "expected_response_part_types": ["chat_text", "tool_summary"]
+  }
+}

--- a/backend/crates/llm-eval/fixtures/assistant_cases/assistant_mixed_agenda_inbox_next_week.json
+++ b/backend/crates/llm-eval/fixtures/assistant_cases/assistant_mixed_agenda_inbox_next_week.json
@@ -1,0 +1,10 @@
+{
+  "case_id": "assistant_mixed_agenda_inbox_next_week",
+  "description": "English mixed-intent paraphrase with agenda + inbox routes to mixed lane.",
+  "query": "Give me agenda and inbox updates for next week",
+  "expectations": {
+    "detected_capability": "mixed",
+    "resolved_capability": "mixed",
+    "expected_response_part_types": ["chat_text", "tool_summary", "tool_summary"]
+  }
+}

--- a/backend/crates/llm-eval/fixtures/goldens/assistant_calendar_agenda_afternoon.golden.json
+++ b/backend/crates/llm-eval/fixtures/goldens/assistant_calendar_agenda_afternoon.golden.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "assistant_calendar_agenda_afternoon",
+  "description": "English temporal paraphrase using agenda routes to calendar today lane.",
+  "detected_capability": "meetings_today",
+  "prior_capability": null,
+  "query": "What is on my agenda this afternoon?",
+  "resolved_capability": "meetings_today",
+  "response_part_types": [
+    "chat_text",
+    "tool_summary"
+  ]
+}

--- a/backend/crates/llm-eval/fixtures/goldens/assistant_email_mailbox_messages.golden.json
+++ b/backend/crates/llm-eval/fixtures/goldens/assistant_email_mailbox_messages.golden.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "assistant_email_mailbox_messages",
+  "description": "English inbox paraphrase using mailbox/messages routes to email lane.",
+  "detected_capability": "email_lookup",
+  "prior_capability": null,
+  "query": "Any messages from finance in my mailbox this week?",
+  "resolved_capability": "email_lookup",
+  "response_part_types": [
+    "chat_text",
+    "tool_summary"
+  ]
+}

--- a/backend/crates/llm-eval/fixtures/goldens/assistant_follow_up_prior_calendar_temporal.golden.json
+++ b/backend/crates/llm-eval/fixtures/goldens/assistant_follow_up_prior_calendar_temporal.golden.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "assistant_follow_up_prior_calendar_temporal",
+  "description": "English follow-up temporal reference reuses prior calendar lane.",
+  "detected_capability": null,
+  "prior_capability": "calendar_lookup",
+  "query": "what else afterwards",
+  "resolved_capability": "calendar_lookup",
+  "response_part_types": [
+    "chat_text",
+    "tool_summary"
+  ]
+}

--- a/backend/crates/llm-eval/fixtures/goldens/assistant_mixed_agenda_inbox_next_week.golden.json
+++ b/backend/crates/llm-eval/fixtures/goldens/assistant_mixed_agenda_inbox_next_week.golden.json
@@ -1,0 +1,13 @@
+{
+  "case_id": "assistant_mixed_agenda_inbox_next_week",
+  "description": "English mixed-intent paraphrase with agenda + inbox routes to mixed lane.",
+  "detected_capability": "mixed",
+  "prior_capability": null,
+  "query": "Give me agenda and inbox updates for next week",
+  "resolved_capability": "mixed",
+  "response_part_types": [
+    "chat_text",
+    "tool_summary",
+    "tool_summary"
+  ]
+}


### PR DESCRIPTION
## Summary
Implements Phase C as an English-only hardening pass for assistant planner routing.

## Changes
- Added deterministic language policy gate in enclave route policy:
  - supported planner language hints: `en` / `en-*`
  - non-English planner hints route to clarification instead of executing tool lanes
- Expanded deterministic fallback detection for English temporal/paraphrase phrasing in `shared::assistant_planner`:
  - calendar terms include agenda/appointment variants
  - email terms include mailbox/messages/thread variants
  - follow-up markers include `afterwards`, `what else`, `same window`, `same timeframe`
- Added test coverage for:
  - non-English planner hint clarification
  - English language-variant pass-through (`en-US`)
  - follow-up continuity markers for prior-capability reuse
- Added new assistant eval fixtures + goldens for English temporal/paraphrase coverage:
  - `assistant_calendar_agenda_afternoon`
  - `assistant_email_mailbox_messages`
  - `assistant_follow_up_prior_calendar_temporal`
  - `assistant_mixed_agenda_inbox_next_week`

## Validation
- `just backend-tests`
- `just backend-deep-review`
- `just ios-build`

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: backend unit/integration/eval suites all green with new cases
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: policy logic remains isolated to enclave orchestrator policy module; fallback heuristics remain in shared planner helper
- Performance/scalability concerns: no material concerns identified
- Refactor recommendations: none blocking for this phase

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #185
