### PR TITLE
Add assistant session list and delete APIs

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -115,6 +115,62 @@ paths:
           $ref: "#/components/responses/TooManyRequests"
         "502":
           $ref: "#/components/responses/BadGateway"
+  /v1/assistant/sessions:
+    get:
+      tags: [Assistant]
+      summary: List assistant thread sessions for the current user
+      operationId: listAssistantSessions
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Assistant sessions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAssistantSessionsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    delete:
+      tags: [Assistant]
+      summary: Delete all assistant thread sessions for the current user
+      operationId: deleteAllAssistantSessions
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Assistant sessions deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /v1/assistant/sessions/{session_id}:
+    delete:
+      tags: [Assistant]
+      summary: Delete a single assistant thread session
+      operationId: deleteAssistantSession
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: session_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Assistant session deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /v1/connectors:
     get:
       tags: [Connectors]
@@ -479,6 +535,30 @@ components:
           format: uuid
         envelope:
           $ref: "#/components/schemas/AssistantEncryptedResponseEnvelope"
+    AssistantSessionSummary:
+      type: object
+      required: [session_id, created_at, updated_at, expires_at]
+      properties:
+        session_id:
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+    ListAssistantSessionsResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AssistantSessionSummary"
     AssistantAttestedKeyRequest:
       type: object
       required: [challenge_nonce, issued_at, expires_at, request_id]

--- a/backend/crates/api-server/src/http/assistant/mod.rs
+++ b/backend/crates/api-server/src/http/assistant/mod.rs
@@ -1,5 +1,9 @@
 mod attested_key;
 mod query;
+mod sessions;
 
 pub(crate) use attested_key::fetch_attested_key;
 pub(crate) use query::query_assistant;
+pub(crate) use sessions::{
+    delete_all_assistant_sessions, delete_assistant_session, list_assistant_sessions,
+};

--- a/backend/crates/api-server/src/http/assistant/sessions.rs
+++ b/backend/crates/api-server/src/http/assistant/sessions.rs
@@ -1,0 +1,105 @@
+use axum::Json;
+use axum::extract::{Extension, Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use chrono::Utc;
+use shared::models::{
+    AssistantSessionSummary, ErrorBody, ErrorResponse, ListAssistantSessionsResponse, OkResponse,
+};
+use uuid::Uuid;
+
+use super::super::errors::store_error_response;
+use super::super::{AppState, AuthUser};
+
+const ASSISTANT_SESSIONS_LIST_LIMIT: i64 = 200;
+
+pub(crate) async fn list_assistant_sessions(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+) -> Response {
+    let now = Utc::now();
+    let sessions = match state
+        .store
+        .list_assistant_encrypted_sessions(user.user_id, now, ASSISTANT_SESSIONS_LIST_LIMIT)
+        .await
+    {
+        Ok(sessions) => sessions,
+        Err(err) => return store_error_response(err),
+    };
+
+    let items = sessions
+        .into_iter()
+        .map(|session| AssistantSessionSummary {
+            session_id: session.session_id,
+            created_at: session.created_at,
+            updated_at: session.updated_at,
+            expires_at: session.expires_at,
+        })
+        .collect();
+
+    (
+        StatusCode::OK,
+        Json(ListAssistantSessionsResponse { items }),
+    )
+        .into_response()
+}
+
+pub(crate) async fn delete_assistant_session(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Path(session_id): Path<String>,
+) -> Response {
+    let session_id = match Uuid::parse_str(&session_id) {
+        Ok(session_id) => session_id,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: ErrorBody {
+                        code: "not_found".to_string(),
+                        message: "Assistant session not found".to_string(),
+                    },
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    let deleted = match state
+        .store
+        .delete_assistant_encrypted_session(user.user_id, session_id)
+        .await
+    {
+        Ok(deleted) => deleted,
+        Err(err) => return store_error_response(err),
+    };
+
+    if deleted {
+        return (StatusCode::OK, Json(OkResponse { ok: true })).into_response();
+    }
+
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse {
+            error: ErrorBody {
+                code: "not_found".to_string(),
+                message: "Assistant session not found".to_string(),
+            },
+        }),
+    )
+        .into_response()
+}
+
+pub(crate) async fn delete_all_assistant_sessions(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+) -> Response {
+    match state
+        .store
+        .delete_all_assistant_encrypted_sessions(user.user_id)
+        .await
+    {
+        Ok(_) => (StatusCode::OK, Json(OkResponse { ok: true })).into_response(),
+        Err(err) => store_error_response(err),
+    }
+}

--- a/backend/crates/api-server/src/http/mod.rs
+++ b/backend/crates/api-server/src/http/mod.rs
@@ -95,6 +95,15 @@ pub fn build_router(app_state: AppState) -> Router {
             )),
         )
         .route(
+            "/v1/assistant/sessions",
+            get(assistant::list_assistant_sessions)
+                .delete(assistant::delete_all_assistant_sessions),
+        )
+        .route(
+            "/v1/assistant/sessions/{session_id}",
+            delete(assistant::delete_assistant_session),
+        )
+        .route(
             "/v1/connectors/google/start",
             post(connectors::start_google_connect).layer(middleware::from_fn_with_state(
                 protected_rate_limit_layer_state.clone(),

--- a/backend/crates/integration-tests/tests/api_assistant_sessions.rs
+++ b/backend/crates/integration-tests/tests/api_assistant_sessions.rs
@@ -1,0 +1,252 @@
+mod support;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Method, Request, StatusCode, header};
+use chrono::{Duration, Utc};
+use serde_json::{Value, json};
+use serial_test::serial;
+use shared::models::{AssistantSessionStateEnvelope, ListAssistantSessionsResponse, OkResponse};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use support::api_app::{build_test_router, user_id_for_subject};
+use support::clerk::TestClerkAuth;
+
+#[tokio::test]
+#[serial]
+async fn assistant_sessions_list_and_delete_respect_user_boundaries() {
+    let store = support::test_store().await;
+    support::reset_database(store.pool()).await;
+
+    let clerk = TestClerkAuth::start().await;
+    let subject_a = "assistant-sessions-user-a";
+    let subject_b = "assistant-sessions-user-b";
+    let user_a = user_id_for_subject(&clerk.issuer, subject_a);
+    let user_b = user_id_for_subject(&clerk.issuer, subject_b);
+    let auth_a = format!("Bearer {}", clerk.token_for_subject(subject_a));
+    let auth_b = format!("Bearer {}", clerk.token_for_subject(subject_b));
+    let app = build_test_router(store.clone(), &clerk).await;
+
+    let now = Utc::now();
+    let session_a_old = Uuid::new_v4();
+    let session_a_new = Uuid::new_v4();
+    let session_b = Uuid::new_v4();
+
+    store
+        .upsert_assistant_encrypted_session(
+            user_a,
+            session_a_old,
+            &test_state("cipher-a-old", now + Duration::days(3)),
+            now - Duration::minutes(30),
+            3600,
+        )
+        .await
+        .expect("older session insert should succeed");
+    store
+        .upsert_assistant_encrypted_session(
+            user_a,
+            session_a_new,
+            &test_state("cipher-a-new", now + Duration::days(3)),
+            now - Duration::minutes(10),
+            3600,
+        )
+        .await
+        .expect("newer session insert should succeed");
+    store
+        .upsert_assistant_encrypted_session(
+            user_b,
+            session_b,
+            &test_state("cipher-b", now + Duration::days(3)),
+            now - Duration::minutes(5),
+            3600,
+        )
+        .await
+        .expect("user-b session insert should succeed");
+
+    let initial_list = send_json(
+        &app,
+        request(
+            Method::GET,
+            "/v1/assistant/sessions",
+            Some(auth_a.as_str()),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(initial_list.status, StatusCode::OK);
+    let initial_list_body: ListAssistantSessionsResponse =
+        serde_json::from_value(initial_list.body).expect("list response should decode");
+    assert_eq!(initial_list_body.items.len(), 2);
+    assert_eq!(initial_list_body.items[0].session_id, session_a_new);
+    assert_eq!(initial_list_body.items[1].session_id, session_a_old);
+
+    let cross_user_delete = send_json(
+        &app,
+        request(
+            Method::DELETE,
+            &format!("/v1/assistant/sessions/{session_a_old}"),
+            Some(auth_b.as_str()),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(cross_user_delete.status, StatusCode::NOT_FOUND);
+    assert_eq!(error_code(&cross_user_delete.body), Some("not_found"));
+
+    let malformed_delete = send_json(
+        &app,
+        request(
+            Method::DELETE,
+            "/v1/assistant/sessions/not-a-uuid",
+            Some(auth_a.as_str()),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(malformed_delete.status, StatusCode::NOT_FOUND);
+    assert_eq!(error_code(&malformed_delete.body), Some("not_found"));
+
+    let single_delete = send_json(
+        &app,
+        request(
+            Method::DELETE,
+            &format!("/v1/assistant/sessions/{session_a_old}"),
+            Some(auth_a.as_str()),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(single_delete.status, StatusCode::OK);
+    let single_delete_body: OkResponse =
+        serde_json::from_value(single_delete.body).expect("single delete response should decode");
+    assert!(single_delete_body.ok);
+
+    let list_after_single_delete = send_json(
+        &app,
+        request(
+            Method::GET,
+            "/v1/assistant/sessions",
+            Some(auth_a.as_str()),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(list_after_single_delete.status, StatusCode::OK);
+    let list_after_single_delete_body: ListAssistantSessionsResponse =
+        serde_json::from_value(list_after_single_delete.body)
+            .expect("post-delete list response should decode");
+    assert_eq!(list_after_single_delete_body.items.len(), 1);
+    assert_eq!(
+        list_after_single_delete_body.items[0].session_id,
+        session_a_new
+    );
+
+    let delete_all = send_json(
+        &app,
+        request(
+            Method::DELETE,
+            "/v1/assistant/sessions",
+            Some(auth_a.as_str()),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(delete_all.status, StatusCode::OK);
+    let delete_all_body: OkResponse =
+        serde_json::from_value(delete_all.body).expect("delete-all response should decode");
+    assert!(delete_all_body.ok);
+
+    let list_after_delete_all = send_json(
+        &app,
+        request(
+            Method::GET,
+            "/v1/assistant/sessions",
+            Some(auth_a.as_str()),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(list_after_delete_all.status, StatusCode::OK);
+    let list_after_delete_all_body: ListAssistantSessionsResponse =
+        serde_json::from_value(list_after_delete_all.body)
+            .expect("post-delete-all list response should decode");
+    assert!(list_after_delete_all_body.items.is_empty());
+
+    let user_b_unchanged = send_json(
+        &app,
+        request(
+            Method::GET,
+            "/v1/assistant/sessions",
+            Some(auth_b.as_str()),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(user_b_unchanged.status, StatusCode::OK);
+    let user_b_unchanged_body: ListAssistantSessionsResponse =
+        serde_json::from_value(user_b_unchanged.body).expect("user-b list response should decode");
+    assert_eq!(user_b_unchanged_body.items.len(), 1);
+    assert_eq!(user_b_unchanged_body.items[0].session_id, session_b);
+}
+
+fn test_state(
+    ciphertext: &str,
+    expires_at: chrono::DateTime<Utc>,
+) -> AssistantSessionStateEnvelope {
+    AssistantSessionStateEnvelope {
+        version: "v1".to_string(),
+        algorithm: "x25519-chacha20poly1305".to_string(),
+        key_id: "assistant-ingress-v1".to_string(),
+        nonce: "nonce".to_string(),
+        ciphertext: ciphertext.to_string(),
+        expires_at,
+    }
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn send_json(app: &axum::Router, request: Request<Body>) -> JsonResponse {
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("request should succeed");
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should read");
+    let body = serde_json::from_slice::<Value>(&body).unwrap_or_else(|_| json!({}));
+
+    JsonResponse { status, body }
+}
+
+fn request(method: Method, path: &str, bearer: Option<&str>, body: Option<Value>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(path)
+        .header(header::ACCEPT, "application/json");
+
+    if let Some(token) = bearer {
+        builder = builder.header(header::AUTHORIZATION, token);
+    }
+
+    let request_body = body
+        .map(|value| {
+            serde_json::to_vec(&value).expect("json body should serialize for integration request")
+        })
+        .unwrap_or_default();
+    if !request_body.is_empty() {
+        builder = builder.header(header::CONTENT_TYPE, "application/json");
+    }
+
+    builder
+        .body(Body::from(request_body))
+        .expect("integration request should build")
+}
+
+fn error_code(body: &Value) -> Option<&str> {
+    body.get("error")?.get("code")?.as_str()
+}

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -140,6 +140,19 @@ pub struct AssistantQueryResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssistantSessionSummary {
+    pub session_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListAssistantSessionsResponse {
+    pub items: Vec<AssistantSessionSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssistantPlaintextQueryRequest {
     pub query: String,
     #[serde(default)]

--- a/backend/crates/shared/src/repos/mod.rs
+++ b/backend/crates/shared/src/repos/mod.rs
@@ -15,6 +15,7 @@ mod preferences;
 mod privacy;
 mod users;
 
+pub use assistant_encrypted_sessions::AssistantEncryptedSessionMetadataRecord;
 pub use assistant_encrypted_sessions::AssistantEncryptedSessionRecord;
 
 const DEFAULT_MEETING_REMINDER_MINUTES: i32 = 15;


### PR DESCRIPTION
## Summary
- add authenticated assistant session management endpoints:
  - `GET /v1/assistant/sessions`
  - `DELETE /v1/assistant/sessions/{session_id}`
  - `DELETE /v1/assistant/sessions`
- add shared response models and OpenAPI contract updates for session listing
- add store methods for listing/deleting encrypted assistant sessions (user-scoped)
- add integration coverage for ordering, cross-user isolation, malformed id handling, single delete, and delete-all

## Security / Privacy Review
- no plaintext assistant message content is exposed or persisted in these new endpoints
- all session operations are user-scoped via authenticated `AuthUser`
- malformed session IDs return deterministic `not_found` envelope to avoid inconsistent error surfaces
- AI deep review: **no findings**

## Validation
- `just backend-deep-review`
- `just ios-build`

Closes #198