### PR TITLE
[Automation v2][iOS] Add NSE decrypt path for encrypted automation notifications

### DIFF
--- a/alfred/Packages/AlfredAPIClient/Sources/AutomationNotificationCrypto.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/AutomationNotificationCrypto.swift
@@ -1,0 +1,418 @@
+import CryptoKit
+import Foundation
+import Security
+
+public struct AutomationNotificationContent: Codable, Equatable, Sendable {
+    public let title: String
+    public let body: String
+
+    public init(title: String, body: String) {
+        self.title = title
+        self.body = body
+    }
+
+    public static let fallback = AutomationNotificationContent(
+        title: "Automation update",
+        body: "Open Alfred to view your latest automation result."
+    )
+}
+
+public struct AutomationNotificationRegistrationMaterial: Equatable, Sendable {
+    public let deviceID: String
+    public let algorithm: String
+    public let publicKey: String
+
+    public init(deviceID: String, algorithm: String, publicKey: String) {
+        self.deviceID = deviceID
+        self.algorithm = algorithm
+        self.publicKey = publicKey
+    }
+}
+
+public struct AutomationNotificationDecryptionMaterial: Equatable, Sendable {
+    public let deviceID: String
+    public let privateKeyRawRepresentation: Data
+
+    public init(deviceID: String, privateKeyRawRepresentation: Data) {
+        self.deviceID = deviceID
+        self.privateKeyRawRepresentation = privateKeyRawRepresentation
+    }
+}
+
+public struct AutomationEncryptedNotificationEnvelope: Codable, Equatable, Sendable {
+    public let version: String
+    public let algorithm: String
+    public let keyID: String
+    public let requestID: String
+    public let senderPublicKey: String
+    public let nonce: String
+    public let ciphertext: String
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case algorithm
+        case keyID = "key_id"
+        case requestID = "request_id"
+        case senderPublicKey = "sender_public_key"
+        case nonce
+        case ciphertext
+    }
+
+    public init(
+        version: String,
+        algorithm: String,
+        keyID: String,
+        requestID: String,
+        senderPublicKey: String,
+        nonce: String,
+        ciphertext: String
+    ) {
+        self.version = version
+        self.algorithm = algorithm
+        self.keyID = keyID
+        self.requestID = requestID
+        self.senderPublicKey = senderPublicKey
+        self.nonce = nonce
+        self.ciphertext = ciphertext
+    }
+}
+
+public enum AutomationNotificationCryptoError: Error {
+    case keychain(OSStatus)
+    case invalidKeyMaterial
+    case payloadInvalid
+    case envelopeMissing
+    case unsupportedVersion
+    case unsupportedAlgorithm
+    case invalidSenderPublicKey
+    case invalidNonce
+    case invalidCiphertext
+    case keyAgreementFailed
+    case decryptionFailed
+    case plaintextInvalid
+}
+
+public enum AutomationNotificationCrypto {
+    public static let versionV1 = "v1"
+    public static let algorithmX25519ChaCha20Poly1305 = "x25519-chacha20poly1305"
+
+    private static let keychainService = "com.prodata.alfred.automation-notification"
+    private static let keychainAccount = "device-key-material-v1"
+
+    private struct StoredKeyMaterial: Codable {
+        let deviceID: String
+        let privateKeyBase64: String
+    }
+
+    private struct PayloadRoot: Codable {
+        let alfredAutomation: PayloadContainer
+
+        enum CodingKeys: String, CodingKey {
+            case alfredAutomation = "alfred_automation"
+        }
+    }
+
+    private struct PayloadContainer: Codable {
+        let version: String
+        let envelope: AutomationEncryptedNotificationEnvelope
+    }
+
+    private struct NotificationPlaintext: Codable {
+        let title: String
+        let body: String
+    }
+
+    public static func registrationMaterial() throws -> AutomationNotificationRegistrationMaterial {
+        let stored = try loadOrCreateStoredKeyMaterial()
+        let privateKeyData = try decodePrivateKeyData(base64Encoded: stored.privateKeyBase64)
+
+        let privateKey: Curve25519.KeyAgreement.PrivateKey
+        do {
+            privateKey = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: privateKeyData)
+        } catch {
+            throw AutomationNotificationCryptoError.invalidKeyMaterial
+        }
+
+        return AutomationNotificationRegistrationMaterial(
+            deviceID: stored.deviceID,
+            algorithm: algorithmX25519ChaCha20Poly1305,
+            publicKey: privateKey.publicKey.rawRepresentation.base64EncodedString()
+        )
+    }
+
+    public static func decryptionMaterial() throws -> AutomationNotificationDecryptionMaterial? {
+        guard let stored = try loadStoredKeyMaterial() else {
+            return nil
+        }
+        let privateKeyData = try decodePrivateKeyData(base64Encoded: stored.privateKeyBase64)
+
+        return AutomationNotificationDecryptionMaterial(
+            deviceID: stored.deviceID,
+            privateKeyRawRepresentation: privateKeyData
+        )
+    }
+
+    public static func encryptedEnvelope(from userInfo: [AnyHashable: Any]) throws -> AutomationEncryptedNotificationEnvelope {
+        let jsonObject = normalizeUserInfo(userInfo)
+        guard JSONSerialization.isValidJSONObject(jsonObject) else {
+            throw AutomationNotificationCryptoError.payloadInvalid
+        }
+
+        let payloadData = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        let payload = try JSONDecoder().decode(PayloadRoot.self, from: payloadData)
+
+        guard payload.alfredAutomation.version == versionV1,
+              payload.alfredAutomation.envelope.version == versionV1 else {
+            throw AutomationNotificationCryptoError.unsupportedVersion
+        }
+
+        return payload.alfredAutomation.envelope
+    }
+
+    public static func decrypt(
+        envelope: AutomationEncryptedNotificationEnvelope,
+        material: AutomationNotificationDecryptionMaterial
+    ) throws -> AutomationNotificationContent {
+        guard envelope.version == versionV1 else {
+            throw AutomationNotificationCryptoError.unsupportedVersion
+        }
+        guard envelope.algorithm == algorithmX25519ChaCha20Poly1305 else {
+            throw AutomationNotificationCryptoError.unsupportedAlgorithm
+        }
+
+        guard let nonceData = Data(base64Encoded: envelope.nonce), nonceData.count == 12 else {
+            throw AutomationNotificationCryptoError.invalidNonce
+        }
+        guard let ciphertextWithTag = Data(base64Encoded: envelope.ciphertext), ciphertextWithTag.count >= 16 else {
+            throw AutomationNotificationCryptoError.invalidCiphertext
+        }
+        guard let senderPublicKeyData = Data(base64Encoded: envelope.senderPublicKey), senderPublicKeyData.count == 32 else {
+            throw AutomationNotificationCryptoError.invalidSenderPublicKey
+        }
+
+        let recipientPrivateKey: Curve25519.KeyAgreement.PrivateKey
+        let senderPublicKey: Curve25519.KeyAgreement.PublicKey
+        do {
+            recipientPrivateKey = try Curve25519.KeyAgreement.PrivateKey(rawRepresentation: material.privateKeyRawRepresentation)
+            senderPublicKey = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: senderPublicKeyData)
+        } catch {
+            throw AutomationNotificationCryptoError.invalidKeyMaterial
+        }
+
+        let sharedSecret: SharedSecret
+        do {
+            sharedSecret = try recipientPrivateKey.sharedSecretFromKeyAgreement(with: senderPublicKey)
+        } catch {
+            throw AutomationNotificationCryptoError.keyAgreementFailed
+        }
+
+        let derivedKey = deriveNotificationSymmetricKey(
+            sharedSecret: sharedSecret,
+            requestID: envelope.requestID,
+            deviceID: material.deviceID
+        )
+        let aad = Data("\(envelope.requestID)|\(material.deviceID)".utf8)
+
+        let nonce: ChaChaPoly.Nonce
+        do {
+            nonce = try ChaChaPoly.Nonce(data: nonceData)
+        } catch {
+            throw AutomationNotificationCryptoError.invalidNonce
+        }
+
+        let encryptedBytes = ciphertextWithTag.prefix(ciphertextWithTag.count - 16)
+        let tag = ciphertextWithTag.suffix(16)
+
+        let sealedBox: ChaChaPoly.SealedBox
+        do {
+            sealedBox = try ChaChaPoly.SealedBox(
+                nonce: nonce,
+                ciphertext: Data(encryptedBytes),
+                tag: Data(tag)
+            )
+        } catch {
+            throw AutomationNotificationCryptoError.invalidCiphertext
+        }
+
+        let plaintext: Data
+        do {
+            plaintext = try ChaChaPoly.open(sealedBox, using: derivedKey, authenticating: aad)
+        } catch {
+            throw AutomationNotificationCryptoError.decryptionFailed
+        }
+
+        let decoded: NotificationPlaintext
+        do {
+            decoded = try JSONDecoder().decode(NotificationPlaintext.self, from: plaintext)
+        } catch {
+            throw AutomationNotificationCryptoError.plaintextInvalid
+        }
+
+        let title = decoded.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = decoded.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty, !body.isEmpty else {
+            throw AutomationNotificationCryptoError.plaintextInvalid
+        }
+
+        return AutomationNotificationContent(title: title, body: body)
+    }
+
+    public static func resolveVisibleContent(
+        from userInfo: [AnyHashable: Any],
+        timeoutNanoseconds: UInt64 = 1_500_000_000,
+        decryptor: (@Sendable (AutomationEncryptedNotificationEnvelope, AutomationNotificationDecryptionMaterial) async throws -> AutomationNotificationContent)? = nil
+    ) async -> AutomationNotificationContent {
+        let envelope: AutomationEncryptedNotificationEnvelope
+        do {
+            envelope = try encryptedEnvelope(from: userInfo)
+        } catch {
+            return .fallback
+        }
+
+        let material: AutomationNotificationDecryptionMaterial
+        do {
+            guard let loaded = try decryptionMaterial() else {
+                return .fallback
+            }
+            material = loaded
+        } catch {
+            return .fallback
+        }
+
+        let decryptOperation = decryptor ?? { envelope, material in
+            try decrypt(envelope: envelope, material: material)
+        }
+
+        return await withTaskGroup(of: AutomationNotificationContent?.self) { group in
+            group.addTask {
+                try? await decryptOperation(envelope, material)
+            }
+            group.addTask {
+                if timeoutNanoseconds > 0 {
+                    try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                }
+                return nil
+            }
+
+            let resolved = await group.next() ?? nil
+            group.cancelAll()
+            return resolved ?? .fallback
+        }
+    }
+
+    private static func deriveNotificationSymmetricKey(
+        sharedSecret: SharedSecret,
+        requestID: String,
+        deviceID: String
+    ) -> SymmetricKey {
+        let secretData = sharedSecret.withUnsafeBytes { Data($0) }
+        var digestInput = Data()
+        digestInput.append(secretData)
+        digestInput.append(Data("|".utf8))
+        digestInput.append(Data(requestID.utf8))
+        digestInput.append(Data("|".utf8))
+        digestInput.append(Data(deviceID.utf8))
+        digestInput.append(Data("|notification".utf8))
+        let digest = SHA256.hash(data: digestInput)
+        return SymmetricKey(data: Data(digest))
+    }
+
+    private static func decodePrivateKeyData(base64Encoded: String) throws -> Data {
+        guard let privateKeyData = Data(base64Encoded: base64Encoded), privateKeyData.count == 32 else {
+            throw AutomationNotificationCryptoError.invalidKeyMaterial
+        }
+        return privateKeyData
+    }
+
+    private static func normalizeUserInfo(_ userInfo: [AnyHashable: Any]) -> [String: Any] {
+        userInfo.reduce(into: [String: Any]()) { partialResult, entry in
+            if let key = entry.key as? String {
+                partialResult[key] = entry.value
+            }
+        }
+    }
+
+    private static func loadOrCreateStoredKeyMaterial() throws -> StoredKeyMaterial {
+        do {
+            if let stored = try loadStoredKeyMaterial() {
+                _ = try decodePrivateKeyData(base64Encoded: stored.privateKeyBase64)
+                return stored
+            }
+        } catch AutomationNotificationCryptoError.invalidKeyMaterial {
+            // Regenerate key material if a stale/corrupt payload was found.
+        } catch {
+            throw error
+        }
+
+        let generated = StoredKeyMaterial(
+            deviceID: UUID().uuidString.lowercased(),
+            privateKeyBase64: Curve25519.KeyAgreement.PrivateKey().rawRepresentation.base64EncodedString()
+        )
+        try store(storedKeyMaterial: generated)
+        return generated
+    }
+
+    private static func loadStoredKeyMaterial() throws -> StoredKeyMaterial? {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess else {
+            throw AutomationNotificationCryptoError.keychain(status)
+        }
+        guard let data = item as? Data else {
+            throw AutomationNotificationCryptoError.invalidKeyMaterial
+        }
+
+        do {
+            return try JSONDecoder().decode(StoredKeyMaterial.self, from: data)
+        } catch {
+            // Reset corrupt key material to avoid repeated decrypt failures.
+            _ = SecItemDelete(query as CFDictionary)
+            throw AutomationNotificationCryptoError.invalidKeyMaterial
+        }
+    }
+
+    private static func store(storedKeyMaterial: StoredKeyMaterial) throws {
+        let encoded = try JSONEncoder().encode(storedKeyMaterial)
+
+        let attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecValueData as String: encoded,
+        ]
+
+        let addStatus = SecItemAdd(attributes as CFDictionary, nil)
+        if addStatus == errSecSuccess {
+            return
+        }
+        guard addStatus == errSecDuplicateItem else {
+            throw AutomationNotificationCryptoError.keychain(addStatus)
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+        ]
+        let update: [String: Any] = [
+            kSecValueData as String: encoded,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+        guard updateStatus == errSecSuccess else {
+            throw AutomationNotificationCryptoError.keychain(updateStatus)
+        }
+    }
+}

--- a/alfred/alfred.xcodeproj/project.pbxproj
+++ b/alfred/alfred.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		22F13A7C287F078A1F788EC1 /* AlfredAPIClient in Frameworks */ = {isa = PBXBuildFile; productRef = C3AABD002F40C03E00D8F6E7 /* AlfredAPIClient */; };
+		2A08A9A2C7CE792DD0987E00 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95611B0BAFCF4BCF38FA3DCB /* NotificationService.swift */; };
+		93EE5AE298FFD846C8E82DA3 /* alfredNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = DB36E1109E2802BBA5719436 /* alfredNotificationServiceExtension.appex */; };
 		C36BA2CA2F48CE9F00B2F152 /* IQKeyboardManagerSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C36BA2C92F48CE9F00B2F152 /* IQKeyboardManagerSwift */; };
 		C3AABD012F40C03E00D8F6E7 /* AlfredAPIClient in Frameworks */ = {isa = PBXBuildFile; productRef = C3AABD002F40C03E00D8F6E7 /* AlfredAPIClient */; };
 		C3AABD2A2F4133F400D8F6E7 /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = C3AABD292F4133F400D8F6E7 /* ClerkKit */; };
@@ -15,6 +18,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		ABB44118195993B0BA2EAC1B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C3E6B8B62F3FFFBC00C03FF0 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 132420810B8D3F6598D96D28;
+			remoteInfo = alfredNotificationServiceExtension;
+		};
 		C3E6B8CC2F3FFFBD00C03FF0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C3E6B8B62F3FFFBC00C03FF0 /* Project object */;
@@ -24,25 +34,55 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		0D74320FB23F2565A5283D90 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				93EE5AE298FFD846C8E82DA3 /* alfredNotificationServiceExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		38DF45289929E341ADF164EE /* alfredNotificationServiceExtension.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = alfredNotificationServiceExtension.entitlements; sourceTree = "<group>"; };
+		95611B0BAFCF4BCF38FA3DCB /* NotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		95A3C373062B820B4D65D336 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C3E6B8BE2F3FFFBC00C03FF0 /* alfred.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = alfred.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3E6B8CB2F3FFFBD00C03FF0 /* alfredTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = alfredTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DB36E1109E2802BBA5719436 /* alfredNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = alfredNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		C3E6B8C02F3FFFBC00C03FF0 /* alfred */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = alfred;
 			sourceTree = "<group>";
 		};
 		C3E6B8CE2F3FFFBD00C03FF0 /* alfredTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = alfredTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		9ADC70DA28641F21B2E65ABA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				22F13A7C287F078A1F788EC1 /* AlfredAPIClient in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C3E6B8BB2F3FFFBC00C03FF0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -65,12 +105,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A1793636008158BD53CE64CC /* alfredNotificationServiceExtension */ = {
+			isa = PBXGroup;
+			children = (
+				95611B0BAFCF4BCF38FA3DCB /* NotificationService.swift */,
+				95A3C373062B820B4D65D336 /* Info.plist */,
+				38DF45289929E341ADF164EE /* alfredNotificationServiceExtension.entitlements */,
+			);
+			name = alfredNotificationServiceExtension;
+			path = alfredNotificationServiceExtension;
+			sourceTree = "<group>";
+		};
 		C3E6B8B52F3FFFBC00C03FF0 = {
 			isa = PBXGroup;
 			children = (
 				C3E6B8C02F3FFFBC00C03FF0 /* alfred */,
 				C3E6B8CE2F3FFFBD00C03FF0 /* alfredTests */,
 				C3E6B8BF2F3FFFBC00C03FF0 /* Products */,
+				A1793636008158BD53CE64CC /* alfredNotificationServiceExtension */,
 			);
 			sourceTree = "<group>";
 		};
@@ -79,6 +131,7 @@
 			children = (
 				C3E6B8BE2F3FFFBC00C03FF0 /* alfred.app */,
 				C3E6B8CB2F3FFFBD00C03FF0 /* alfredTests.xctest */,
+				DB36E1109E2802BBA5719436 /* alfredNotificationServiceExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -86,6 +139,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		132420810B8D3F6598D96D28 /* alfredNotificationServiceExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D06A7674F19D68F05CBF540A /* Build configuration list for PBXNativeTarget "alfredNotificationServiceExtension" */;
+			buildPhases = (
+				7731571C098178A4F9224209 /* Sources */,
+				9ADC70DA28641F21B2E65ABA /* Frameworks */,
+				31A84F3236347334014F31B0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = alfredNotificationServiceExtension;
+			packageProductDependencies = (
+				C3AABD002F40C03E00D8F6E7 /* AlfredAPIClient */,
+			);
+			productName = alfredNotificationServiceExtension;
+			productReference = DB36E1109E2802BBA5719436 /* alfredNotificationServiceExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		C3E6B8BD2F3FFFBC00C03FF0 /* alfred */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C3E6B8DF2F3FFFBD00C03FF0 /* Build configuration list for PBXNativeTarget "alfred" */;
@@ -93,10 +166,12 @@
 				C3E6B8BA2F3FFFBC00C03FF0 /* Sources */,
 				C3E6B8BB2F3FFFBC00C03FF0 /* Frameworks */,
 				C3E6B8BC2F3FFFBC00C03FF0 /* Resources */,
+				0D74320FB23F2565A5283D90 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				916B11DA4EAD67D540270A64 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				C3E6B8C02F3FFFBC00C03FF0 /* alfred */,
@@ -130,8 +205,6 @@
 				C3E6B8CE2F3FFFBD00C03FF0 /* alfredTests */,
 			);
 			name = alfredTests;
-			packageProductDependencies = (
-			);
 			productName = alfredTests;
 			productReference = C3E6B8CB2F3FFFBD00C03FF0 /* alfredTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -165,7 +238,7 @@
 			mainGroup = C3E6B8B52F3FFFBC00C03FF0;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				C3AABCFF2F40C03E00D8F6E7 /* XCLocalSwiftPackageReference "Packages/AlfredAPIClient" */,
+				C3AABCFF2F40C03E00D8F6E7 /* XCLocalSwiftPackageReference "AlfredAPIClient" */,
 				C3AABD282F4133F400D8F6E7 /* XCRemoteSwiftPackageReference "clerk-ios" */,
 				D10100012F50000000D8F6E7 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */,
 				C36BA2C82F48CE9F00B2F152 /* XCRemoteSwiftPackageReference "IQKeyboardManager" */,
@@ -177,11 +250,19 @@
 			targets = (
 				C3E6B8BD2F3FFFBC00C03FF0 /* alfred */,
 				C3E6B8CA2F3FFFBD00C03FF0 /* alfredTests */,
+				132420810B8D3F6598D96D28 /* alfredNotificationServiceExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		31A84F3236347334014F31B0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C3E6B8BC2F3FFFBC00C03FF0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -199,6 +280,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		7731571C098178A4F9224209 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2A08A9A2C7CE792DD0987E00 /* NotificationService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C3E6B8BA2F3FFFBC00C03FF0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -216,6 +305,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		916B11DA4EAD67D540270A64 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = alfredNotificationServiceExtension;
+			target = 132420810B8D3F6598D96D28 /* alfredNotificationServiceExtension */;
+			targetProxy = ABB44118195993B0BA2EAC1B /* PBXContainerItemProxy */;
+		};
 		C3E6B8CD2F3FFFBD00C03FF0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = C3E6B8BD2F3FFFBC00C03FF0 /* alfred */;
@@ -224,6 +319,69 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		100DCEF2CC634CF770B1B6D7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = alfredNotificationServiceExtension/alfredNotificationServiceExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GNQ3HY2357;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = alfredNotificationServiceExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.prodata.alfred.NotificationServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2AA23022B43C87CEB2E555A5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = alfredNotificationServiceExtension/alfredNotificationServiceExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GNQ3HY2357;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = alfredNotificationServiceExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.prodata.alfred.NotificationServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		C3E6B8DD2F3FFFBD00C03FF0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -492,10 +650,19 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		D06A7674F19D68F05CBF540A /* Build configuration list for PBXNativeTarget "alfredNotificationServiceExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2AA23022B43C87CEB2E555A5 /* Release */,
+				100DCEF2CC634CF770B1B6D7 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		C3AABCFF2F40C03E00D8F6E7 /* XCLocalSwiftPackageReference "Packages/AlfredAPIClient" */ = {
+		C3AABCFF2F40C03E00D8F6E7 /* XCLocalSwiftPackageReference "AlfredAPIClient" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/AlfredAPIClient;
 		};

--- a/alfred/alfred/alfred.entitlements
+++ b/alfred/alfred/alfred.entitlements
@@ -10,5 +10,9 @@
 	<array>
 		<string>webcredentials:obliging-mammoth-40.clerk.accounts.dev</string>
 	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.prodata.alfred.shared</string>
+	</array>
 </dict>
 </plist>

--- a/alfred/alfred/alfredApp.swift
+++ b/alfred/alfred/alfredApp.swift
@@ -5,6 +5,7 @@
 //  Created by Nitesh Chowdhary Balusu on 2/13/26.
 //
 
+import AlfredAPIClient
 import ClerkKit
 import ClerkKitUI
 import IQKeyboardManagerSwift
@@ -24,6 +25,11 @@ struct alfredApp: App {
         IQKeyboardManager.shared.keyboardDistance = 12
         IQKeyboardManager.shared.resignOnTouchOutside = true
         IQKeyboardToolbarManager.shared.isEnabled = false
+        do {
+            _ = try AutomationNotificationCrypto.registrationMaterial()
+        } catch {
+            AppLogger.warning("Notification key material bootstrap failed.")
+        }
         self.clerk = configuredClerk
         _model = StateObject(wrappedValue: AppModel(clerk: configuredClerk))
     }

--- a/alfred/alfredNotificationServiceExtension/Info.plist
+++ b/alfred/alfredNotificationServiceExtension/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>Alfred Notification Service</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.usernotifications.service</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+    </dict>
+</dict>
+</plist>

--- a/alfred/alfredNotificationServiceExtension/NotificationService.swift
+++ b/alfred/alfredNotificationServiceExtension/NotificationService.swift
@@ -1,0 +1,56 @@
+import AlfredAPIClient
+import UserNotifications
+
+final class NotificationService: UNNotificationServiceExtension {
+    private var contentHandler: ((UNNotificationContent) -> Void)?
+    private var bestAttemptContent: UNMutableNotificationContent?
+    private var processingTask: Task<Void, Never>?
+    private let stateLock = NSLock()
+    private var didDeliver = false
+
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        self.contentHandler = contentHandler
+        let content = (request.content.mutableCopy() as? UNMutableNotificationContent)
+            ?? UNMutableNotificationContent()
+        bestAttemptContent = content
+
+        processingTask = Task { [weak self] in
+            guard let self else { return }
+            let resolved = await AutomationNotificationCrypto.resolveVisibleContent(from: request.content.userInfo)
+            content.title = resolved.title
+            content.body = resolved.body
+            self.deliver(content)
+        }
+    }
+
+    override func serviceExtensionTimeWillExpire() {
+        processingTask?.cancel()
+        processingTask = nil
+
+        if let content = bestAttemptContent {
+            content.title = AutomationNotificationContent.fallback.title
+            content.body = AutomationNotificationContent.fallback.body
+            deliver(content)
+        } else {
+            let fallback = UNMutableNotificationContent()
+            fallback.title = AutomationNotificationContent.fallback.title
+            fallback.body = AutomationNotificationContent.fallback.body
+            deliver(fallback)
+        }
+    }
+
+    private func deliver(_ content: UNNotificationContent) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard !didDeliver else {
+            return
+        }
+        didDeliver = true
+        contentHandler?(content)
+        contentHandler = nil
+    }
+}

--- a/alfred/alfredNotificationServiceExtension/alfredNotificationServiceExtension.entitlements
+++ b/alfred/alfredNotificationServiceExtension/alfredNotificationServiceExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.prodata.alfred.shared</string>
+    </array>
+</dict>
+</plist>

--- a/alfred/alfredTests/AutomationNotificationCryptoTests.swift
+++ b/alfred/alfredTests/AutomationNotificationCryptoTests.swift
@@ -1,0 +1,157 @@
+import AlfredAPIClient
+import CryptoKit
+import XCTest
+
+final class AutomationNotificationCryptoTests: XCTestCase {
+    func testRegistrationMaterialAndDecryptionMaterialRemainAligned() throws {
+        let registration = try AutomationNotificationCrypto.registrationMaterial()
+        let decryption = try XCTUnwrap(AutomationNotificationCrypto.decryptionMaterial())
+
+        XCTAssertEqual(registration.deviceID, decryption.deviceID)
+        XCTAssertEqual(
+            registration.algorithm,
+            AutomationNotificationCrypto.algorithmX25519ChaCha20Poly1305
+        )
+        XCTAssertFalse(registration.publicKey.isEmpty)
+    }
+
+    func testResolveVisibleContentDecryptsValidPayload() async throws {
+        let registration = try AutomationNotificationCrypto.registrationMaterial()
+        let plaintext = AutomationNotificationContent(title: "Build status", body: "Everything is healthy.")
+        let envelope = try makeEnvelope(
+            plaintext: plaintext,
+            deviceID: registration.deviceID,
+            recipientPublicKeyBase64: registration.publicKey
+        )
+
+        let userInfo: [AnyHashable: Any] = [
+            "alfred_automation": [
+                "version": AutomationNotificationCrypto.versionV1,
+                "envelope": [
+                    "version": envelope.version,
+                    "algorithm": envelope.algorithm,
+                    "key_id": envelope.keyID,
+                    "request_id": envelope.requestID,
+                    "sender_public_key": envelope.senderPublicKey,
+                    "nonce": envelope.nonce,
+                    "ciphertext": envelope.ciphertext,
+                ],
+            ],
+        ]
+
+        let resolved = await AutomationNotificationCrypto.resolveVisibleContent(from: userInfo)
+        XCTAssertEqual(resolved, plaintext)
+    }
+
+    func testResolveVisibleContentFallsBackOnInvalidPayload() async {
+        let userInfo: [AnyHashable: Any] = ["unexpected": "value"]
+        let resolved = await AutomationNotificationCrypto.resolveVisibleContent(from: userInfo)
+
+        XCTAssertEqual(resolved, .fallback)
+    }
+
+    func testResolveVisibleContentFallsBackOnTimeout() async throws {
+        let _ = try AutomationNotificationCrypto.registrationMaterial()
+        let userInfo: [AnyHashable: Any] = [
+            "alfred_automation": [
+                "version": AutomationNotificationCrypto.versionV1,
+                "envelope": [
+                    "version": AutomationNotificationCrypto.versionV1,
+                    "algorithm": AutomationNotificationCrypto.algorithmX25519ChaCha20Poly1305,
+                    "key_id": "sender-key",
+                    "request_id": "req-timeout",
+                    "sender_public_key": Data(repeating: 7, count: 32).base64EncodedString(),
+                    "nonce": Data(repeating: 9, count: 12).base64EncodedString(),
+                    "ciphertext": Data(repeating: 5, count: 32).base64EncodedString(),
+                ],
+            ],
+        ]
+
+        let resolved = await AutomationNotificationCrypto.resolveVisibleContent(
+            from: userInfo,
+            timeoutNanoseconds: 10_000_000,
+            decryptor: { _, _ in
+                try await Task.sleep(nanoseconds: 300_000_000)
+                return AutomationNotificationContent(title: "Late", body: "Result")
+            }
+        )
+
+        XCTAssertEqual(resolved, .fallback)
+    }
+
+    private func makeEnvelope(
+        plaintext: AutomationNotificationContent,
+        deviceID: String,
+        recipientPublicKeyBase64: String
+    ) throws -> AutomationEncryptedNotificationEnvelope {
+        let senderPrivateKey = Curve25519.KeyAgreement.PrivateKey()
+        let requestID = UUID().uuidString.lowercased()
+
+        guard let recipientPublicKeyData = Data(base64Encoded: recipientPublicKeyBase64), recipientPublicKeyData.count == 32 else {
+            XCTFail("recipient public key must decode to 32 bytes")
+            throw TestError.invalidFixture
+        }
+        let recipientPublicKey = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: recipientPublicKeyData)
+
+        let sharedSecret = try senderPrivateKey.sharedSecretFromKeyAgreement(with: recipientPublicKey)
+        let symmetricKey = deriveSymmetricKey(
+            sharedSecret: sharedSecret,
+            requestID: requestID,
+            deviceID: deviceID
+        )
+
+        let nonceData = randomNonceData()
+        let nonce = try ChaChaPoly.Nonce(data: nonceData)
+        let aad = Data("\(requestID)|\(deviceID)".utf8)
+        let plaintextData = try JSONEncoder().encode(plaintext)
+        let sealedBox = try ChaChaPoly.seal(
+            plaintextData,
+            using: symmetricKey,
+            nonce: nonce,
+            authenticating: aad
+        )
+
+        var ciphertextWithTag = Data()
+        ciphertextWithTag.append(sealedBox.ciphertext)
+        ciphertextWithTag.append(sealedBox.tag)
+
+        return AutomationEncryptedNotificationEnvelope(
+            version: AutomationNotificationCrypto.versionV1,
+            algorithm: AutomationNotificationCrypto.algorithmX25519ChaCha20Poly1305,
+            keyID: "sender-key",
+            requestID: requestID,
+            senderPublicKey: senderPrivateKey.publicKey.rawRepresentation.base64EncodedString(),
+            nonce: nonceData.base64EncodedString(),
+            ciphertext: ciphertextWithTag.base64EncodedString()
+        )
+    }
+
+    private func deriveSymmetricKey(
+        sharedSecret: SharedSecret,
+        requestID: String,
+        deviceID: String
+    ) -> SymmetricKey {
+        let secretData = sharedSecret.withUnsafeBytes { Data($0) }
+        var digestInput = Data()
+        digestInput.append(secretData)
+        digestInput.append(Data("|".utf8))
+        digestInput.append(Data(requestID.utf8))
+        digestInput.append(Data("|".utf8))
+        digestInput.append(Data(deviceID.utf8))
+        digestInput.append(Data("|notification".utf8))
+        let digest = SHA256.hash(data: digestInput)
+        return SymmetricKey(data: Data(digest))
+    }
+
+    private func randomNonceData() -> Data {
+        var bytes = [UInt8](repeating: 0, count: 12)
+        for index in bytes.indices {
+            bytes[index] = UInt8.random(in: 0...255)
+        }
+        return Data(bytes)
+    }
+
+    private enum TestError: Error {
+        case invalidFixture
+    }
+}


### PR DESCRIPTION
## Summary
Implements issue #214 by adding an iOS Notification Service Extension that decrypts encrypted automation notification payloads on-device and rewrites visible content locally.

Closes #214.

## What changed
1. Added `alfredNotificationServiceExtension` target and app embed wiring.
2. Added shared crypto/key material module:
   - `AutomationNotificationCrypto`
   - payload contract parsing (`alfred_automation` envelope)
   - X25519 + ChaCha20-Poly1305 decrypt path
   - bounded timeout + safe fallback content path
3. Added app bootstrap to ensure key registration material exists at startup.
4. Added keychain shared-group entitlements for app + extension.
5. Added unit tests for:
   - decrypt success
   - invalid payload fallback
   - timeout fallback
   - registration/decryption key material alignment

## Validation
- `just check-tools`
- `just ios-build`
- `just ios-test`

## AI review summary
### 1) Security audit
- Findings: no plaintext automation content logging introduced; fallback text is generic; invalid/corrupt key material now regenerates safely.
- Risk level: Low.
- Required fixes: removed brittle explicit `Foundation.framework` SDK-path reference from project file.

### 2) Bug check
- Findings: no functional regressions found in changed code paths; timeout/fallback and duplicate-delivery protection behave as intended.
- Repro/test evidence: new `AutomationNotificationCryptoTests` plus full `just ios-test` pass.
- Required fixes: added key-material validation in load-or-create path to avoid persistent failure state with corrupted stored key payload.

### 3) Scalability/code quality review
- Findings: new logic is isolated in dedicated module + extension target; no monolithic file growth beyond policy thresholds.
- Performance/scalability concerns: decrypt path is bounded by timeout and NSE lifecycle.
- Refactor recommendations: none required for this scope.

### 4) Final status
- Merge recommendation: `APPROVE`