### PR TITLE
[Automation v2][Backend/API] Implement automation CRUD endpoints with encrypted prompt envelope input

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10,6 +10,7 @@ tags:
   - name: Assistant
   - name: Connectors
   - name: Preferences
+  - name: Automations
   - name: Audit
   - name: Privacy
 paths:
@@ -306,6 +307,117 @@ paths:
                 $ref: "#/components/schemas/OkResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /v1/automations:
+    get:
+      tags: [Automations]
+      summary: List automation rules for the current user
+      operationId: listAutomations
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+      responses:
+        "200":
+          description: Automation rules
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAutomationsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      tags: [Automations]
+      summary: Create a periodic automation rule
+      operationId: createAutomation
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAutomationRequest"
+      responses:
+        "200":
+          description: Automation rule created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationRuleSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+  /v1/automations/{rule_id}:
+    patch:
+      tags: [Automations]
+      summary: Update an automation rule (schedule, prompt envelope, or status)
+      operationId: updateAutomation
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: rule_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAutomationRequest"
+      responses:
+        "200":
+          description: Automation rule updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutomationRuleSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+    delete:
+      tags: [Automations]
+      summary: Delete an automation rule
+      operationId: deleteAutomation
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: rule_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Automation rule deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
   /v1/audit-events:
     get:
       tags: [Audit]
@@ -691,6 +803,135 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ConnectorSummary"
+    AutomationPromptEnvelope:
+      type: object
+      required:
+        [
+          version,
+          algorithm,
+          key_id,
+          request_id,
+          client_ephemeral_public_key,
+          nonce,
+          ciphertext
+        ]
+      properties:
+        version:
+          type: string
+          enum: [v1]
+        algorithm:
+          type: string
+          enum: [x25519-chacha20poly1305]
+        key_id:
+          type: string
+          minLength: 1
+        request_id:
+          type: string
+          minLength: 1
+        client_ephemeral_public_key:
+          type: string
+          description: Base64-encoded 32-byte X25519 public key.
+        nonce:
+          type: string
+          description: Base64-encoded 12-byte nonce.
+        ciphertext:
+          type: string
+          description: Base64-encoded encrypted automation prompt payload.
+    CreateAutomationRequest:
+      type: object
+      required: [interval_seconds, time_zone, prompt_envelope]
+      properties:
+        interval_seconds:
+          type: integer
+          format: int32
+          minimum: 60
+          maximum: 604800
+        time_zone:
+          type: string
+          description: IANA timezone identifier (for example, America/Los_Angeles).
+          minLength: 1
+          maxLength: 64
+        prompt_envelope:
+          $ref: "#/components/schemas/AutomationPromptEnvelope"
+    AutomationScheduleUpdate:
+      type: object
+      required: [interval_seconds, time_zone]
+      properties:
+        interval_seconds:
+          type: integer
+          format: int32
+          minimum: 60
+          maximum: 604800
+        time_zone:
+          type: string
+          description: IANA timezone identifier (for example, America/Los_Angeles).
+          minLength: 1
+          maxLength: 64
+    AutomationStatus:
+      type: string
+      enum: [ACTIVE, PAUSED]
+    UpdateAutomationRequest:
+      type: object
+      properties:
+        schedule:
+          $ref: "#/components/schemas/AutomationScheduleUpdate"
+        prompt_envelope:
+          $ref: "#/components/schemas/AutomationPromptEnvelope"
+        status:
+          $ref: "#/components/schemas/AutomationStatus"
+    AutomationScheduleType:
+      type: string
+      enum: [INTERVAL_SECONDS]
+    AutomationRuleSummary:
+      type: object
+      required:
+        [
+          rule_id,
+          status,
+          schedule_type,
+          interval_seconds,
+          time_zone,
+          next_run_at,
+          prompt_sha256,
+          created_at,
+          updated_at
+        ]
+      properties:
+        rule_id:
+          type: string
+          format: uuid
+        status:
+          $ref: "#/components/schemas/AutomationStatus"
+        schedule_type:
+          $ref: "#/components/schemas/AutomationScheduleType"
+        interval_seconds:
+          type: integer
+          format: int32
+        time_zone:
+          type: string
+        next_run_at:
+          type: string
+          format: date-time
+        last_run_at:
+          type: string
+          format: date-time
+          nullable: true
+        prompt_sha256:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    ListAutomationsResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AutomationRuleSummary"
     Preferences:
       type: object
       required:

--- a/backend/crates/api-server/src/http/automations.rs
+++ b/backend/crates/api-server/src/http/automations.rs
@@ -1,0 +1,397 @@
+use std::collections::HashMap;
+
+use axum::Json;
+use axum::extract::{Extension, Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use base64::Engine as _;
+use chrono::{Duration as ChronoDuration, Utc};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use shared::assistant_crypto::{
+    ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305, ASSISTANT_ENVELOPE_VERSION_V1,
+};
+use shared::models::{
+    AutomationRuleSummary, AutomationScheduleKind, AutomationStatus, CreateAutomationRequest,
+    ErrorBody, ErrorResponse, ListAutomationsResponse, OkResponse, UpdateAutomationRequest,
+};
+use shared::repos::{
+    AuditResult, AutomationRuleRecord, AutomationRuleStatus as RepoAutomationRuleStatus,
+    AutomationScheduleType as RepoAutomationScheduleType, StoreError,
+};
+use uuid::Uuid;
+
+use super::errors::{bad_request_response, store_error_response};
+use super::{AppState, AuthUser};
+
+const AUTOMATION_LIST_DEFAULT_LIMIT: i64 = 50;
+const AUTOMATION_LIST_MAX_LIMIT: i64 = 200;
+const MAX_PROMPT_ENVELOPE_CIPHERTEXT_BYTES: usize = 65_536;
+type PromptValidationError = (&'static str, &'static str);
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ListAutomationsQuery {
+    pub(super) limit: Option<i64>,
+}
+
+pub(super) async fn create_automation(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Json(request): Json<CreateAutomationRequest>,
+) -> Response {
+    let prompt_payload = match validated_prompt_payload(&request.prompt_envelope) {
+        Ok(payload) => payload,
+        Err((code, message)) => return bad_request_response(code, message),
+    };
+    let prompt_sha256 = format!("{:x}", Sha256::digest(&prompt_payload));
+    let next_run_at = Utc::now() + ChronoDuration::seconds(i64::from(request.interval_seconds));
+
+    let created_rule = match state
+        .store
+        .create_automation_rule(
+            user.user_id,
+            request.interval_seconds,
+            &request.time_zone,
+            next_run_at,
+            &prompt_payload,
+            &prompt_sha256,
+        )
+        .await
+    {
+        Ok(rule) => rule,
+        Err(err) => return automation_store_error_response(err),
+    };
+
+    let mut metadata = HashMap::new();
+    metadata.insert("rule_id".to_string(), created_rule.id.to_string());
+    metadata.insert(
+        "schedule_type".to_string(),
+        created_rule.schedule_type.as_str().to_string(),
+    );
+    metadata.insert(
+        "interval_seconds".to_string(),
+        created_rule.interval_seconds.to_string(),
+    );
+    metadata.insert("time_zone".to_string(), created_rule.time_zone.clone());
+    if let Err(err) = state
+        .store
+        .add_audit_event(
+            user.user_id,
+            "AUTOMATION_RULE_CREATED",
+            None,
+            AuditResult::Success,
+            &metadata,
+        )
+        .await
+    {
+        return store_error_response(err);
+    }
+
+    (StatusCode::OK, Json(automation_rule_summary(created_rule))).into_response()
+}
+
+pub(super) async fn list_automations(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Query(query): Query<ListAutomationsQuery>,
+) -> Response {
+    let limit = query.limit.unwrap_or(AUTOMATION_LIST_DEFAULT_LIMIT);
+    if !(1..=AUTOMATION_LIST_MAX_LIMIT).contains(&limit) {
+        return bad_request_response("invalid_limit", "limit must be between 1 and 200");
+    }
+
+    let rules = match state.store.list_automation_rules(user.user_id, limit).await {
+        Ok(rules) => rules,
+        Err(err) => return automation_store_error_response(err),
+    };
+
+    let items = rules.into_iter().map(automation_rule_summary).collect();
+    (StatusCode::OK, Json(ListAutomationsResponse { items })).into_response()
+}
+
+pub(super) async fn update_automation(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Path(rule_id): Path<String>,
+    Json(request): Json<UpdateAutomationRequest>,
+) -> Response {
+    let rule_id = match Uuid::parse_str(&rule_id) {
+        Ok(rule_id) => rule_id,
+        Err(_) => return automation_not_found_response(),
+    };
+
+    if request.schedule.is_none() && request.prompt_envelope.is_none() && request.status.is_none() {
+        return bad_request_response(
+            "invalid_automation_update",
+            "Provide at least one update field: schedule, prompt_envelope, or status",
+        );
+    }
+
+    let mut rule = match state.store.get_automation_rule(user.user_id, rule_id).await {
+        Ok(Some(rule)) => rule,
+        Ok(None) => return automation_not_found_response(),
+        Err(err) => return automation_store_error_response(err),
+    };
+
+    let mut changed_fields: Vec<&str> = Vec::new();
+
+    if let Some(schedule) = request.schedule {
+        let next_run_at =
+            Utc::now() + ChronoDuration::seconds(i64::from(schedule.interval_seconds));
+        rule = match state
+            .store
+            .update_automation_rule_schedule(
+                user.user_id,
+                rule_id,
+                schedule.interval_seconds,
+                &schedule.time_zone,
+                next_run_at,
+            )
+            .await
+        {
+            Ok(Some(rule)) => rule,
+            Ok(None) => return automation_not_found_response(),
+            Err(err) => return automation_store_error_response(err),
+        };
+        changed_fields.push("schedule");
+    }
+
+    if let Some(prompt_envelope) = request.prompt_envelope {
+        let prompt_payload = match validated_prompt_payload(&prompt_envelope) {
+            Ok(payload) => payload,
+            Err((code, message)) => return bad_request_response(code, message),
+        };
+        let prompt_sha256 = format!("{:x}", Sha256::digest(&prompt_payload));
+        rule = match state
+            .store
+            .update_automation_rule_prompt(user.user_id, rule_id, &prompt_payload, &prompt_sha256)
+            .await
+        {
+            Ok(Some(rule)) => rule,
+            Ok(None) => return automation_not_found_response(),
+            Err(err) => return automation_store_error_response(err),
+        };
+        changed_fields.push("prompt");
+    }
+
+    if let Some(status) = request.status {
+        match status {
+            AutomationStatus::Paused => {
+                match state
+                    .store
+                    .pause_automation_rule(user.user_id, rule_id)
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => return automation_not_found_response(),
+                    Err(err) => return automation_store_error_response(err),
+                }
+                changed_fields.push("status");
+            }
+            AutomationStatus::Active => {
+                let interval_seconds = if rule.interval_seconds > 0 {
+                    i64::from(rule.interval_seconds)
+                } else {
+                    60
+                };
+                let next_run_at = Utc::now() + ChronoDuration::seconds(interval_seconds);
+                match state
+                    .store
+                    .resume_automation_rule(user.user_id, rule_id, next_run_at)
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => return automation_not_found_response(),
+                    Err(err) => return automation_store_error_response(err),
+                }
+                changed_fields.push("status");
+            }
+        }
+
+        rule = match state.store.get_automation_rule(user.user_id, rule_id).await {
+            Ok(Some(rule)) => rule,
+            Ok(None) => return automation_not_found_response(),
+            Err(err) => return automation_store_error_response(err),
+        };
+    }
+
+    if !changed_fields.is_empty() {
+        let mut metadata = HashMap::new();
+        metadata.insert("rule_id".to_string(), rule.id.to_string());
+        metadata.insert("updated_fields".to_string(), changed_fields.join(","));
+        if let Err(err) = state
+            .store
+            .add_audit_event(
+                user.user_id,
+                "AUTOMATION_RULE_UPDATED",
+                None,
+                AuditResult::Success,
+                &metadata,
+            )
+            .await
+        {
+            return store_error_response(err);
+        }
+    }
+
+    (StatusCode::OK, Json(automation_rule_summary(rule))).into_response()
+}
+
+pub(super) async fn delete_automation(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Path(rule_id): Path<String>,
+) -> Response {
+    let rule_id = match Uuid::parse_str(&rule_id) {
+        Ok(rule_id) => rule_id,
+        Err(_) => return automation_not_found_response(),
+    };
+
+    match state
+        .store
+        .delete_automation_rule(user.user_id, rule_id)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => return automation_not_found_response(),
+        Err(err) => return automation_store_error_response(err),
+    }
+
+    let mut metadata = HashMap::new();
+    metadata.insert("rule_id".to_string(), rule_id.to_string());
+    if let Err(err) = state
+        .store
+        .add_audit_event(
+            user.user_id,
+            "AUTOMATION_RULE_DELETED",
+            None,
+            AuditResult::Success,
+            &metadata,
+        )
+        .await
+    {
+        return store_error_response(err);
+    }
+
+    (StatusCode::OK, Json(OkResponse { ok: true })).into_response()
+}
+
+fn validated_prompt_payload(
+    envelope: &shared::models::AutomationPromptEnvelope,
+) -> Result<Vec<u8>, PromptValidationError> {
+    if envelope.version != ASSISTANT_ENVELOPE_VERSION_V1 {
+        return Err((
+            "invalid_envelope_version",
+            "automation prompt envelope version is not supported",
+        ));
+    }
+
+    if envelope.algorithm != ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305 {
+        return Err((
+            "invalid_envelope_algorithm",
+            "automation prompt envelope algorithm is not supported",
+        ));
+    }
+
+    if envelope.key_id.trim().is_empty() {
+        return Err(("invalid_key_id", "key_id is required"));
+    }
+
+    if envelope.request_id.trim().is_empty() {
+        return Err(("invalid_request_id", "request_id is required"));
+    }
+
+    let client_public_key = match base64::engine::general_purpose::STANDARD
+        .decode(envelope.client_ephemeral_public_key.as_bytes())
+    {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return Err((
+                "invalid_client_public_key",
+                "client_ephemeral_public_key must be valid base64",
+            ));
+        }
+    };
+    if client_public_key.len() != 32 {
+        return Err((
+            "invalid_client_public_key",
+            "client_ephemeral_public_key must decode to 32 bytes",
+        ));
+    }
+
+    let nonce = match base64::engine::general_purpose::STANDARD.decode(envelope.nonce.as_bytes()) {
+        Ok(bytes) => bytes,
+        Err(_) => return Err(("invalid_nonce", "nonce must be valid base64")),
+    };
+    if nonce.len() != 12 {
+        return Err(("invalid_nonce", "nonce must decode to 12 bytes"));
+    }
+
+    let ciphertext =
+        match base64::engine::general_purpose::STANDARD.decode(envelope.ciphertext.as_bytes()) {
+            Ok(ciphertext) => ciphertext,
+            Err(_) => {
+                return Err(("invalid_ciphertext", "ciphertext must be valid base64"));
+            }
+        };
+
+    if ciphertext.is_empty() {
+        return Err(("invalid_ciphertext", "ciphertext must not be empty"));
+    }
+
+    if ciphertext.len() > MAX_PROMPT_ENVELOPE_CIPHERTEXT_BYTES {
+        return Err(("invalid_ciphertext", "ciphertext exceeds size limit"));
+    }
+
+    serde_json::to_vec(envelope).map_err(|_| {
+        (
+            "invalid_prompt_envelope",
+            "automation prompt envelope payload is invalid",
+        )
+    })
+}
+
+fn automation_rule_summary(rule: AutomationRuleRecord) -> AutomationRuleSummary {
+    let status = match rule.status {
+        RepoAutomationRuleStatus::Active => AutomationStatus::Active,
+        RepoAutomationRuleStatus::Paused => AutomationStatus::Paused,
+    };
+    let schedule_type = match rule.schedule_type {
+        RepoAutomationScheduleType::IntervalSeconds => AutomationScheduleKind::IntervalSeconds,
+    };
+
+    AutomationRuleSummary {
+        rule_id: rule.id.to_string(),
+        status,
+        schedule_type,
+        interval_seconds: rule.interval_seconds,
+        time_zone: rule.time_zone,
+        next_run_at: rule.next_run_at,
+        last_run_at: rule.last_run_at,
+        prompt_sha256: rule.prompt_sha256,
+        created_at: rule.created_at,
+        updated_at: rule.updated_at,
+    }
+}
+
+fn automation_store_error_response(err: StoreError) -> Response {
+    match err {
+        StoreError::InvalidData(message) => {
+            bad_request_response("invalid_automation_request", &message)
+        }
+        other => store_error_response(other),
+    }
+}
+
+fn automation_not_found_response() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse {
+            error: ErrorBody {
+                code: "not_found".to_string(),
+                message: "Automation rule not found".to_string(),
+            },
+        }),
+    )
+        .into_response()
+}

--- a/backend/crates/api-server/src/http/mod.rs
+++ b/backend/crates/api-server/src/http/mod.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 mod assistant;
 mod audit;
 mod authn;
+mod automations;
 mod clerk_identity;
 mod clerk_jwks_cache;
 mod connectors;
@@ -128,6 +129,24 @@ pub fn build_router(app_state: AppState) -> Router {
         .route(
             "/v1/preferences",
             get(preferences::get_preferences).put(preferences::update_preferences),
+        )
+        .route(
+            "/v1/automations",
+            get(automations::list_automations)
+                .post(automations::create_automation)
+                .layer(middleware::from_fn_with_state(
+                    protected_rate_limit_layer_state.clone(),
+                    rate_limit::sensitive_rate_limit_middleware,
+                )),
+        )
+        .route(
+            "/v1/automations/{rule_id}",
+            delete(automations::delete_automation)
+                .patch(automations::update_automation)
+                .layer(middleware::from_fn_with_state(
+                    protected_rate_limit_layer_state.clone(),
+                    rate_limit::sensitive_rate_limit_middleware,
+                )),
         )
         .route("/v1/audit-events", get(audit::list_audit_events))
         .route(

--- a/backend/crates/api-server/src/http/rate_limit.rs
+++ b/backend/crates/api-server/src/http/rate_limit.rs
@@ -23,6 +23,9 @@ enum SensitiveEndpoint {
     GoogleConnectCallback,
     RevokeConnector,
     PrivacyDeleteAll,
+    AutomationCreate,
+    AutomationUpdate,
+    AutomationDelete,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,6 +60,13 @@ impl SensitiveEndpoint {
                 Some(Self::RevokeConnector)
             }
             (&Method::POST, "/v1/privacy/delete-all") => Some(Self::PrivacyDeleteAll),
+            (&Method::POST, "/v1/automations") => Some(Self::AutomationCreate),
+            (&Method::PATCH, path) if path.starts_with("/v1/automations/") => {
+                Some(Self::AutomationUpdate)
+            }
+            (&Method::DELETE, path) if path.starts_with("/v1/automations/") => {
+                Some(Self::AutomationDelete)
+            }
             _ => None,
         }
     }
@@ -67,6 +77,9 @@ impl SensitiveEndpoint {
             Self::GoogleConnectCallback => "google_connect_callback",
             Self::RevokeConnector => "revoke_connector",
             Self::PrivacyDeleteAll => "privacy_delete_all",
+            Self::AutomationCreate => "automation_create",
+            Self::AutomationUpdate => "automation_update",
+            Self::AutomationDelete => "automation_delete",
         }
     }
 
@@ -87,6 +100,18 @@ impl SensitiveEndpoint {
             Self::PrivacyDeleteAll => RateLimitPolicy {
                 max_requests: 3,
                 window_seconds: 3600,
+            },
+            Self::AutomationCreate => RateLimitPolicy {
+                max_requests: 20,
+                window_seconds: 60,
+            },
+            Self::AutomationUpdate => RateLimitPolicy {
+                max_requests: 30,
+                window_seconds: 60,
+            },
+            Self::AutomationDelete => RateLimitPolicy {
+                max_requests: 20,
+                window_seconds: 60,
             },
         }
     }

--- a/backend/crates/integration-tests/tests/api_automations.rs
+++ b/backend/crates/integration-tests/tests/api_automations.rs
@@ -1,0 +1,354 @@
+mod support;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Method, Request, StatusCode, header};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde_json::{Value, json};
+use serial_test::serial;
+use tower::ServiceExt;
+
+use support::api_app::build_test_router;
+use support::clerk::TestClerkAuth;
+
+#[tokio::test]
+#[serial]
+async fn automation_crud_flow_succeeds_for_owner() {
+    let store = support::test_store().await;
+    support::reset_database(store.pool()).await;
+
+    let clerk = TestClerkAuth::start().await;
+    let auth = format!("Bearer {}", clerk.token_for_subject("automation-owner"));
+    let app = build_test_router(store, &clerk).await;
+
+    let create = send_json(
+        &app,
+        request(
+            Method::POST,
+            "/v1/automations",
+            Some(&auth),
+            Some(json!({
+                "interval_seconds": 300,
+                "time_zone": "UTC",
+                "prompt_envelope": prompt_envelope("create-request")
+            })),
+        ),
+    )
+    .await;
+    assert_eq!(create.status, StatusCode::OK);
+    assert_eq!(
+        create.body.get("status").and_then(Value::as_str),
+        Some("ACTIVE")
+    );
+    assert_eq!(
+        create.body.get("schedule_type").and_then(Value::as_str),
+        Some("INTERVAL_SECONDS")
+    );
+    let rule_id = create
+        .body
+        .get("rule_id")
+        .and_then(Value::as_str)
+        .expect("create response should include rule_id")
+        .to_string();
+
+    let list = send_json(
+        &app,
+        request(Method::GET, "/v1/automations", Some(&auth), None),
+    )
+    .await;
+    assert_eq!(list.status, StatusCode::OK);
+    let items = list
+        .body
+        .get("items")
+        .and_then(Value::as_array)
+        .expect("list response should include items");
+    assert_eq!(items.len(), 1);
+    assert_eq!(
+        items[0].get("rule_id").and_then(Value::as_str),
+        Some(rule_id.as_str())
+    );
+
+    let update_schedule = send_json(
+        &app,
+        request(
+            Method::PATCH,
+            &format!("/v1/automations/{rule_id}"),
+            Some(&auth),
+            Some(json!({
+                "schedule": {
+                    "interval_seconds": 900,
+                    "time_zone": "America/New_York"
+                }
+            })),
+        ),
+    )
+    .await;
+    assert_eq!(update_schedule.status, StatusCode::OK);
+    assert_eq!(
+        update_schedule
+            .body
+            .get("interval_seconds")
+            .and_then(Value::as_i64),
+        Some(900)
+    );
+    assert_eq!(
+        update_schedule
+            .body
+            .get("time_zone")
+            .and_then(Value::as_str),
+        Some("America/New_York")
+    );
+
+    let pause = send_json(
+        &app,
+        request(
+            Method::PATCH,
+            &format!("/v1/automations/{rule_id}"),
+            Some(&auth),
+            Some(json!({"status": "PAUSED"})),
+        ),
+    )
+    .await;
+    assert_eq!(pause.status, StatusCode::OK);
+    assert_eq!(
+        pause.body.get("status").and_then(Value::as_str),
+        Some("PAUSED")
+    );
+
+    let resume = send_json(
+        &app,
+        request(
+            Method::PATCH,
+            &format!("/v1/automations/{rule_id}"),
+            Some(&auth),
+            Some(json!({"status": "ACTIVE"})),
+        ),
+    )
+    .await;
+    assert_eq!(resume.status, StatusCode::OK);
+    assert_eq!(
+        resume.body.get("status").and_then(Value::as_str),
+        Some("ACTIVE")
+    );
+
+    let update_prompt = send_json(
+        &app,
+        request(
+            Method::PATCH,
+            &format!("/v1/automations/{rule_id}"),
+            Some(&auth),
+            Some(json!({"prompt_envelope": prompt_envelope("update-request")})),
+        ),
+    )
+    .await;
+    assert_eq!(update_prompt.status, StatusCode::OK);
+
+    let deleted = send_json(
+        &app,
+        request(
+            Method::DELETE,
+            &format!("/v1/automations/{rule_id}"),
+            Some(&auth),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(deleted.status, StatusCode::OK);
+    assert_eq!(deleted.body.get("ok").and_then(Value::as_bool), Some(true));
+
+    let list_after_delete = send_json(
+        &app,
+        request(Method::GET, "/v1/automations", Some(&auth), None),
+    )
+    .await;
+    assert_eq!(list_after_delete.status, StatusCode::OK);
+    let items_after_delete = list_after_delete
+        .body
+        .get("items")
+        .and_then(Value::as_array)
+        .expect("list response should include items");
+    assert!(items_after_delete.is_empty());
+}
+
+#[tokio::test]
+#[serial]
+async fn automation_create_rejects_invalid_schedule() {
+    let store = support::test_store().await;
+    support::reset_database(store.pool()).await;
+
+    let clerk = TestClerkAuth::start().await;
+    let auth = format!(
+        "Bearer {}",
+        clerk.token_for_subject("automation-invalid-schedule")
+    );
+    let app = build_test_router(store, &clerk).await;
+
+    let response = send_json(
+        &app,
+        request(
+            Method::POST,
+            "/v1/automations",
+            Some(&auth),
+            Some(json!({
+                "interval_seconds": 30,
+                "time_zone": "UTC",
+                "prompt_envelope": prompt_envelope("invalid-schedule")
+            })),
+        ),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        error_code(&response.body),
+        Some("invalid_automation_request")
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn automation_create_rejects_invalid_envelope() {
+    let store = support::test_store().await;
+    support::reset_database(store.pool()).await;
+
+    let clerk = TestClerkAuth::start().await;
+    let auth = format!(
+        "Bearer {}",
+        clerk.token_for_subject("automation-invalid-envelope")
+    );
+    let app = build_test_router(store, &clerk).await;
+
+    let mut invalid = prompt_envelope("invalid-envelope");
+    invalid["nonce"] = json!("not-base64");
+    let response = send_json(
+        &app,
+        request(
+            Method::POST,
+            "/v1/automations",
+            Some(&auth),
+            Some(json!({
+                "interval_seconds": 300,
+                "time_zone": "UTC",
+                "prompt_envelope": invalid
+            })),
+        ),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::BAD_REQUEST);
+    assert_eq!(error_code(&response.body), Some("invalid_nonce"));
+}
+
+#[tokio::test]
+#[serial]
+async fn automation_mutations_are_user_scoped() {
+    let store = support::test_store().await;
+    support::reset_database(store.pool()).await;
+
+    let clerk = TestClerkAuth::start().await;
+    let auth_a = format!("Bearer {}", clerk.token_for_subject("automation-owner-a"));
+    let auth_b = format!("Bearer {}", clerk.token_for_subject("automation-owner-b"));
+    let app = build_test_router(store, &clerk).await;
+
+    let create = send_json(
+        &app,
+        request(
+            Method::POST,
+            "/v1/automations",
+            Some(&auth_a),
+            Some(json!({
+                "interval_seconds": 300,
+                "time_zone": "UTC",
+                "prompt_envelope": prompt_envelope("owner-a")
+            })),
+        ),
+    )
+    .await;
+    assert_eq!(create.status, StatusCode::OK);
+    let rule_id = create
+        .body
+        .get("rule_id")
+        .and_then(Value::as_str)
+        .expect("create response should include rule_id");
+
+    let update_other_user = send_json(
+        &app,
+        request(
+            Method::PATCH,
+            &format!("/v1/automations/{rule_id}"),
+            Some(&auth_b),
+            Some(json!({"status": "PAUSED"})),
+        ),
+    )
+    .await;
+    assert_eq!(update_other_user.status, StatusCode::NOT_FOUND);
+
+    let delete_other_user = send_json(
+        &app,
+        request(
+            Method::DELETE,
+            &format!("/v1/automations/{rule_id}"),
+            Some(&auth_b),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(delete_other_user.status, StatusCode::NOT_FOUND);
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn send_json(app: &axum::Router, request: Request<Body>) -> JsonResponse {
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("request should succeed");
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should read");
+    let body = serde_json::from_slice::<Value>(&body).unwrap_or_else(|_| json!({}));
+
+    JsonResponse { status, body }
+}
+
+fn request(
+    method: Method,
+    uri: &str,
+    auth_header: Option<&str>,
+    json_body: Option<Value>,
+) -> Request<Body> {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(auth_header) = auth_header {
+        builder = builder.header(header::AUTHORIZATION, auth_header);
+    }
+
+    match json_body {
+        Some(body) => builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request should build"),
+        None => builder.body(Body::empty()).expect("request should build"),
+    }
+}
+
+fn prompt_envelope(request_id: &str) -> Value {
+    json!({
+        "version": "v1",
+        "algorithm": "x25519-chacha20poly1305",
+        "key_id": "assistant-ingress-v1",
+        "request_id": request_id,
+        "client_ephemeral_public_key": STANDARD.encode([7_u8; 32]),
+        "nonce": STANDARD.encode([9_u8; 12]),
+        "ciphertext": STANDARD.encode(b"encrypted-automation-prompt")
+    })
+}
+
+fn error_code(body: &Value) -> Option<&str> {
+    body.get("error")
+        .and_then(|error| error.get("code"))
+        .and_then(Value::as_str)
+}

--- a/backend/crates/shared/src/models.rs
+++ b/backend/crates/shared/src/models.rs
@@ -255,6 +255,76 @@ pub struct ListConnectorsResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AutomationPromptEnvelope {
+    pub version: String,
+    pub algorithm: String,
+    pub key_id: String,
+    pub request_id: String,
+    pub client_ephemeral_public_key: String,
+    pub nonce: String,
+    pub ciphertext: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateAutomationRequest {
+    pub interval_seconds: u32,
+    pub time_zone: String,
+    pub prompt_envelope: AutomationPromptEnvelope,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AutomationScheduleUpdate {
+    pub interval_seconds: u32,
+    pub time_zone: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AutomationStatus {
+    Active,
+    Paused,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateAutomationRequest {
+    #[serde(default)]
+    pub schedule: Option<AutomationScheduleUpdate>,
+    #[serde(default)]
+    pub prompt_envelope: Option<AutomationPromptEnvelope>,
+    #[serde(default)]
+    pub status: Option<AutomationStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AutomationScheduleKind {
+    IntervalSeconds,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutomationRuleSummary {
+    pub rule_id: String,
+    pub status: AutomationStatus,
+    pub schedule_type: AutomationScheduleKind,
+    pub interval_seconds: i32,
+    pub time_zone: String,
+    pub next_run_at: DateTime<Utc>,
+    pub last_run_at: Option<DateTime<Utc>>,
+    pub prompt_sha256: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListAutomationsResponse {
+    pub items: Vec<AutomationRuleSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Preferences {
     pub meeting_reminder_minutes: u32,
     pub morning_brief_local_time: String,


### PR DESCRIPTION
## Summary
Implements Automation v2 API CRUD endpoints with encrypted prompt-envelope input handling.

## Changes
- Added new API handlers in `backend/crates/api-server/src/http/automations.rs`:
  - `POST /v1/automations`
  - `GET /v1/automations`
  - `PATCH /v1/automations/{rule_id}`
  - `DELETE /v1/automations/{rule_id}`
- Added strict envelope-shape validation for `prompt_envelope` (version/algorithm, required fields, base64 validity, expected byte lengths, ciphertext size cap).
- Added per-user ownership checks with not-found behavior for cross-user mutation attempts.
- Added metadata-only audit events for create/update/delete operations.
- Added sensitive endpoint rate-limit mappings for automation create/update/delete.
- Added shared API models and list response types in `backend/crates/shared/src/models.rs`.
- Updated OpenAPI in `api/openapi.yaml` with Automations tag, paths, and schemas.
- Added integration tests in `backend/crates/integration-tests/tests/api_automations.rs` for:
  - owner CRUD happy path
  - invalid schedule rejection
  - invalid envelope rejection
  - user-scoped mutation enforcement

## Validation
- `just backend-verify` (pass)
- `just backend-tests` (pass)
- `just ios-build` (pass)
- `just backend-deep-review` (pass)

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: integration coverage in `api_automations.rs` + full backend verification suite
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no findings (routing in `http/*`, repo logic remains in `shared/src/repos`)
- Performance/scalability concerns: no findings
- Refactor recommendations: none

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #210
