### PR TITLE
docs: rewrite README from implemented code paths (incl. general chat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Alfred
 
+> Batman's loyal butler.
+
 Alfred is a privacy-first AI assistant for iOS with a hosted Rust backend.
 
 The product goal is proactive help over Google data (calendar + email) with strong privacy boundaries, not a generic chat app.


### PR DESCRIPTION
## Summary
This refreshes the root `README.md` using current backend and iOS implementation details from code rather than planning-only status text.

## What changed
- Reframed project intro and added GitHub About tagline: `Batman's loyal butler.`
- Added code-backed "What Exists In Code Today" sections for backend and iOS.
- Explicitly documented assistant lane support including `general_chat`.
- Clarified planner-driven routing behavior (clarification flow, English-first policy, deterministic fallback).
- Clarified current iOS surfaces (Home/Activity/Connectors) and that preferences/privacy delete-all are implemented on backend but not currently surfaced in main iOS navigation.
- Kept local dev/build/workflow instructions aligned with current repo commands and docs.

## Validation
- `just check-tools`
- `just ios-build`

## Notes
- Docs-only change; no runtime code or contracts were modified.