### PR TITLE
[Automation v2][iOS/UI] Replace Activity tab with Automations tab

### DIFF
--- a/alfred/Packages/AlfredAPIClient/Sources/Models.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/Models.swift
@@ -135,6 +135,104 @@ public struct ListConnectorsResponse: Codable, Sendable {
     public let items: [ConnectorSummary]
 }
 
+public struct CreateAutomationRequest: Codable, Sendable {
+    public let intervalSeconds: Int
+    public let timeZone: String
+    public let promptEnvelope: AssistantEncryptedRequestEnvelope
+
+    enum CodingKeys: String, CodingKey {
+        case intervalSeconds = "interval_seconds"
+        case timeZone = "time_zone"
+        case promptEnvelope = "prompt_envelope"
+    }
+
+    public init(
+        intervalSeconds: Int,
+        timeZone: String,
+        promptEnvelope: AssistantEncryptedRequestEnvelope
+    ) {
+        self.intervalSeconds = intervalSeconds
+        self.timeZone = timeZone
+        self.promptEnvelope = promptEnvelope
+    }
+}
+
+public struct AutomationScheduleUpdate: Codable, Sendable {
+    public let intervalSeconds: Int
+    public let timeZone: String
+
+    enum CodingKeys: String, CodingKey {
+        case intervalSeconds = "interval_seconds"
+        case timeZone = "time_zone"
+    }
+
+    public init(intervalSeconds: Int, timeZone: String) {
+        self.intervalSeconds = intervalSeconds
+        self.timeZone = timeZone
+    }
+}
+
+public enum AutomationStatus: String, Codable, Sendable {
+    case active = "ACTIVE"
+    case paused = "PAUSED"
+}
+
+public struct UpdateAutomationRequest: Codable, Sendable {
+    public let schedule: AutomationScheduleUpdate?
+    public let promptEnvelope: AssistantEncryptedRequestEnvelope?
+    public let status: AutomationStatus?
+
+    enum CodingKeys: String, CodingKey {
+        case schedule
+        case promptEnvelope = "prompt_envelope"
+        case status
+    }
+
+    public init(
+        schedule: AutomationScheduleUpdate? = nil,
+        promptEnvelope: AssistantEncryptedRequestEnvelope? = nil,
+        status: AutomationStatus? = nil
+    ) {
+        self.schedule = schedule
+        self.promptEnvelope = promptEnvelope
+        self.status = status
+    }
+}
+
+public enum AutomationScheduleType: String, Codable, Sendable {
+    case intervalSeconds = "INTERVAL_SECONDS"
+}
+
+public struct AutomationRuleSummary: Codable, Sendable {
+    public let ruleId: UUID
+    public let status: AutomationStatus
+    public let scheduleType: AutomationScheduleType
+    public let intervalSeconds: Int
+    public let timeZone: String
+    public let nextRunAt: Date
+    public let lastRunAt: Date?
+    public let promptSha256: String
+    public let createdAt: Date
+    public let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case ruleId = "rule_id"
+        case status
+        case scheduleType = "schedule_type"
+        case intervalSeconds = "interval_seconds"
+        case timeZone = "time_zone"
+        case nextRunAt = "next_run_at"
+        case lastRunAt = "last_run_at"
+        case promptSha256 = "prompt_sha256"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+}
+
+public struct ListAutomationsResponse: Codable, Sendable {
+    public let items: [AutomationRuleSummary]
+}
+
 public struct Preferences: Codable, Sendable {
     public let meetingReminderMinutes: Int
     public let morningBriefLocalTime: String

--- a/alfred/alfred/AppTab.swift
+++ b/alfred/alfred/AppTab.swift
@@ -3,7 +3,7 @@ import Foundation
 enum AppTab: Hashable, CaseIterable {
     case home
     case threads
-    case activity
+    case automations
     case connectors
 
     var title: String {
@@ -12,8 +12,8 @@ enum AppTab: Hashable, CaseIterable {
             return "Home"
         case .threads:
             return "Threads"
-        case .activity:
-            return "Activity"
+        case .automations:
+            return "Automations"
         case .connectors:
             return "Connectors"
         }
@@ -25,8 +25,8 @@ enum AppTab: Hashable, CaseIterable {
             return "house"
         case .threads:
             return "text.bubble"
-        case .activity:
-            return "clock.arrow.circlepath"
+        case .automations:
+            return "calendar.badge.clock"
         case .connectors:
             return "link"
         }

--- a/alfred/alfred/Views/AppTabShellView.swift
+++ b/alfred/alfred/Views/AppTabShellView.swift
@@ -6,8 +6,8 @@ struct AppTabShellView: View {
     @Environment(Clerk.self) private var clerk
     @ObservedObject var model: AppModel
     @State private var tabPaths: [AppTab: NavigationPath] = AppTabShellView.defaultPaths()
-    private let swipeTabs: [AppTab] = [.threads, .home, .activity, .connectors]
-    private let visibleTopTabs: [AppTab] = [.home, .activity, .connectors]
+    private let swipeTabs: [AppTab] = [.threads, .home, .automations, .connectors]
+    private let visibleTopTabs: [AppTab] = [.home, .automations, .connectors]
     private let threadsHomeButtonSize: CGFloat = 47
 
     var body: some View {
@@ -173,8 +173,8 @@ struct AppTabShellView: View {
             HomeView(model: model)
         case .threads:
             AssistantThreadsView(model: model, reservesTrailingOverlaySpace: true)
-        case .activity:
-            ActivityView(model: model)
+        case .automations:
+            AutomationsView(model: model)
         case .connectors:
             ConnectorsView(model: model)
         }

--- a/alfred/alfred/Views/AutomationViewComponents.swift
+++ b/alfred/alfred/Views/AutomationViewComponents.swift
@@ -1,0 +1,334 @@
+import AlfredAPIClient
+import SwiftUI
+
+struct AutomationRuleCard: View {
+    let title: String
+    let rule: AutomationRuleSummary
+    let isMutating: Bool
+    let onTogglePause: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        AppCard {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(title)
+                            .font(.headline)
+                            .foregroundStyle(AppTheme.Colors.textPrimary)
+
+                        Text(intervalSummary)
+                            .font(.subheadline)
+                            .foregroundStyle(AppTheme.Colors.textSecondary)
+                    }
+
+                    Spacer(minLength: 8)
+
+                    AppStatusBadge(title: statusTitle, style: statusStyle)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    AutomationMetadataRow(label: "Time zone", value: rule.timeZone)
+                    AutomationMetadataRow(label: "Next run", value: format(date: rule.nextRunAt))
+                    AutomationMetadataRow(label: "Last run", value: format(date: rule.lastRunAt))
+                }
+
+                HStack(spacing: 8) {
+                    Button(rule.status == .active ? "Pause" : "Resume", action: onTogglePause)
+                        .buttonStyle(.appSecondary)
+                        .disabled(isMutating)
+
+                    Button("Delete", role: .destructive, action: onDelete)
+                        .buttonStyle(.appSecondary)
+                        .disabled(isMutating)
+                }
+
+                if isMutating {
+                    ProgressView()
+                        .tint(AppTheme.Colors.accent)
+                }
+            }
+        }
+    }
+
+    private var intervalSummary: String {
+        "Runs \(AutomationIntervalFormatter.label(for: rule.intervalSeconds))"
+    }
+
+    private var statusTitle: String {
+        switch rule.status {
+        case .active:
+            return "Active"
+        case .paused:
+            return "Paused"
+        }
+    }
+
+    private var statusStyle: AppStatusBadge.Style {
+        switch rule.status {
+        case .active:
+            return .success
+        case .paused:
+            return .neutral
+        }
+    }
+
+    private func format(date: Date?) -> String {
+        guard let date else {
+            return "Never"
+        }
+        return date.formatted(date: .abbreviated, time: .shortened)
+    }
+}
+
+private struct AutomationMetadataRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+                .frame(width: 72, alignment: .leading)
+
+            Text(value)
+                .font(.caption)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+        }
+    }
+}
+
+struct AutomationCreatePayload {
+    let title: String
+    let intervalSeconds: Int
+    let timeZone: String
+    let prompt: String
+}
+
+struct AutomationCreateSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let defaultTimeZone: String
+    let onSubmit: @Sendable (AutomationCreatePayload) async throws -> Void
+
+    @State private var title = ""
+    @State private var intervalMinutes = 60
+    @State private var timeZone = ""
+    @State private var prompt = ""
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+
+    private let quickIntervals: [Int] = [15, 60, 240, 1_440]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Automation") {
+                    TextField("Name (optional)", text: $title)
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Interval")
+                            .font(.subheadline.weight(.semibold))
+
+                        HStack(spacing: 8) {
+                            ForEach(quickIntervals, id: \.self) { minutes in
+                                Button(quickLabel(minutes: minutes)) {
+                                    intervalMinutes = minutes
+                                }
+                                .buttonStyle(.appSecondary)
+                            }
+                        }
+
+                        Stepper(value: $intervalMinutes, in: 1...10_080) {
+                            Text(AutomationIntervalFormatter.label(for: intervalMinutes * 60))
+                        }
+                    }
+
+                    TextField("Time zone", text: $timeZone)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+
+                Section("Prompt") {
+                    TextEditor(text: $prompt)
+                        .frame(minHeight: 180)
+
+                    Text("Prompt and output remain encrypted outside the enclave path.")
+                        .font(.footnote)
+                        .foregroundStyle(AppTheme.Colors.textSecondary)
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundStyle(AppTheme.Colors.danger)
+                    }
+                }
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .navigationTitle("New Automation")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .disabled(isSubmitting)
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(isSubmitting ? "Creating…" : "Create") {
+                        Task {
+                            await submit()
+                        }
+                    }
+                    .disabled(isSubmitting)
+                }
+            }
+            .onAppear {
+                if timeZone.isEmpty {
+                    timeZone = defaultTimeZone
+                }
+            }
+        }
+    }
+
+    private func submit() async {
+        let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPrompt.isEmpty else {
+            errorMessage = "Prompt is required."
+            return
+        }
+
+        let trimmedTimeZone = timeZone.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTimeZone.isEmpty else {
+            errorMessage = "Time zone is required."
+            return
+        }
+        guard TimeZone(identifier: trimmedTimeZone) != nil else {
+            errorMessage = "Time zone must be a valid IANA identifier."
+            return
+        }
+
+        isSubmitting = true
+        defer { isSubmitting = false }
+
+        do {
+            try await onSubmit(
+                AutomationCreatePayload(
+                    title: title.trimmingCharacters(in: .whitespacesAndNewlines),
+                    intervalSeconds: intervalMinutes * 60,
+                    timeZone: trimmedTimeZone,
+                    prompt: trimmedPrompt
+                )
+            )
+            dismiss()
+        } catch {
+            errorMessage = AppModel.errorMessage(from: error)
+        }
+    }
+
+    private func quickLabel(minutes: Int) -> String {
+        AutomationIntervalFormatter.label(for: minutes * 60)
+    }
+}
+
+enum AutomationIntervalFormatter {
+    static func label(for intervalSeconds: Int) -> String {
+        if intervalSeconds % 86_400 == 0 {
+            return "every \(intervalSeconds / 86_400)d"
+        }
+        if intervalSeconds % 3_600 == 0 {
+            return "every \(intervalSeconds / 3_600)h"
+        }
+        if intervalSeconds % 60 == 0 {
+            return "every \(intervalSeconds / 60)m"
+        }
+        return "every \(intervalSeconds)s"
+    }
+}
+
+struct AutomationInlineButton: View {
+    let title: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(title, action: action)
+            .font(.caption.weight(.semibold))
+            .buttonStyle(.plain)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(AppTheme.Colors.surfaceElevated)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(AppTheme.Colors.outline, lineWidth: 1)
+            )
+            .foregroundStyle(AppTheme.Colors.textPrimary)
+    }
+}
+
+struct AutomationCallout: View {
+    let title: String
+    let message: String
+    let buttonTitle: String
+    let action: () -> Void
+
+    var body: some View {
+        AppCard {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(AppTheme.Colors.textPrimary)
+
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+
+                Button(buttonTitle, action: action)
+                    .buttonStyle(.appSecondary)
+            }
+        }
+    }
+}
+
+struct AutomationLoadingStateCard: View {
+    var body: some View {
+        AppCard {
+            VStack(alignment: .leading, spacing: 12) {
+                ProgressView()
+                    .tint(AppTheme.Colors.accent)
+
+                Text("Loading automations…")
+                    .font(.subheadline)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+            }
+        }
+    }
+}
+
+struct AutomationEmptyStateCard: View {
+    let title: String
+    let message: String
+    let buttonTitle: String
+    let action: () -> Void
+
+    var body: some View {
+        AppCard {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(AppTheme.Colors.textPrimary)
+
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+
+                Button(buttonTitle, action: action)
+                    .buttonStyle(.appPrimary)
+            }
+        }
+    }
+}

--- a/alfred/alfred/Views/AutomationsView.swift
+++ b/alfred/alfred/Views/AutomationsView.swift
@@ -1,0 +1,223 @@
+import AlfredAPIClient
+import SwiftUI
+
+struct AutomationsView: View {
+    @ObservedObject var model: AppModel
+    @State private var rules: [AutomationRuleSummary] = []
+    @State private var localTitles: [UUID: String] = [:]
+    @State private var isLoading = false
+    @State private var loadErrorMessage: String?
+    @State private var mutationErrorMessage: String?
+    @State private var mutatingRuleIDs: Set<UUID> = []
+    @State private var activeSheet: SheetRoute?
+
+    private enum SheetRoute: String, Identifiable {
+        case create
+
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: AppTheme.Layout.sectionSpacing) {
+                headerCard
+
+                if let mutationErrorMessage {
+                    AutomationCallout(
+                        title: "Automation action failed",
+                        message: mutationErrorMessage,
+                        buttonTitle: "Dismiss"
+                    ) {
+                        self.mutationErrorMessage = nil
+                    }
+                }
+
+                if isLoading && rules.isEmpty {
+                    AutomationLoadingStateCard()
+                } else if rules.isEmpty {
+                    AutomationEmptyStateCard(
+                        title: emptyStateTitle,
+                        message: emptyStateMessage,
+                        buttonTitle: "Create automation"
+                    ) {
+                        activeSheet = .create
+                    }
+                } else {
+                    ForEach(rules, id: \.ruleId) { rule in
+                        AutomationRuleCard(
+                            title: title(for: rule),
+                            rule: rule,
+                            isMutating: mutatingRuleIDs.contains(rule.ruleId),
+                            onTogglePause: { togglePause(for: rule) },
+                            onDelete: { delete(rule: rule) }
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal, AppTheme.Layout.screenPadding)
+            .padding(.vertical, AppTheme.Layout.sectionSpacing)
+        }
+        .appScreenBackground()
+        .task {
+            if rules.isEmpty {
+                await loadAutomations()
+            }
+        }
+        .sheet(item: $activeSheet) { _ in
+            AutomationCreateSheet(
+                defaultTimeZone: TimeZone.current.identifier,
+                onSubmit: { payload in
+                    try await createAutomation(payload)
+                }
+            )
+        }
+    }
+
+    private var headerCard: some View {
+        AppCard {
+            AppSectionHeader("Automations", subtitle: "Scheduled prompts with private push delivery") {
+                HStack(spacing: 8) {
+                    AppStatusBadge(
+                        title: statusBadge.title,
+                        style: statusBadge.style
+                    )
+
+                    AutomationInlineButton(title: isLoading ? "Loading…" : "Refresh") {
+                        Task {
+                            await loadAutomations()
+                        }
+                    }
+                    .disabled(isLoading)
+
+                    AutomationInlineButton(title: "New") {
+                        activeSheet = .create
+                    }
+                }
+            }
+
+            if let loadErrorMessage, !rules.isEmpty {
+                AutomationCallout(
+                    title: "Could not refresh automations",
+                    message: loadErrorMessage,
+                    buttonTitle: "Retry"
+                ) {
+                    Task {
+                        await loadAutomations()
+                    }
+                }
+            }
+        }
+    }
+
+    private var statusBadge: (title: String, style: AppStatusBadge.Style) {
+        if isLoading {
+            return ("Loading", .warning)
+        }
+        if rules.isEmpty {
+            return ("Empty", .neutral)
+        }
+        if loadErrorMessage != nil {
+            return ("Stale", .warning)
+        }
+        return ("Updated", .success)
+    }
+
+    private var emptyStateTitle: String {
+        if loadErrorMessage != nil {
+            return "Unable to load automations"
+        }
+        return "No automations yet"
+    }
+
+    private var emptyStateMessage: String {
+        if let loadErrorMessage {
+            return loadErrorMessage
+        }
+        return "Create a periodic prompt and Alfred will run it for you automatically."
+    }
+
+    @MainActor
+    private func loadAutomations() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let response = try await model.apiClient.listAutomations(limit: 100)
+            rules = response.items.sorted(by: { $0.nextRunAt < $1.nextRunAt })
+            loadErrorMessage = nil
+        } catch {
+            loadErrorMessage = AppModel.errorMessage(from: error)
+        }
+    }
+
+    @MainActor
+    private func createAutomation(_ payload: AutomationCreatePayload) async throws {
+        let created = try await model.apiClient.createAutomationEncrypted(
+            intervalSeconds: payload.intervalSeconds,
+            timeZone: payload.timeZone,
+            prompt: payload.prompt,
+            attestationConfig: AppConfiguration.assistantAttestationVerificationConfig
+        )
+
+        if !payload.title.isEmpty {
+            localTitles[created.ruleId] = payload.title
+        }
+
+        upsert(created)
+        loadErrorMessage = nil
+    }
+
+    private func togglePause(for rule: AutomationRuleSummary) {
+        Task { @MainActor in
+            guard !mutatingRuleIDs.contains(rule.ruleId) else { return }
+            mutatingRuleIDs.insert(rule.ruleId)
+            defer { mutatingRuleIDs.remove(rule.ruleId) }
+
+            do {
+                let nextStatus: AutomationStatus = rule.status == .active ? .paused : .active
+                let updated = try await model.apiClient.updateAutomation(
+                    ruleID: rule.ruleId,
+                    request: UpdateAutomationRequest(status: nextStatus)
+                )
+                upsert(updated)
+                mutationErrorMessage = nil
+            } catch {
+                mutationErrorMessage = AppModel.errorMessage(from: error)
+            }
+        }
+    }
+
+    private func delete(rule: AutomationRuleSummary) {
+        Task { @MainActor in
+            guard !mutatingRuleIDs.contains(rule.ruleId) else { return }
+            mutatingRuleIDs.insert(rule.ruleId)
+            defer { mutatingRuleIDs.remove(rule.ruleId) }
+
+            do {
+                _ = try await model.apiClient.deleteAutomation(ruleID: rule.ruleId)
+                rules.removeAll(where: { $0.ruleId == rule.ruleId })
+                localTitles.removeValue(forKey: rule.ruleId)
+                mutationErrorMessage = nil
+            } catch {
+                mutationErrorMessage = AppModel.errorMessage(from: error)
+            }
+        }
+    }
+
+    private func upsert(_ updated: AutomationRuleSummary) {
+        if let index = rules.firstIndex(where: { $0.ruleId == updated.ruleId }) {
+            rules[index] = updated
+        } else {
+            rules.append(updated)
+        }
+        rules.sort { $0.nextRunAt < $1.nextRunAt }
+    }
+
+    private func title(for rule: AutomationRuleSummary) -> String {
+        if let local = localTitles[rule.ruleId], !local.isEmpty {
+            return local
+        }
+        return "Automation \(rule.ruleId.uuidString.prefix(8))"
+    }
+}

--- a/alfred/alfredTests/AutomationAPIModelCodableTests.swift
+++ b/alfred/alfredTests/AutomationAPIModelCodableTests.swift
@@ -1,0 +1,94 @@
+import AlfredAPIClient
+import Foundation
+import XCTest
+
+final class AutomationAPIModelCodableTests: XCTestCase {
+    func testCreateAutomationRequestEncodesSnakeCaseFields() throws {
+        let request = CreateAutomationRequest(
+            intervalSeconds: 900,
+            timeZone: "America/Los_Angeles",
+            promptEnvelope: try makePromptEnvelope()
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["interval_seconds"] as? Int, 900)
+        XCTAssertEqual(json["time_zone"] as? String, "America/Los_Angeles")
+
+        let envelope = try XCTUnwrap(json["prompt_envelope"] as? [String: Any])
+        XCTAssertEqual(envelope["key_id"] as? String, "key-1")
+        XCTAssertEqual(envelope["request_id"] as? String, "req-1")
+        XCTAssertEqual(envelope["client_ephemeral_public_key"] as? String, "pub-key")
+    }
+
+    func testUpdateAutomationRequestEncodesStatusAndSchedule() throws {
+        let request = UpdateAutomationRequest(
+            schedule: AutomationScheduleUpdate(
+                intervalSeconds: 3_600,
+                timeZone: "UTC"
+            ),
+            status: .paused
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(json["status"] as? String, "PAUSED")
+
+        let schedule = try XCTUnwrap(json["schedule"] as? [String: Any])
+        XCTAssertEqual(schedule["interval_seconds"] as? Int, 3_600)
+        XCTAssertEqual(schedule["time_zone"] as? String, "UTC")
+    }
+
+    func testListAutomationsResponseDecodesDatesAndEnums() throws {
+        let payload = """
+        {
+          "items": [
+            {
+              "rule_id": "f92ee2cb-1a34-4e40-aa4e-e8c2bd1522de",
+              "status": "ACTIVE",
+              "schedule_type": "INTERVAL_SECONDS",
+              "interval_seconds": 1800,
+              "time_zone": "UTC",
+              "next_run_at": "2026-02-21T12:00:00Z",
+              "last_run_at": null,
+              "prompt_sha256": "abc123",
+              "created_at": "2026-02-21T10:00:00Z",
+              "updated_at": "2026-02-21T11:00:00Z"
+            }
+          ]
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let response = try decoder.decode(ListAutomationsResponse.self, from: Data(payload.utf8))
+
+        XCTAssertEqual(response.items.count, 1)
+        XCTAssertEqual(response.items[0].status, .active)
+        XCTAssertEqual(response.items[0].scheduleType, .intervalSeconds)
+        XCTAssertEqual(response.items[0].intervalSeconds, 1_800)
+        XCTAssertEqual(response.items[0].timeZone, "UTC")
+        XCTAssertNil(response.items[0].lastRunAt)
+    }
+
+    private func makePromptEnvelope() throws -> AssistantEncryptedRequestEnvelope {
+        let payload = """
+        {
+          "version": "v1",
+          "algorithm": "x25519-chacha20poly1305",
+          "key_id": "key-1",
+          "request_id": "req-1",
+          "client_ephemeral_public_key": "pub-key",
+          "nonce": "nonce",
+          "ciphertext": "ciphertext"
+        }
+        """
+
+        return try JSONDecoder().decode(
+            AssistantEncryptedRequestEnvelope.self,
+            from: Data(payload.utf8)
+        )
+    }
+}

--- a/alfred/alfredTests/AutomationIntervalFormatterTests.swift
+++ b/alfred/alfredTests/AutomationIntervalFormatterTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import alfred
+
+struct AutomationIntervalFormatterTests {
+    @Test
+    func formatsMinutesIntervals() {
+        #expect(AutomationIntervalFormatter.label(for: 60) == "every 1m")
+        #expect(AutomationIntervalFormatter.label(for: 900) == "every 15m")
+    }
+
+    @Test
+    func formatsHoursAndDaysIntervals() {
+        #expect(AutomationIntervalFormatter.label(for: 3_600) == "every 1h")
+        #expect(AutomationIntervalFormatter.label(for: 86_400) == "every 1d")
+    }
+
+    @Test
+    func formatsRawSecondsWhenNotDivisibleByMinute() {
+        #expect(AutomationIntervalFormatter.label(for: 95) == "every 95s")
+    }
+}


### PR DESCRIPTION
## Summary
- replace the top-level Activity tab with a new Automations tab
- add automations list + create sheet + pause/resume/delete actions
- integrate iOS API client with `/v1/automations` CRUD and encrypted prompt envelope create path
- add tests for automation API codable models and interval formatter

## Validation
- `just check-tools`
- `just ios-build`
- `just ios-test`

## Deep review
### Security and privacy
- verified create flow uses `createAutomationEncrypted` with attested key verification and encrypted envelope payload
- no plaintext prompt content is sent through non-encrypted automation API path in UI flow

### Bugs and regressions
- no blocking regressions found in tab routing, automation CRUD flow wiring, or model encode/decode contracts
- removed an incidental Xcode project-file churn before commit
- replaced a `try!` in test helper with throwing decode for safer failure behavior

### Refactoring/scalability
- split UI into `AutomationsView.swift` and `AutomationViewComponents.swift` to keep files modular and under policy limits

Closes #219
