### PR TITLE
[P0-14] Reconcile Phase I board with delivered work and backlog

### DIFF
--- a/docs/phase1-master-todo.md
+++ b/docs/phase1-master-todo.md
@@ -2,6 +2,7 @@
 
 - Project: Alfred (iOS + Hosted Backend + TEE-sensitive processing)
 - Created: 2026-02-14
+- Updated: 2026-02-21 (issue `#41` reconciliation pass)
 - Scope: Phase I private beta readiness
 
 ## 1) Phase I Outcome
@@ -72,6 +73,19 @@ Ship a private beta where iOS users can:
 5. Breaking protocol/contract changes are explicitly acceptable pre-launch for this migration.
 6. `#149` hardening completed: OAuth code exchange moved to enclave path, job payload storage is encrypted-at-write, Redis reliability state is metadata-only, and privacy guard tests/docs were expanded.
 
+## Automation v2 Direction Update (2026-02-21)
+
+1. Proactive backend architecture is now automation-first via client-defined periodic prompt jobs (tracker `#208`).
+2. Completed delivery phases:
+   1. Schema/repositories (`#209`)
+   2. API CRUD (`#210`)
+   3. Generic worker scheduler/executor (`#211`)
+   4. Enclave automation execution + encrypted artifacts (`#212`)
+   5. Encrypted APNs payload contract (`#213`)
+   6. iOS Notification Service Extension decrypt/render (`#214`)
+   7. iOS Automations tab + scheduler UI (`#219`)
+3. Legacy hardcoded proactive flows are treated as replaced by the automation runtime line.
+
 ## 5) Execution Board
 
 ### A) Product and Scope Control
@@ -90,20 +104,20 @@ Ship a private beta where iOS users can:
 
 | ID | Pri | Task | Owner | ETA | Status | Depends On | Exit Criteria |
 |---|---|---|---|---|---|---|---|
-| BE-001 | P0 | Migrate backend auth to Clerk JWT verification and identity mapping | BE | 2026-02-26 | IN_PROGRESS | PROD-001 | Protected endpoints authorize Clerk tokens and map Clerk subject to stable user identity |
-| BE-002 | P0 | Add health/readiness endpoints | BE | 2026-02-20 | TODO | - | `/healthz` and `/readyz` live |
-| BE-003 | P0 | Add structured logging with request_id | BE | 2026-02-21 | TODO | BE-002 | Request logs include trace fields |
+| BE-001 | P0 | Migrate backend auth to Clerk JWT verification and identity mapping | BE | 2026-02-26 | DONE | PROD-001 | Protected endpoints authorize Clerk tokens and map Clerk subject to stable user identity |
+| BE-002 | P0 | Add health/readiness endpoints | BE | 2026-02-20 | DONE | - | `/healthz` and `/readyz` live |
+| BE-003 | P0 | Add structured logging with request_id | BE | 2026-02-21 | DONE | BE-002 | Request logs include trace fields |
 | BE-004 | P0 | Standardize API error envelope/codes | BE | 2026-02-22 | TODO | BE-001 | All endpoints use common error format |
 | BE-005 | P0 | Implement `/v1/connectors/google/start` real OAuth URL + state | BE | 2026-03-01 | DONE | BE-004 | Endpoint returns valid provider URL/state |
 | BE-006 | P0 | Implement `/v1/connectors/google/callback` token exchange | BE | 2026-03-03 | DONE | BE-005 | Real token exchange succeeds |
 | BE-007 | P0 | Implement `/v1/connectors/{id}` revoke + provider-side revoke | BE | 2026-03-05 | DONE | BE-006 | Connector revoke fully works |
-| BE-008 | P0 | Implement `/v1/preferences` persistence | BE | 2026-03-06 | TODO | DB-001 | Read/write preferences backed by DB |
+| BE-008 | P0 | Implement `/v1/preferences` persistence | BE | 2026-03-06 | DONE | DB-001 | Read/write preferences backed by DB |
 | BE-009 | P0 | Implement `/v1/audit-events` pagination and filters | BE | 2026-03-10 | TODO | DB-004 | Cursor pagination works |
 | BE-010 | P0 | Implement `/v1/privacy/delete-all` async job trigger | BE | 2026-03-12 | DONE | DB-007 | Delete request queued and trackable |
 | BE-011 | P1 | Add endpoint-level rate limiting | BE | 2026-03-14 | DONE | BE-004 | Rate-limits enforced |
 | BE-012 | P1 | OpenAPI drift check in CI | BE | 2026-03-14 | TODO | BE-004 | CI fails on contract drift |
 | BE-013 | P1 | Refactor oversized security-critical backend modules for maintainability | BE | 2026-03-16 | DONE | BE-006, WRK-007 | `worker/src/main.rs` and `http/connectors.rs` decomposed into focused modules with behavior parity |
-| BE-014 | P0 | Deprecate legacy custom auth endpoints and align contracts/docs to Clerk | BE | 2026-03-04 | IN_PROGRESS | BE-001, IOS-001 | Legacy `/v1/auth/ios/session*` endpoints removed or disabled-by-default and docs/contracts updated |
+| BE-014 | P0 | Deprecate legacy custom auth endpoints and align contracts/docs to Clerk | BE | 2026-03-04 | DONE | BE-001, IOS-001 | Legacy `/v1/auth/ios/session*` endpoints removed or disabled-by-default and docs/contracts updated |
 
 ### C) Database and Migrations
 
@@ -111,7 +125,7 @@ Ship a private beta where iOS users can:
 |---|---|---|---|---|---|---|---|
 | DB-001 | P0 | Wire Postgres in backend (`sqlx`) | BE | 2026-02-24 | DONE | - | App connects and queries DB |
 | DB-002 | P0 | Convert draft SQL into migration sequence | BE | 2026-02-24 | DONE | DB-001 | `migrate up` produces schema |
-| DB-003 | P0 | Add token encryption metadata fields (version/rotated_at) | BE | 2026-02-27 | TODO | DB-002 | Schema supports key rotation |
+| DB-003 | P0 | Add token encryption metadata fields (version/rotated_at) | BE | 2026-02-27 | DONE | DB-002 | Schema supports key rotation |
 | DB-004 | P0 | Add audit_events indexes and query plan checks | BE | 2026-03-01 | TODO | DB-002 | Audit endpoint query < target latency |
 | DB-005 | P0 | Add jobs table locking/lease fields | BE | 2026-03-02 | DONE | DB-002 | Worker-safe leasing possible |
 | DB-006 | P1 | Add dead-letter table for failed jobs | BE | 2026-03-04 | DONE | DB-005 | Failed job archival works |
@@ -156,25 +170,25 @@ Ship a private beta where iOS users can:
 | ID | Pri | Task | Owner | ETA | Status | Depends On | Exit Criteria |
 |---|---|---|---|---|---|---|---|
 | APNS-001 | P0 | Configure APNs credentials per environment | IOS | 2026-03-01 | TODO | - | Dev/staging push can be sent |
-| APNS-002 | P0 | Implement device registration endpoint persistence | BE | 2026-03-02 | TODO | DB-002 | Device token saved/updated |
+| APNS-002 | P0 | Implement device registration endpoint persistence | BE | 2026-03-02 | DONE | DB-002 | Device token saved/updated |
 | APNS-003 | P0 | Wire iOS token registration call on app start | IOS | 2026-03-05 | TODO | APNS-002 | Device appears in backend DB |
-| APNS-004 | P0 | Implement push send service in backend | BE | 2026-03-09 | TODO | APNS-001 | Backend sends push successfully |
-| APNS-005 | P1 | Add retry handling for APNs transient failures | BE | 2026-03-11 | TODO | APNS-004 | Retry behavior validated |
-| APNS-006 | P1 | Add quiet-hours suppression in send path | BE | 2026-03-13 | TODO | BE-008, APNS-004 | Quiet hour rule enforced |
-| APNS-007 | P1 | Add redacted notification audit records | BE | 2026-03-13 | TODO | DB-004, APNS-004 | Notification logs visible |
+| APNS-004 | P0 | Implement push send service in backend | BE | 2026-03-09 | DONE | APNS-001 | Backend sends push successfully |
+| APNS-005 | P1 | Add retry handling for APNs transient failures | BE | 2026-03-11 | DONE | APNS-004 | Retry behavior validated |
+| APNS-006 | P1 | Add quiet-hours suppression in send path | BE | 2026-03-13 | DONE | BE-008, APNS-004 | Quiet hour rule enforced |
+| APNS-007 | P1 | Add redacted notification audit records | BE | 2026-03-13 | DONE | DB-004, APNS-004 | Notification logs visible |
 
 ### G) iOS App Delivery
 
 | ID | Pri | Task | Owner | ETA | Status | Depends On | Exit Criteria |
 |---|---|---|---|---|---|---|---|
-| IOS-001 | P0 | Integrate Clerk iOS auth and API token provider wiring | IOS | 2026-02-27 | TODO | BE-001 | App obtains Clerk token and authenticated API calls succeed |
-| IOS-002 | P0 | Native bottom-tab app shell with per-tab navigation stacks (FE02) | IOS | 2026-02-16 | DONE | IOS-013 | Four-tab shell with independent NavigationStack + centralized tab routing |
+| IOS-001 | P0 | Integrate Clerk iOS auth and API token provider wiring | IOS | 2026-02-27 | DONE | BE-001 | App obtains Clerk token and authenticated API calls succeed |
+| IOS-002 | P0 | Native bottom-tab app shell with per-tab navigation stacks (FE02) | IOS | 2026-02-16 | DONE | IOS-013 | Duplicate of IOS-014 retained for historical traceability |
 | IOS-003 | P0 | Build Google connect UI flow + Connectors hub v1 (FE05) | IOS | 2026-03-06 | DONE | BE-005 | Connectors tab shows Google state/actions, error+retry UX, and extensible future-provider layout |
 | IOS-013 | P0 | Dark-mode theme tokens + shared UI primitives (FE01) | IOS | 2026-02-16 | DONE | - | App uses dark-only tokens and shared components |
 | IOS-014 | P0 | Build native tabbed app shell (FE02) | IOS | 2026-02-15 | DONE | IOS-013 | TabView + per-tab NavigationStack with centralized tab routing |
 | IOS-015 | P0 | Home screen v1 redesign (FE03) | IOS | 2026-02-15 | DONE | IOS-014 | Home screen shows summary, status cards, quick actions, and loading/empty/error states |
 | IOS-004 | P0 | Build preferences screen | IOS | 2026-03-08 | DONE | BE-008 | Preferences read/write works |
-| IOS-005 | P0 | Build activity log screen | IOS | 2026-03-12 | DONE | BE-009 | Audit entries visible in app |
+| IOS-005 | P0 | Build activity log screen | IOS | 2026-03-12 | DONE | BE-009 | Activity screen v1 delivered (`#70`); top-tab entry later replaced by Automations (`#219`) |
 | IOS-006 | P0 | Build privacy controls (revoke + delete-all) | IOS | 2026-03-14 | DONE | BE-007, BE-010 | Revoke/delete flows complete |
 | IOS-007 | P1 | Add offline/error state UI patterns | IOS | 2026-03-16 | TODO | IOS-003 | UX handles API failures cleanly |
 | IOS-008 | P1 | Add analytics events (privacy-safe) | IOS | 2026-03-18 | TODO | PROD-003 | KPI events emitting |
@@ -240,7 +254,7 @@ Ship a private beta where iOS users can:
 | AI-013 | P0 | Move LLM reliability state to Redis (`#118`) | BE | 2026-03-30 | DONE | AI-009 | Reliability cache/rate-limit/breaker/budget state is shared and restart-safe |
 | AI-010 | P0 | Add assistant session memory for follow-up continuity (`#101`) | BE | 2026-03-24 | DONE | AI-004 | Session-context follow-up queries supported with retention controls |
 | AI-011 | P0 | Add LLM eval/regression harness in CI (`#102`) | QA | 2026-03-26 | DONE | AI-005, AI-006, AI-007 | Prompt/output regressions are detected by automated checks |
-| AI-012 | P0 | Maintain migration tracker + execution order (`#103`) | FOUNDER | 2026-03-05 | IN_PROGRESS | - | Tracker issue reflects live execution order and status |
+| AI-012 | P0 | Maintain migration tracker + execution order (`#103`) | FOUNDER | 2026-03-05 | DONE | - | Tracker issue reflects live execution order and status |
 | AI-014 | P0 | Replace keyword assistant routing with enclave semantic planner (`#180`) | BE | 2026-02-18 | DONE | AI-004, AI-005, AI-010 | Planner-driven capability resolution is production path with schema validation, policy gating, and deterministic fallback |
 | AI-015 | P0 | Planner rollout phases A-D (contract, integration, English temporal policy, hardening) (`#181`..`#187`) | BE | 2026-02-18 | DONE | AI-014 | All planned rollout phases delivered with unit/integration/eval coverage and deep-review pass |
 
@@ -252,23 +266,61 @@ Ship a private beta where iOS users can:
 | CB-002 | P0 | Implement encrypted message transport + enclave decryption/processing path (`#148`) | BE | 2026-02-27 | DONE | CB-001 | `/v1/assistant/query`-class flows carry ciphertext through control plane; plaintext exists only in enclave runtime |
 | CB-003 | P0 | Add privacy verification gates, redaction tests, and rollout hardening (`#149`) | BE | 2026-03-03 | DONE | CB-002 | Automated checks and audit evidence confirm message-body server blindness with metadata-only server observability (`docs/content-blindness-invariants.md`, boundary guard tests) |
 
+### M) Automation v2 Migration (Client-Defined Periodic Prompt Jobs)
+
+| ID | Pri | Task | Owner | ETA | Status | Depends On | Exit Criteria |
+|---|---|---|---|---|---|---|---|
+| AUTO-001 | P0 | Add automation schema + repository layer (`#209`) | BE | 2026-02-20 | DONE | DB-002 | `automation_rules` lifecycle is persisted with scheduling metadata |
+| AUTO-002 | P0 | Implement automation CRUD API with encrypted prompt envelope (`#210`) | BE | 2026-02-21 | DONE | AUTO-001, SEC-003 | iOS can create/update/pause/delete rules without plaintext host-boundary regressions |
+| AUTO-003 | P0 | Replace hardcoded worker actions with generic scheduler/executor (`#211`) | BE | 2026-02-21 | DONE | AUTO-001, WRK-001 | Worker executes due `AUTOMATION_RUN` jobs with lease/retry/idempotency guarantees |
+| AUTO-004 | P0 | Add enclave automation execution + encrypted notification artifacts (`#212`) | SEC | 2026-02-21 | DONE | AUTO-003, SEC-005 | Automation prompt/output plaintext remains enclave-only |
+| AUTO-005 | P0 | Ship encrypted APNs payload contract for automations (`#213`) | BE | 2026-02-21 | DONE | AUTO-004, APNS-004 | Host sends encrypted push payload with safe fallback envelope |
+| AUTO-006 | P0 | Add iOS Notification Service Extension decrypt/render (`#214`) | IOS | 2026-02-21 | DONE | AUTO-005 | User-visible automation push content is decrypted/rendered on-device |
+| AUTO-007 | P0 | Replace Activity tab with Automations scheduler UI (`#219`) | IOS | 2026-02-21 | DONE | AUTO-002, AUTO-006 | User can manage periodic automations from iOS tab UI |
+| AUTO-008 | P0 | Close tracker and final migration acceptance (`#208`) | FOUNDER | 2026-02-24 | IN_PROGRESS | AUTO-001..AUTO-007 | Tracker confirms legacy-flow removal + final E2E acceptance criteria closure |
+
 ---
 
-## 6) Critical Path (Must Complete for Beta)
+## 6) Reconciliation Summary (2026-02-21)
 
-1. `PROD-001`, `PROD-003`, `PROD-006`
-2. `DB-001`, `DB-002`, `DB-005`
-3. `BE-001`, `BE-005`, `BE-006`, `BE-008`, `BE-010`, `BE-014`
-4. `SEC-001` through `SEC-007`, `SEC-010`, `SEC-012`
-5. `WRK-001`, `WRK-004`, `WRK-005`, `WRK-006`, `WRK-007`
-6. `APNS-001`, `APNS-002`, `APNS-004`
-7. `IOS-001` through `IOS-006`
-8. `QA-002`, `QA-005`, `QA-008`
-9. `GOV-001`, `GOV-002`, `GOV-006`, `GOV-007`, `GOV-008`
-10. `AI-000`, then `AI-001` through `AI-011`, `AI-014`, `AI-015`
-11. `CB-001`, `CB-002`, `CB-003`
+1. Corrected stale statuses where implementation is already merged:
+   1. `BE-001`, `BE-002`, `BE-003`, `BE-008`, `BE-014`
+   2. `DB-003`
+   3. `APNS-002`, `APNS-004`, `APNS-005`, `APNS-006`, `APNS-007`
+   4. `IOS-001`
+   5. `AI-012`
+2. Added missing automation migration board section (`AUTO-001`..`AUTO-008`) aligned to issues `#208`..`#214` and `#219`.
+3. Normalized duplicate board rows by explicitly marking `IOS-002` as historical duplicate of `IOS-014`.
+4. Updated activity UX status note to reflect the activity-to-automations tab migration (`#70` -> `#219`).
 
-## 7) Weekly Operating Cadence
+### Evidence Map for DONE Rows
+
+1. Clerk/Auth migration: `BE-001`, `BE-014`, `IOS-001` -> `#52`, `#53`, `#54`, `#56`.
+2. Backend/API core + logging/rate limits + modularization: `BE-002`, `BE-003`, `BE-005`, `BE-006`, `BE-007`, `BE-008`, `BE-010`, `BE-011`, `BE-013` -> `#1`, `#6`, `#7`, `#9`, `#24`, `#64`.
+3. Database and privacy-state primitives: `DB-001`, `DB-002`, `DB-003`, `DB-005`, `DB-006`, `DB-007`, `GOV-004` -> `#2`, `#4`, `#7`, `#19`, `#127`.
+4. TEE/security line: `SEC-001`..`SEC-010` -> `#121`..`#130`.
+5. Worker core/reliability primitives: `WRK-001`..`WRK-008` -> `#4`, `#18`, `#91`, `#97`, `#98`, `#211`.
+6. APNs pipeline hardening: `APNS-002`, `APNS-004`, `APNS-005`, `APNS-006`, `APNS-007` -> `#5`, `#213`, `#214`.
+7. iOS FE core/tab/connect/privacy line: `IOS-002`, `IOS-003`, `IOS-004`, `IOS-005`, `IOS-006`, `IOS-013`, `IOS-014`, `IOS-015` -> `#67`, `#68`, `#69`, `#70`, `#71`, `#72`, `#219`.
+8. LLM backend migration: `AI-000`..`AI-015` -> `#91`..`#103`, `#118`, `#180`, `#181`, `#182`, `#185`, `#187`.
+9. Content blindness migration: `CB-001`, `CB-002`, `CB-003` -> `#147`, `#148`, `#149`.
+10. Automation v2 migration: `AUTO-001`..`AUTO-007` -> `#209`, `#210`, `#211`, `#212`, `#213`, `#214`, `#219`.
+
+## 7) Critical Path (Outstanding as of 2026-02-21)
+
+1. Product launch gating and decision package: `PROD-001`, `PROD-003`, `PROD-006`, `GOV-008`, `GOV-009` (see open `#42`).
+2. Security assessment and remediation closure: `SEC-011`, `SEC-012`, `GOV-007` (see open `#43`).
+3. APNs client auto-registration + in-app validation hardening: `APNS-003` (see open `#51`).
+4. Automation migration closure and acceptance sign-off: `AUTO-008` (see open `#208`).
+5. Pre-beta verification gates: `QA-002`, `QA-005`, `QA-008`, `IOS-012`.
+
+## 8) Open Backlog Alignment (GitHub `phase-1`)
+
+1. Open `P0` issues: `#41`, `#42`, `#43`, `#51`.
+2. Open `P1` issues: `#8`, `#10`, `#25`, `#44`, `#45`, `#46`, `#73`, `#74`, `#75`, `#76`.
+3. Reconciliation note: automation tracker `#208` is active P0 architecture work but currently unlabeled; board tracks it under `AUTO-008` to preserve execution visibility.
+
+## 9) Weekly Operating Cadence
 
 1. Weekly planning: update status for all `P0` items.
 2. Mid-week risk review: check blocked items and reassign ownership.


### PR DESCRIPTION
## Summary
- reconcile `docs/phase1-master-todo.md` against merged/open GitHub issue state and current architecture
- fix stale board statuses where implementation is already merged
- add Automation v2 migration section (`AUTO-001`..`AUTO-008`) aligned to `#208`..`#214` and `#219`
- add reconciliation summary, DONE evidence map, outstanding critical path, and open backlog alignment snapshot

## Validation
- `just check-tools`

## Review pass
### Security / privacy
- docs-only change; no runtime or boundary logic modified

### Bugs / regressions
- corrected stale status drift (notably Clerk/auth, APNS pipeline, and AI tracker rows)
- normalized duplicate row handling (`IOS-002` vs `IOS-014`) with explicit historical note

### Refactor / maintainability
- board now has explicit update date + reconciliation section to reduce future drift
- added missing automation tracker rows to keep architecture changes visible in the execution source of truth

Closes #41
