### PR TITLE
Fix post-merge iOS runner and Swift isolation warnings

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -110,7 +110,7 @@ jobs:
 
   ios:
     name: iOS Build (master)
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/alfred/alfred/Core/AssistantConversation.swift
+++ b/alfred/alfred/Core/AssistantConversation.swift
@@ -1,7 +1,7 @@
 import AlfredAPIClient
 import Foundation
 
-struct AssistantConversationMessage: Identifiable, Equatable, Codable, Sendable {
+nonisolated struct AssistantConversationMessage: Identifiable, Equatable, Codable, Sendable {
     enum Role: String, Equatable, Codable, Sendable {
         case user
         case assistant
@@ -15,7 +15,7 @@ struct AssistantConversationMessage: Identifiable, Equatable, Codable, Sendable 
     let createdAt: Date
 }
 
-struct AssistantToolSummary: Identifiable, Equatable, Codable, Sendable {
+nonisolated struct AssistantToolSummary: Identifiable, Equatable, Codable, Sendable {
     let id: UUID
     let capability: AssistantQueryCapability
     let title: String

--- a/alfred/alfred/Core/AssistantThread.swift
+++ b/alfred/alfred/Core/AssistantThread.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct AssistantConversationThread: Identifiable, Equatable, Codable, Sendable {
+nonisolated struct AssistantConversationThread: Identifiable, Equatable, Codable, Sendable {
     let id: UUID
     var sessionID: UUID?
     var title: String
@@ -83,7 +83,7 @@ struct AssistantConversationThread: Identifiable, Equatable, Codable, Sendable {
     }
 }
 
-struct AssistantThreadStoreSnapshot: Equatable, Codable, Sendable {
+nonisolated struct AssistantThreadStoreSnapshot: Equatable, Codable, Sendable {
     var activeThreadID: UUID?
     var threads: [AssistantConversationThread]
 


### PR DESCRIPTION
## Summary\n- switch post-merge iOS workflow runner from  to \n- mark assistant conversation/thread persistence model types as  for Swift 6.2 approachable-concurrency compatibility\n- resolve main-actor isolated conformance errors triggered in  and thread equality/codable usage\n\n## Validation\n- Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project alfred/alfred.xcodeproj -scheme alfred -destination "generic/platform=iOS Simulator" build

Resolve Package Graph

Package: onnxruntime-swift-package-manager

Package: alfredapiclient

Package: clerk-ios

Error Domain=NSCocoaErrorDomain Code=513 "“onnxruntime.xcframework” couldn’t be removed because you don’t have permission to access it." UserInfo={NSUserStringVariant=(
    Remove
), NSFilePath=/Volumes/hulk/dev/cache/xcode/alfred-dhhcdazwmcuabsaeclhsvypvhfce/SourcePackages/artifacts/onnxruntime-swift-package-manager/onnxruntime/onnxruntime.xcframework, NSURL=file:///Volumes/hulk/dev/cache/xcode/alfred-dhhcdazwmcuabsaeclhsvypvhfce/SourcePackages/artifacts/onnxruntime-swift-package-manager/onnxruntime/onnxruntime.xcframework, NSUnderlyingError=0x921dbad00 {Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted"}}encountered an I/O error (code: 1) while reading /Volumes/hulk/dev/cache/xcode/alfred-dhhcdazwmcuabsaeclhsvypvhfce/SourcePackages/workspace-state.jsonfatalError