### PR TITLE
[Automation v2] Encrypted APNs payload delivery for automation notifications

### DIFF
--- a/backend/crates/worker/src/job_actions/context.rs
+++ b/backend/crates/worker/src/job_actions/context.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use shared::enclave::EnclaveRpcClient;
+use shared::enclave::EncryptedAutomationNotificationEnvelope;
 use shared::repos::Store;
 
 use crate::{NotificationContent, PushSender};
@@ -13,5 +14,7 @@ pub(crate) struct JobActionContext<'a> {
 
 pub(crate) struct JobActionResult {
     pub(crate) notification: Option<NotificationContent>,
+    pub(crate) encrypted_envelopes_by_device:
+        HashMap<String, EncryptedAutomationNotificationEnvelope>,
     pub(crate) metadata: HashMap<String, String>,
 }

--- a/backend/crates/worker/src/job_actions/helpers.rs
+++ b/backend/crates/worker/src/job_actions/helpers.rs
@@ -39,6 +39,7 @@ pub(super) fn parse_notification_payload(payload: Option<&[u8]>) -> Option<Notif
     Some(NotificationContent {
         title: title.to_string(),
         body: body.to_string(),
+        encrypted_envelope: None,
     })
 }
 

--- a/backend/crates/worker/src/main.rs
+++ b/backend/crates/worker/src/main.rs
@@ -20,7 +20,7 @@ mod types;
 
 use job_processing::process_due_jobs;
 pub(crate) use push_sender::{
-    NotificationContent, PushSendError, PushSender, apns_environment_label,
+    NotificationContent, PushPayloadMode, PushSendError, PushSender, apns_environment_label,
 };
 pub(crate) use retry::retry_delay_seconds;
 pub(crate) use types::{FailureClass, JobExecutionError, WorkerTickMetrics};

--- a/backend/crates/worker/src/push_sender.rs
+++ b/backend/crates/worker/src/push_sender.rs
@@ -1,5 +1,8 @@
 use reqwest::StatusCode;
 use serde::Serialize;
+use serde_json::{Value, json};
+use shared::assistant_crypto::ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305;
+use shared::enclave::EncryptedAutomationNotificationEnvelope;
 use shared::models::ApnsEnvironment;
 use shared::repos::DeviceRegistration;
 use tracing::info;
@@ -20,6 +23,21 @@ pub(crate) enum PushSendError {
     Permanent { code: String, message: String },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PushPayloadMode {
+    Encrypted,
+    Fallback,
+}
+
+impl PushPayloadMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Encrypted => "encrypted",
+            Self::Fallback => "fallback",
+        }
+    }
+}
+
 impl PushSendError {
     pub(crate) fn to_job_error(&self) -> JobExecutionError {
         match self {
@@ -37,6 +55,17 @@ impl PushSendError {
 pub(crate) struct NotificationContent {
     pub(crate) title: String,
     pub(crate) body: String,
+    pub(crate) encrypted_envelope: Option<EncryptedAutomationNotificationEnvelope>,
+}
+
+impl NotificationContent {
+    pub(crate) fn automation_fallback() -> Self {
+        Self {
+            title: "Automation update".to_string(),
+            body: "Open Alfred to view your latest automation result.".to_string(),
+            encrypted_envelope: None,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -44,7 +73,10 @@ struct PushDeliveryRequest<'a> {
     device_token: &'a str,
     title: &'a str,
     body: &'a str,
+    payload: Value,
 }
+
+const APNS_MAX_PAYLOAD_BYTES: usize = 4096;
 
 impl PushSender {
     pub(crate) fn new(
@@ -64,7 +96,7 @@ impl PushSender {
         &self,
         device: &DeviceRegistration,
         content: &NotificationContent,
-    ) -> Result<(), PushSendError> {
+    ) -> Result<PushPayloadMode, PushSendError> {
         let endpoint = match device.environment {
             ApnsEnvironment::Sandbox => self.sandbox_endpoint.as_deref(),
             ApnsEnvironment::Production => self.production_endpoint.as_deref(),
@@ -76,13 +108,24 @@ impl PushSender {
                 environment = %apns_environment_label(&device.environment),
                 "apns endpoint not configured for environment; simulated delivery"
             );
-            return Ok(());
+            return Ok(PushPayloadMode::Fallback);
+        };
+
+        let payload = apns_payload(content)?;
+        let payload_mode = if payload
+            .as_object()
+            .is_some_and(|object| object.contains_key("alfred_automation"))
+        {
+            PushPayloadMode::Encrypted
+        } else {
+            PushPayloadMode::Fallback
         };
 
         let request = PushDeliveryRequest {
             device_token: &device.apns_token,
             title: &content.title,
             body: &content.body,
+            payload,
         };
 
         let mut builder = self.client.post(endpoint).json(&request);
@@ -100,7 +143,7 @@ impl PushSender {
 
         let status = response.status();
         if status.is_success() {
-            return Ok(());
+            return Ok(payload_mode);
         }
 
         let body = response.text().await.unwrap_or_default();
@@ -115,6 +158,93 @@ impl PushSender {
             FailureClass::Transient => Err(PushSendError::Transient { code, message }),
             FailureClass::Permanent => Err(PushSendError::Permanent { code, message }),
         }
+    }
+}
+
+fn apns_payload(content: &NotificationContent) -> Result<Value, PushSendError> {
+    let mut payload = json!({
+        "aps": {
+            "alert": {
+                "title": content.title,
+                "body": content.body
+            }
+        }
+    });
+
+    if let Some(envelope) = content
+        .encrypted_envelope
+        .as_ref()
+        .filter(|value| is_valid_encrypted_envelope(value))
+    {
+        payload["aps"]["mutable-content"] = json!(1);
+        payload["alfred_automation"] = json!({
+            "version": envelope.version,
+            "envelope": {
+                "version": envelope.version,
+                "algorithm": envelope.algorithm,
+                "key_id": envelope.key_id,
+                "request_id": envelope.request_id,
+                "sender_public_key": envelope.sender_public_key,
+                "nonce": envelope.nonce,
+                "ciphertext": envelope.ciphertext
+            }
+        });
+    }
+
+    enforce_apns_payload_size(&mut payload)?;
+    Ok(payload)
+}
+
+fn is_valid_encrypted_envelope(envelope: &EncryptedAutomationNotificationEnvelope) -> bool {
+    envelope.algorithm == ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305
+        && !envelope.version.trim().is_empty()
+        && !envelope.key_id.trim().is_empty()
+        && !envelope.request_id.trim().is_empty()
+        && !envelope.sender_public_key.trim().is_empty()
+        && !envelope.nonce.trim().is_empty()
+        && !envelope.ciphertext.trim().is_empty()
+}
+
+fn enforce_apns_payload_size(payload: &mut Value) -> Result<(), PushSendError> {
+    let payload_size = payload_size_bytes(payload)?;
+    if payload_size <= APNS_MAX_PAYLOAD_BYTES {
+        return Ok(());
+    }
+
+    if payload
+        .as_object()
+        .is_some_and(|object| object.contains_key("alfred_automation"))
+    {
+        drop_encrypted_payload(payload);
+        if payload_size_bytes(payload)? <= APNS_MAX_PAYLOAD_BYTES {
+            return Ok(());
+        }
+    }
+
+    Err(PushSendError::Permanent {
+        code: "APNS_PAYLOAD_TOO_LARGE".to_string(),
+        message: format!(
+            "APNs payload exceeds {APNS_MAX_PAYLOAD_BYTES} byte limit after fallback handling"
+        ),
+    })
+}
+
+fn payload_size_bytes(payload: &Value) -> Result<usize, PushSendError> {
+    serde_json::to_vec(payload)
+        .map(|bytes| bytes.len())
+        .map_err(|_| PushSendError::Permanent {
+            code: "APNS_PAYLOAD_INVALID".to_string(),
+            message: "failed to serialize APNs payload".to_string(),
+        })
+}
+
+fn drop_encrypted_payload(payload: &mut Value) {
+    let Some(object) = payload.as_object_mut() else {
+        return;
+    };
+    object.remove("alfred_automation");
+    if let Some(aps) = object.get_mut("aps").and_then(Value::as_object_mut) {
+        aps.remove("mutable-content");
     }
 }
 
@@ -134,9 +264,16 @@ fn classify_http_failure(status: StatusCode) -> FailureClass {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+    use shared::assistant_crypto::ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305;
+    use shared::enclave::EncryptedAutomationNotificationEnvelope;
+
+    use super::NotificationContent;
     use reqwest::StatusCode;
 
-    use super::classify_http_failure;
+    use super::{
+        apns_payload, classify_http_failure, enforce_apns_payload_size, is_valid_encrypted_envelope,
+    };
     use crate::FailureClass;
 
     #[test]
@@ -161,5 +298,101 @@ mod tests {
             classify_http_failure(StatusCode::GONE),
             FailureClass::Permanent
         ));
+    }
+
+    #[test]
+    fn apns_payload_includes_envelope_and_mutable_content_when_valid() {
+        let content = NotificationContent {
+            title: "Automation update".to_string(),
+            body: "Open Alfred to view your latest automation result.".to_string(),
+            encrypted_envelope: Some(sample_envelope()),
+        };
+
+        let payload = apns_payload(&content).expect("payload should serialize");
+        assert_eq!(payload["aps"]["mutable-content"], json!(1));
+        assert_eq!(
+            payload["alfred_automation"]["envelope"]["algorithm"],
+            json!(ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305)
+        );
+    }
+
+    #[test]
+    fn apns_payload_drops_invalid_envelope() {
+        let mut invalid_envelope = sample_envelope();
+        invalid_envelope.algorithm = "invalid".to_string();
+        assert!(!is_valid_encrypted_envelope(&invalid_envelope));
+
+        let content = NotificationContent {
+            title: "Automation update".to_string(),
+            body: "Open Alfred to view your latest automation result.".to_string(),
+            encrypted_envelope: Some(invalid_envelope),
+        };
+        let payload = apns_payload(&content).expect("payload should serialize");
+
+        assert!(payload.get("alfred_automation").is_none());
+        assert!(payload["aps"].get("mutable-content").is_none());
+    }
+
+    #[test]
+    fn payload_size_guard_drops_encrypted_payload_before_failing() {
+        let mut envelope = sample_envelope();
+        envelope.ciphertext = "A".repeat(7000);
+
+        let mut payload = json!({
+            "aps": {
+                "alert": {
+                    "title": "Automation update",
+                    "body": "Open Alfred to view your latest automation result."
+                },
+                "mutable-content": 1
+            },
+            "alfred_automation": {
+                "version": "v1",
+                "envelope": {
+                    "version": envelope.version,
+                    "algorithm": envelope.algorithm,
+                    "key_id": envelope.key_id,
+                    "request_id": envelope.request_id,
+                    "sender_public_key": envelope.sender_public_key,
+                    "nonce": envelope.nonce,
+                    "ciphertext": envelope.ciphertext
+                }
+            }
+        });
+
+        enforce_apns_payload_size(&mut payload).expect("fallback payload should fit");
+        assert!(payload.get("alfred_automation").is_none());
+        assert!(payload["aps"].get("mutable-content").is_none());
+    }
+
+    #[test]
+    fn payload_size_guard_rejects_oversized_fallback_payload() {
+        let oversized_text = "B".repeat(5000);
+        let mut payload = json!({
+            "aps": {
+                "alert": {
+                    "title": oversized_text,
+                    "body": "still too large"
+                }
+            }
+        });
+
+        let err = enforce_apns_payload_size(&mut payload).expect_err("payload should be rejected");
+        assert!(matches!(
+            err,
+            super::PushSendError::Permanent { code, .. } if code == "APNS_PAYLOAD_TOO_LARGE"
+        ));
+    }
+
+    fn sample_envelope() -> EncryptedAutomationNotificationEnvelope {
+        EncryptedAutomationNotificationEnvelope {
+            version: "v1".to_string(),
+            algorithm: ASSISTANT_ENCRYPTION_ALGORITHM_X25519_CHACHA20POLY1305.to_string(),
+            key_id: "device-key".to_string(),
+            request_id: "req-123".to_string(),
+            sender_public_key: "pub".to_string(),
+            nonce: "nonce".to_string(),
+            ciphertext: "cipher".to_string(),
+        }
     }
 }


### PR DESCRIPTION
## Summary
Implement encrypted APNs payload delivery for automation notifications with safe fallback behavior and payload-size enforcement.

## Changes
- Extend worker automation action result to carry per-device encrypted notification envelopes from enclave artifacts.
- Send generic fallback notification content while injecting device-specific encrypted envelopes into APNs payloads when valid.
- Add APNs payload builder/validator in worker push sender:
  - `aps.mutable-content = 1` when encrypted envelope is present and valid
  - `alfred_automation` encrypted payload contract
  - 4096-byte payload guard with encrypted-section drop fallback before hard failure
- Preserve fanout, retry/permanent error classification, and audit event emission with metadata-only fields.
- Add/expand worker tests covering payload shape, invalid-envelope fallback, and payload-size handling.

## Validation
- `just backend-fmt`
- `just backend-verify`
- `just ios-build`
- `just backend-deep-review`

## AI Review Summary
### 1) Security Audit
- Findings: no findings
- Risk level: low
- Required fixes: none

### 2) Bug Check
- Findings: no findings
- Repro or test evidence: full backend verify + deep review suites passed
- Required fixes: none

### 3) Scalability / Code Quality Review
- Layering and module ownership findings: no violations (push logic remains in worker; DB/HTTP boundaries unchanged)
- Performance/scalability concerns: no material concerns for this scope
- Refactor recommendations: none required for merge

### 4) Final Status
- `just backend-deep-review`: pass
- Merge recommendation: `APPROVE`

Closes #213