### PR TITLE
iOS: persist assistant threads locally with active-session restore

### DIFF
--- a/alfred/alfred/AppModel+AssistantThreads.swift
+++ b/alfred/alfred/AppModel+AssistantThreads.swift
@@ -1,0 +1,191 @@
+import AlfredAPIClient
+import Foundation
+
+extension AppModel {
+    func queryAssistant(query: String) async {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else {
+            errorBanner = ErrorBanner(
+                message: "Message is empty. Type or dictate something first.",
+                retryAction: nil,
+                sourceAction: nil
+            )
+            return
+        }
+
+        let sessionID = assistantSessionIDForActiveThread()
+        let targetThreadID = activeAssistantThreadID
+        await run(action: .queryAssistant, retryAction: .queryAssistant(query: trimmedQuery)) { [self] in
+            let response = try await apiClient.queryAssistantEncrypted(
+                query: trimmedQuery,
+                sessionId: sessionID,
+                attestationConfig: AppConfiguration.assistantAttestationVerificationConfig
+            )
+            AppLogger.info(
+                """
+                Assistant response received capability=\(response.capability.rawValue) \
+                response_parts=\(response.responseParts.count) \
+                payload_key_points=\(response.payload.keyPoints.count) \
+                payload_follow_ups=\(response.payload.followUps.count)
+                """,
+                category: .network
+            )
+
+            applySuccessfulAssistantTurn(
+                query: trimmedQuery,
+                response: response,
+                targetThreadID: targetThreadID
+            )
+            try await persistAssistantThreadsForCurrentUser()
+        }
+    }
+
+    func clearAssistantConversation() {
+        assistantConversation = []
+        assistantResponseText = ""
+        activeAssistantThreadID = nil
+        Task { [weak self] in
+            guard let self else { return }
+            try? await self.persistAssistantThreadsForCurrentUser()
+        }
+    }
+
+    func selectAssistantThread(_ threadID: UUID) {
+        guard let thread = assistantThreads.first(where: { $0.id == threadID }) else { return }
+
+        activeAssistantThreadID = thread.id
+        assistantConversation = thread.messages
+        assistantResponseText = thread.messages.last(where: { $0.role == .assistant })?.text ?? ""
+
+        Task { [weak self] in
+            guard let self else { return }
+            try? await self.persistAssistantThreadsForCurrentUser()
+        }
+    }
+
+    func assistantSessionIDForActiveThread() -> UUID? {
+        guard let activeAssistantThreadID else { return nil }
+        return assistantThreads.first(where: { $0.id == activeAssistantThreadID })?.sessionID
+    }
+
+    func applySuccessfulAssistantTurn(
+        query: String,
+        response: AssistantPlaintextQueryResponse,
+        timestamp: Date = Date(),
+        targetThreadID: UUID? = nil
+    ) {
+        let userMessage = AssistantConversationMapper.userMessage(from: query, createdAt: timestamp)
+        let assistantMessage = AssistantConversationMapper.assistantMessage(from: response, createdAt: timestamp)
+        let newMessages = [userMessage, assistantMessage]
+
+        let resolvedThreadID = targetThreadID ?? activeAssistantThreadID
+        let threadID: UUID
+        if let resolvedThreadID,
+           let existingThreadIndex = assistantThreads.firstIndex(where: { $0.id == resolvedThreadID })
+        {
+            assistantThreads[existingThreadIndex].append(newMessages, sessionID: response.sessionId)
+            threadID = resolvedThreadID
+        } else {
+            let newThread = AssistantConversationThread(
+                sessionID: response.sessionId,
+                createdAt: timestamp,
+                updatedAt: timestamp,
+                messages: newMessages
+            )
+            assistantThreads.insert(newThread, at: 0)
+            threadID = newThread.id
+        }
+
+        assistantThreads.sort(by: assistantThreadUpdatedAtDescending)
+        if let activeThread = assistantThreads.first(where: { $0.id == threadID }) {
+            activeAssistantThreadID = activeThread.id
+            assistantConversation = activeThread.messages
+        } else {
+            activeAssistantThreadID = nil
+            assistantConversation = []
+        }
+        assistantResponseText = assistantMessage.text
+    }
+
+    func restoreAssistantThreads(for userID: String) async {
+        do {
+            let snapshot = try await assistantThreadStore.load(for: userID)
+            applyAssistantThreadSnapshot(snapshot)
+        } catch {
+            AppLogger.error(
+                "Failed to restore assistant threads from local store for user \(userID).",
+                category: .app
+            )
+            resetAssistantThreadState()
+        }
+    }
+
+    func clearPersistedAssistantThreads(for userID: String?) async {
+        guard let userID,
+              !userID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return
+        }
+
+        do {
+            try await assistantThreadStore.clear(for: userID)
+        } catch {
+            AppLogger.error(
+                "Failed to clear assistant thread store for user \(userID).",
+                category: .app
+            )
+        }
+    }
+
+    func resetAssistantThreadState() {
+        assistantThreads = []
+        activeAssistantThreadID = nil
+        assistantConversation = []
+        assistantResponseText = ""
+    }
+
+    private func applyAssistantThreadSnapshot(_ snapshot: AssistantThreadStoreSnapshot) {
+        let sortedThreads = snapshot.threads.sorted(by: assistantThreadUpdatedAtDescending)
+        assistantThreads = sortedThreads
+
+        if let activeThreadID = snapshot.activeThreadID,
+           let activeThread = sortedThreads.first(where: { $0.id == activeThreadID })
+        {
+            self.activeAssistantThreadID = activeThread.id
+            assistantConversation = activeThread.messages
+            assistantResponseText = activeThread.messages.last(where: { $0.role == .assistant })?.text ?? ""
+            return
+        }
+
+        guard let latestThread = sortedThreads.first else {
+            activeAssistantThreadID = nil
+            assistantConversation = []
+            assistantResponseText = ""
+            return
+        }
+
+        activeAssistantThreadID = latestThread.id
+        assistantConversation = latestThread.messages
+        assistantResponseText = latestThread.messages.last(where: { $0.role == .assistant })?.text ?? ""
+    }
+
+    private func persistAssistantThreadsForCurrentUser() async throws {
+        guard let userID = assistantStorageUserID else { return }
+
+        let snapshot = AssistantThreadStoreSnapshot(
+            activeThreadID: activeAssistantThreadID,
+            threads: assistantThreads
+        )
+        try await assistantThreadStore.save(snapshot, for: userID)
+    }
+
+    private func assistantThreadUpdatedAtDescending(
+        _ lhs: AssistantConversationThread,
+        _ rhs: AssistantConversationThread
+    ) -> Bool {
+        if lhs.updatedAt == rhs.updatedAt {
+            return lhs.createdAt > rhs.createdAt
+        }
+        return lhs.updatedAt > rhs.updatedAt
+    }
+}

--- a/alfred/alfred/Core/AssistantConversation.swift
+++ b/alfred/alfred/Core/AssistantConversation.swift
@@ -1,8 +1,8 @@
 import AlfredAPIClient
 import Foundation
 
-struct AssistantConversationMessage: Identifiable, Equatable {
-    enum Role: String, Equatable {
+struct AssistantConversationMessage: Identifiable, Equatable, Codable, Sendable {
+    enum Role: String, Equatable, Codable, Sendable {
         case user
         case assistant
     }
@@ -15,7 +15,7 @@ struct AssistantConversationMessage: Identifiable, Equatable {
     let createdAt: Date
 }
 
-struct AssistantToolSummary: Identifiable, Equatable {
+struct AssistantToolSummary: Identifiable, Equatable, Codable, Sendable {
     let id: UUID
     let capability: AssistantQueryCapability
     let title: String

--- a/alfred/alfred/Core/AssistantThread.swift
+++ b/alfred/alfred/Core/AssistantThread.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct AssistantConversationThread: Identifiable, Equatable, Codable, Sendable {
+    let id: UUID
+    var sessionID: UUID?
+    var title: String
+    var createdAt: Date
+    var updatedAt: Date
+    var lastMessagePreview: String
+    var messages: [AssistantConversationMessage]
+
+    enum CodingKeys: String, CodingKey {
+        case id = "thread_id"
+        case sessionID = "session_id"
+        case title
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case lastMessagePreview = "last_message_preview"
+        case messages
+    }
+
+    init(
+        id: UUID = UUID(),
+        sessionID: UUID? = nil,
+        title: String? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        lastMessagePreview: String? = nil,
+        messages: [AssistantConversationMessage] = []
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messages = messages
+        self.title = title ?? Self.derivedTitle(from: messages)
+        self.lastMessagePreview = lastMessagePreview ?? Self.derivedLastMessagePreview(from: messages)
+    }
+
+    mutating func append(_ newMessages: [AssistantConversationMessage], sessionID: UUID?) {
+        messages.append(contentsOf: newMessages)
+        self.sessionID = sessionID
+        if let lastMessageDate = messages.last?.createdAt {
+            updatedAt = lastMessageDate
+        } else {
+            updatedAt = Date()
+        }
+        title = Self.derivedTitle(from: messages)
+        lastMessagePreview = Self.derivedLastMessagePreview(from: messages)
+    }
+
+    mutating func refreshMetadata() {
+        title = Self.derivedTitle(from: messages)
+        lastMessagePreview = Self.derivedLastMessagePreview(from: messages)
+        if let lastMessageDate = messages.last?.createdAt {
+            updatedAt = lastMessageDate
+        }
+    }
+
+    private static func derivedTitle(from messages: [AssistantConversationMessage]) -> String {
+        let preferredSource = messages.first(where: { $0.role == .user })?.text
+            ?? messages.first?.text
+            ?? "New Chat"
+        return snippet(from: preferredSource, limit: 48, fallback: "New Chat")
+    }
+
+    private static func derivedLastMessagePreview(from messages: [AssistantConversationMessage]) -> String {
+        let source = messages.last?.text ?? ""
+        return snippet(from: source, limit: 84, fallback: "")
+    }
+
+    private static func snippet(from value: String, limit: Int, fallback: String) -> String {
+        let normalized = value
+            .replacingOccurrences(of: "\n", with: " ")
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+
+        guard !normalized.isEmpty else { return fallback }
+        guard normalized.count > limit else { return normalized }
+
+        let prefix = normalized.prefix(limit)
+        return "\(prefix)..."
+    }
+}
+
+struct AssistantThreadStoreSnapshot: Equatable, Codable, Sendable {
+    var activeThreadID: UUID?
+    var threads: [AssistantConversationThread]
+
+    enum CodingKeys: String, CodingKey {
+        case activeThreadID = "active_thread_id"
+        case threads
+    }
+
+    static let empty = AssistantThreadStoreSnapshot(activeThreadID: nil, threads: [])
+}

--- a/alfred/alfred/Core/AssistantThreadStore.swift
+++ b/alfred/alfred/Core/AssistantThreadStore.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+actor AssistantThreadStore {
+    private let fileManager: FileManager
+    private let storageDirectoryURL: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(fileManager: FileManager = .default, storageDirectoryURL: URL? = nil) {
+        self.fileManager = fileManager
+        self.storageDirectoryURL = Self.resolveStorageDirectoryURL(
+            fileManager: fileManager,
+            override: storageDirectoryURL
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        self.encoder = encoder
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    func load(for userID: String) throws -> AssistantThreadStoreSnapshot {
+        let fileURL = try fileURL(for: userID)
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return .empty
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else { return .empty }
+
+        var snapshot = try decoder.decode(AssistantThreadStoreSnapshot.self, from: data)
+        snapshot.threads = snapshot.threads
+            .map { thread in
+                var normalized = thread
+                normalized.refreshMetadata()
+                return normalized
+            }
+            .sorted(by: Self.updatedAtDescending)
+
+        if let activeThreadID = snapshot.activeThreadID,
+           snapshot.threads.contains(where: { $0.id == activeThreadID })
+        {
+            return snapshot
+        }
+
+        snapshot.activeThreadID = snapshot.threads.first?.id
+        return snapshot
+    }
+
+    func save(_ snapshot: AssistantThreadStoreSnapshot, for userID: String) throws {
+        try ensureStorageDirectoryExists()
+
+        let normalizedThreads = snapshot.threads
+            .map { thread in
+                var normalized = thread
+                normalized.refreshMetadata()
+                return normalized
+            }
+            .sorted(by: Self.updatedAtDescending)
+        let normalizedActiveID = {
+            guard let activeID = snapshot.activeThreadID else { return Optional<UUID>.none }
+            return normalizedThreads.contains(where: { $0.id == activeID }) ? activeID : nil
+        }()
+        let normalizedSnapshot = AssistantThreadStoreSnapshot(
+            activeThreadID: normalizedActiveID,
+            threads: normalizedThreads
+        )
+        let data = try encoder.encode(normalizedSnapshot)
+        try data.write(to: try fileURL(for: userID), options: [.atomic])
+    }
+
+    func clear(for userID: String) throws {
+        let fileURL = try fileURL(for: userID)
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+        try fileManager.removeItem(at: fileURL)
+    }
+
+    private func ensureStorageDirectoryExists() throws {
+        var isDirectory: ObjCBool = false
+        let directoryPath = storageDirectoryURL.path
+
+        if fileManager.fileExists(atPath: directoryPath, isDirectory: &isDirectory) {
+            if isDirectory.boolValue {
+                return
+            }
+
+            try fileManager.removeItem(at: storageDirectoryURL)
+        }
+
+        try fileManager.createDirectory(
+            at: storageDirectoryURL,
+            withIntermediateDirectories: true
+        )
+    }
+
+    private func fileURL(for userID: String) throws -> URL {
+        guard !userID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AssistantThreadStoreError.invalidUserID
+        }
+
+        let sanitized = sanitizedUserComponent(userID)
+        return storageDirectoryURL
+            .appendingPathComponent("assistant_threads_\(sanitized)")
+            .appendingPathExtension("json")
+    }
+
+    private func sanitizedUserComponent(_ userID: String) -> String {
+        let base64 = Data(userID.utf8).base64EncodedString()
+        let normalized = base64
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return normalized.isEmpty ? "unknown_user" : normalized
+    }
+
+    private static func resolveStorageDirectoryURL(
+        fileManager: FileManager,
+        override: URL?
+    ) -> URL {
+        if let override {
+            return override
+        }
+
+        let applicationSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return applicationSupportURL
+            .appendingPathComponent("alfred", isDirectory: true)
+            .appendingPathComponent("assistant_threads", isDirectory: true)
+    }
+
+    private static func updatedAtDescending(
+        _ lhs: AssistantConversationThread,
+        _ rhs: AssistantConversationThread
+    ) -> Bool {
+        if lhs.updatedAt == rhs.updatedAt {
+            return lhs.createdAt > rhs.createdAt
+        }
+        return lhs.updatedAt > rhs.updatedAt
+    }
+}
+
+enum AssistantThreadStoreError: Error {
+    case invalidUserID
+}

--- a/alfred/alfredTests/AppModelAssistantThreadStateTests.swift
+++ b/alfred/alfredTests/AppModelAssistantThreadStateTests.swift
@@ -1,0 +1,97 @@
+import AlfredAPIClient
+import ClerkKit
+import XCTest
+@testable import alfred
+
+@MainActor
+final class AppModelAssistantThreadStateTests: XCTestCase {
+    func testClearAssistantConversationKeepsExistingThreads() {
+        let model = makeModel()
+        let initialResponse = makeAssistantResponse(
+            sessionID: UUID(),
+            text: "First answer"
+        )
+
+        model.applySuccessfulAssistantTurn(
+            query: "first question",
+            response: initialResponse,
+            timestamp: Date(timeIntervalSince1970: 10)
+        )
+        XCTAssertEqual(model.assistantThreads.count, 1)
+
+        model.clearAssistantConversation()
+
+        XCTAssertEqual(model.assistantThreads.count, 1)
+        XCTAssertTrue(model.assistantConversation.isEmpty)
+        XCTAssertNil(model.activeAssistantThreadID)
+    }
+
+    func testSelectingThreadSwitchesActiveSessionAndConversation() {
+        let model = makeModel()
+        let firstSessionID = UUID()
+        let secondSessionID = UUID()
+        let firstResponse = makeAssistantResponse(
+            sessionID: firstSessionID,
+            text: "First thread answer"
+        )
+        let secondResponse = makeAssistantResponse(
+            sessionID: secondSessionID,
+            text: "Second thread answer"
+        )
+
+        model.applySuccessfulAssistantTurn(
+            query: "first question",
+            response: firstResponse,
+            timestamp: Date(timeIntervalSince1970: 100)
+        )
+        let firstThreadID = try! XCTUnwrap(model.assistantThreads.first?.id)
+
+        model.clearAssistantConversation()
+        model.applySuccessfulAssistantTurn(
+            query: "second question",
+            response: secondResponse,
+            timestamp: Date(timeIntervalSince1970: 200)
+        )
+        XCTAssertEqual(model.assistantSessionIDForActiveThread(), secondSessionID)
+
+        model.selectAssistantThread(firstThreadID)
+
+        XCTAssertEqual(model.assistantSessionIDForActiveThread(), firstSessionID)
+        XCTAssertEqual(model.assistantConversation.count, 2)
+        XCTAssertEqual(model.assistantConversation.first?.text, "first question")
+        XCTAssertEqual(model.assistantConversation.last?.text, "First thread answer")
+    }
+
+    private func makeModel() -> AppModel {
+        let clerk = Clerk.preview { preview in
+            preview.isSignedIn = false
+        }
+        return AppModel(clerk: clerk)
+    }
+
+    private func makeAssistantResponse(
+        sessionID: UUID,
+        text: String
+    ) -> AssistantPlaintextQueryResponse {
+        let json = """
+        {
+          "session_id": "\(sessionID.uuidString)",
+          "capability": "general_chat",
+          "display_text": "\(text)",
+          "payload": {
+            "title": "Assistant",
+            "summary": "\(text)",
+            "key_points": [],
+            "follow_ups": []
+          },
+          "response_parts": [
+            {
+              "type": "chat_text",
+              "text": "\(text)"
+            }
+          ]
+        }
+        """
+        return try! JSONDecoder().decode(AssistantPlaintextQueryResponse.self, from: Data(json.utf8))
+    }
+}

--- a/alfred/alfredTests/AssistantThreadStoreTests.swift
+++ b/alfred/alfredTests/AssistantThreadStoreTests.swift
@@ -1,0 +1,119 @@
+import AlfredAPIClient
+import Foundation
+import XCTest
+@testable import alfred
+
+@MainActor
+final class AssistantThreadStoreTests: XCTestCase {
+    func testLoadReturnsEmptySnapshotWhenNoSavedThreadsExist() async throws {
+        let store = AssistantThreadStore(storageDirectoryURL: makeTemporaryDirectoryURL())
+
+        let snapshot = try await store.load(for: "user_123")
+
+        XCTAssertEqual(snapshot, .empty)
+    }
+
+    func testSaveAndLoadRoundTripsThreadsAndActiveThread() async throws {
+        let store = AssistantThreadStore(storageDirectoryURL: makeTemporaryDirectoryURL())
+        let firstSessionID = UUID()
+        let secondSessionID = UUID()
+
+        var firstThread = AssistantConversationThread(
+            id: UUID(),
+            sessionID: firstSessionID,
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 101),
+            messages: [
+                AssistantConversationMessage(
+                    id: UUID(),
+                    role: .user,
+                    text: "Plan an NYC weekend",
+                    capability: nil,
+                    toolSummaries: [],
+                    createdAt: Date(timeIntervalSince1970: 100)
+                ),
+                AssistantConversationMessage(
+                    id: UUID(),
+                    role: .assistant,
+                    text: "Start with Friday dinner in Soho.",
+                    capability: .generalChat,
+                    toolSummaries: [],
+                    createdAt: Date(timeIntervalSince1970: 101)
+                ),
+            ]
+        )
+        firstThread.refreshMetadata()
+
+        var secondThread = AssistantConversationThread(
+            id: UUID(),
+            sessionID: secondSessionID,
+            createdAt: Date(timeIntervalSince1970: 200),
+            updatedAt: Date(timeIntervalSince1970: 201),
+            messages: [
+                AssistantConversationMessage(
+                    id: UUID(),
+                    role: .user,
+                    text: "Review this week's calendar",
+                    capability: nil,
+                    toolSummaries: [],
+                    createdAt: Date(timeIntervalSince1970: 200)
+                ),
+                AssistantConversationMessage(
+                    id: UUID(),
+                    role: .assistant,
+                    text: "You have six meetings before Thursday.",
+                    capability: .meetingsToday,
+                    toolSummaries: [],
+                    createdAt: Date(timeIntervalSince1970: 201)
+                ),
+            ]
+        )
+        secondThread.refreshMetadata()
+
+        let snapshot = AssistantThreadStoreSnapshot(
+            activeThreadID: firstThread.id,
+            threads: [firstThread, secondThread]
+        )
+
+        try await store.save(snapshot, for: "user_123")
+        let loadedSnapshot = try await store.load(for: "user_123")
+
+        XCTAssertEqual(loadedSnapshot.activeThreadID, firstThread.id)
+        XCTAssertEqual(loadedSnapshot.threads.count, 2)
+        XCTAssertEqual(loadedSnapshot.threads[0].id, secondThread.id)
+        XCTAssertEqual(loadedSnapshot.threads[1].id, firstThread.id)
+    }
+
+    func testClearRemovesSavedSnapshot() async throws {
+        let store = AssistantThreadStore(storageDirectoryURL: makeTemporaryDirectoryURL())
+        let thread = AssistantConversationThread(
+            sessionID: UUID(),
+            messages: [
+                AssistantConversationMessage(
+                    id: UUID(),
+                    role: .user,
+                    text: "hello",
+                    capability: nil,
+                    toolSummaries: [],
+                    createdAt: Date(timeIntervalSince1970: 10)
+                ),
+            ]
+        )
+        try await store.save(
+            AssistantThreadStoreSnapshot(activeThreadID: thread.id, threads: [thread]),
+            for: "user_123"
+        )
+
+        try await store.clear(for: "user_123")
+        let loadedSnapshot = try await store.load(for: "user_123")
+
+        XCTAssertEqual(loadedSnapshot, .empty)
+    }
+
+    private func makeTemporaryDirectoryURL() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("assistant-thread-store-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/alfred/alfredTests/KittenSpeechTextNormalizerTests.swift
+++ b/alfred/alfredTests/KittenSpeechTextNormalizerTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import alfred
 
+@MainActor
 final class KittenSpeechTextNormalizerTests: XCTestCase {
     func testNormalizeExpandsUtcTimeWithSeconds() {
         let normalized = KittenSpeechTextNormalizer.normalize("The server restarts at 12:00:00 UTC.")


### PR DESCRIPTION
## Summary
Implements issue #200 by adding a local iOS persistence layer for assistant threads and wiring it into `AppModel` so chat history survives restarts, active thread sessions resume correctly, and sign-out clears persisted assistant data.

## Changes
- Added assistant thread domain models with required metadata (`thread_id`, `session_id`, title, previews, timestamps, messages).
- Added `AssistantThreadStore` actor for per-user disk persistence in Application Support with deterministic ordering and active-thread snapshot handling.
- Refactored assistant query/thread logic out of `AppModel.swift` into `AppModel+AssistantThreads.swift` and integrated:
  - persist after successful assistant response,
  - restore persisted threads on signed-in bootstrap,
  - route follow-up queries with the active thread `session_id`,
  - keep previous threads when starting new chat,
  - clear persisted assistant data on sign-out / auth reset.
- Added unit tests for store CRUD and active-thread switching semantics.
- Added `@MainActor` annotation in `KittenSpeechTextNormalizerTests` to satisfy current actor-isolation test compilation.

## Acceptance Criteria Mapping
- [x] Thread list and messages survive app restarts.
- [x] Selecting a persisted thread continues queries using correct `session_id`.
- [x] Starting a new chat no longer destroys prior persisted threads.
- [x] Sign-out clears persisted assistant thread data.
- [x] Unit tests cover store CRUD + active-thread switching semantics.

## Validation
- `just ios-build` ✅
- `just ios-test` ✅

## AI Review Summary
- Security audit: no findings.
- Bug check: no findings.
- Scalability/code quality review: no findings.
- Merge recommendation: APPROVE.

Closes #200