### PR TITLE
Add automation output history with notification tap routing

### DIFF
--- a/alfred/Packages/AlfredAPIClient/Sources/AutomationNotificationCrypto.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/AutomationNotificationCrypto.swift
@@ -169,6 +169,14 @@ public enum AutomationNotificationCrypto {
         return payload.alfredAutomation.envelope
     }
 
+    public static func requestID(from userInfo: [AnyHashable: Any]) -> String? {
+        guard let value = try? encryptedEnvelope(from: userInfo).requestID else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     public static func decrypt(
         envelope: AutomationEncryptedNotificationEnvelope,
         material: AutomationNotificationDecryptionMaterial

--- a/alfred/Packages/AlfredAPIClient/Sources/AutomationOutputHistoryStore.swift
+++ b/alfred/Packages/AlfredAPIClient/Sources/AutomationOutputHistoryStore.swift
@@ -1,0 +1,352 @@
+import Foundation
+
+public struct AutomationOutputHistoryEntry: Codable, Equatable, Sendable, Identifiable {
+    public let requestID: String
+    public let title: String
+    public let body: String
+    public let receivedAt: Date
+    public let openedAt: Date?
+
+    public var id: String { requestID }
+
+    enum CodingKeys: String, CodingKey {
+        case requestID = "request_id"
+        case title
+        case body
+        case receivedAt = "received_at"
+        case openedAt = "opened_at"
+    }
+
+    public init(
+        requestID: String,
+        title: String,
+        body: String,
+        receivedAt: Date,
+        openedAt: Date? = nil
+    ) {
+        self.requestID = requestID
+        self.title = title
+        self.body = body
+        self.receivedAt = receivedAt
+        self.openedAt = openedAt
+    }
+}
+
+public enum AutomationOutputHistoryStoreError: Error {
+    case invalidRequestID
+    case invalidContent
+}
+
+public actor AutomationOutputHistoryStore {
+    public static let appGroupIdentifier = "group.com.prodata.alfred.shared"
+
+    private struct Snapshot: Codable {
+        var pendingOpenRequestID: String?
+        var entries: [AutomationOutputHistoryEntry]
+
+        enum CodingKeys: String, CodingKey {
+            case pendingOpenRequestID = "pending_open_request_id"
+            case entries
+        }
+    }
+
+    private let fileManager: FileManager
+    private let storageDirectoryURL: URL
+    private let historyFileURL: URL
+    private let maxEntries: Int
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(
+        fileManager: FileManager = .default,
+        storageDirectoryURL: URL? = nil,
+        maxEntries: Int = 200
+    ) {
+        self.fileManager = fileManager
+        self.storageDirectoryURL = Self.resolveStorageDirectoryURL(
+            fileManager: fileManager,
+            override: storageDirectoryURL
+        )
+        self.historyFileURL = self.storageDirectoryURL.appendingPathComponent("automation_output_history.json")
+        self.maxEntries = max(1, maxEntries)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        self.encoder = encoder
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    public func list() throws -> [AutomationOutputHistoryEntry] {
+        try loadSnapshot().entries
+    }
+
+    @discardableResult
+    public func upsertDelivered(
+        requestID: String,
+        title: String,
+        body: String,
+        receivedAt: Date = Date()
+    ) throws -> AutomationOutputHistoryEntry {
+        var snapshot = try loadSnapshot()
+        let normalizedRequestID = try normalizedRequestID(from: requestID)
+        let normalizedTitle = try normalizedContent(title)
+        let normalizedBody = try normalizedContent(body)
+
+        let existingIndex = snapshot.entries.firstIndex { $0.requestID == normalizedRequestID }
+        let entry = AutomationOutputHistoryEntry(
+            requestID: normalizedRequestID,
+            title: normalizedTitle,
+            body: normalizedBody,
+            receivedAt: receivedAt,
+            openedAt: existingIndex.flatMap { snapshot.entries[$0].openedAt }
+        )
+
+        if let existingIndex {
+            snapshot.entries[existingIndex] = entry
+        } else {
+            snapshot.entries.append(entry)
+        }
+
+        snapshot.entries = normalizedEntries(snapshot.entries)
+        try saveSnapshot(snapshot)
+        return entry
+    }
+
+    @discardableResult
+    public func upsertOpenedFromNotificationTap(
+        requestID: String,
+        title: String,
+        body: String,
+        openedAt: Date = Date()
+    ) throws -> AutomationOutputHistoryEntry {
+        var snapshot = try loadSnapshot()
+        let normalizedRequestID = try normalizedRequestID(from: requestID)
+        let normalizedTitle = try normalizedContent(title)
+        let normalizedBody = try normalizedContent(body)
+
+        let existing = snapshot.entries.first { $0.requestID == normalizedRequestID }
+        let entry = AutomationOutputHistoryEntry(
+            requestID: normalizedRequestID,
+            title: normalizedTitle,
+            body: normalizedBody,
+            receivedAt: existing?.receivedAt ?? openedAt,
+            openedAt: openedAt
+        )
+
+        if let existingIndex = snapshot.entries.firstIndex(where: { $0.requestID == normalizedRequestID }) {
+            snapshot.entries[existingIndex] = entry
+        } else {
+            snapshot.entries.append(entry)
+        }
+        snapshot.pendingOpenRequestID = normalizedRequestID
+        snapshot.entries = normalizedEntries(snapshot.entries)
+
+        try saveSnapshot(snapshot)
+        return entry
+    }
+
+    public func markOpened(
+        requestID: String,
+        openedAt: Date = Date()
+    ) throws -> AutomationOutputHistoryEntry? {
+        var snapshot = try loadSnapshot()
+        let normalizedRequestID = try normalizedRequestID(from: requestID)
+        guard let existingIndex = snapshot.entries.firstIndex(where: { $0.requestID == normalizedRequestID }) else {
+            return nil
+        }
+
+        let existing = snapshot.entries[existingIndex]
+        let updated = AutomationOutputHistoryEntry(
+            requestID: existing.requestID,
+            title: existing.title,
+            body: existing.body,
+            receivedAt: existing.receivedAt,
+            openedAt: openedAt
+        )
+
+        snapshot.entries[existingIndex] = updated
+        snapshot.entries = normalizedEntries(snapshot.entries)
+        try saveSnapshot(snapshot)
+        return updated
+    }
+
+    public func peekPendingOpenRequestID() throws -> String? {
+        try loadSnapshot().pendingOpenRequestID
+    }
+
+    public func consumePendingOpenRequestID() throws -> String? {
+        var snapshot = try loadSnapshot()
+        let pending = snapshot.pendingOpenRequestID
+        snapshot.pendingOpenRequestID = nil
+        try saveSnapshot(snapshot)
+        return pending
+    }
+
+    public func clear() throws {
+        if fileManager.fileExists(atPath: historyFileURL.path) {
+            try fileManager.removeItem(at: historyFileURL)
+        }
+    }
+
+    private func loadSnapshot() throws -> Snapshot {
+        guard fileManager.fileExists(atPath: historyFileURL.path) else {
+            return Snapshot(pendingOpenRequestID: nil, entries: [])
+        }
+
+        let data = try Data(contentsOf: historyFileURL)
+        guard !data.isEmpty else {
+            return Snapshot(pendingOpenRequestID: nil, entries: [])
+        }
+
+        let decoded = try decoder.decode(Snapshot.self, from: data)
+        let pendingRequestID = decoded.pendingOpenRequestID.map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return Snapshot(
+            pendingOpenRequestID: pendingRequestID?.isEmpty == false ? pendingRequestID : nil,
+            entries: normalizedEntries(decoded.entries)
+        )
+    }
+
+    private func saveSnapshot(_ snapshot: Snapshot) throws {
+        try ensureStorageDirectoryExists()
+        let normalized = Snapshot(
+            pendingOpenRequestID: snapshot.pendingOpenRequestID,
+            entries: normalizedEntries(snapshot.entries)
+        )
+        let data = try encoder.encode(normalized)
+        try data.write(to: historyFileURL, options: [.atomic])
+    }
+
+    private func normalizedEntries(_ entries: [AutomationOutputHistoryEntry]) -> [AutomationOutputHistoryEntry] {
+        var byRequestID: [String: AutomationOutputHistoryEntry] = [:]
+
+        for entry in entries {
+            let requestID = entry.requestID.trimmingCharacters(in: .whitespacesAndNewlines)
+            let title = entry.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let body = entry.body.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !requestID.isEmpty, !title.isEmpty, !body.isEmpty else {
+                continue
+            }
+
+            let normalized = AutomationOutputHistoryEntry(
+                requestID: requestID,
+                title: title,
+                body: body,
+                receivedAt: entry.receivedAt,
+                openedAt: entry.openedAt
+            )
+
+            if let existing = byRequestID[requestID] {
+                let preferred = preferredEntry(lhs: existing, rhs: normalized)
+                byRequestID[requestID] = preferred
+            } else {
+                byRequestID[requestID] = normalized
+            }
+        }
+
+        return byRequestID.values
+            .sorted(by: Self.receivedAtDescending)
+            .prefix(maxEntries)
+            .map { $0 }
+    }
+
+    private func preferredEntry(
+        lhs: AutomationOutputHistoryEntry,
+        rhs: AutomationOutputHistoryEntry
+    ) -> AutomationOutputHistoryEntry {
+        let pickedReceivedAt = max(lhs.receivedAt, rhs.receivedAt)
+        let pickedOpenedAt: Date?
+        switch (lhs.openedAt, rhs.openedAt) {
+        case let (left?, right?):
+            pickedOpenedAt = max(left, right)
+        case let (left?, nil):
+            pickedOpenedAt = left
+        case let (nil, right?):
+            pickedOpenedAt = right
+        case (nil, nil):
+            pickedOpenedAt = nil
+        }
+        let title = rhs.receivedAt >= lhs.receivedAt ? rhs.title : lhs.title
+        let body = rhs.receivedAt >= lhs.receivedAt ? rhs.body : lhs.body
+
+        return AutomationOutputHistoryEntry(
+            requestID: lhs.requestID,
+            title: title,
+            body: body,
+            receivedAt: pickedReceivedAt,
+            openedAt: pickedOpenedAt
+        )
+    }
+
+    private func normalizedRequestID(from value: String) throws -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw AutomationOutputHistoryStoreError.invalidRequestID
+        }
+        return trimmed
+    }
+
+    private func normalizedContent(_ value: String) throws -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw AutomationOutputHistoryStoreError.invalidContent
+        }
+        return trimmed
+    }
+
+    private func ensureStorageDirectoryExists() throws {
+        var isDirectory: ObjCBool = false
+        let directoryPath = storageDirectoryURL.path
+
+        if fileManager.fileExists(atPath: directoryPath, isDirectory: &isDirectory) {
+            if isDirectory.boolValue {
+                return
+            }
+            try fileManager.removeItem(at: storageDirectoryURL)
+        }
+
+        try fileManager.createDirectory(
+            at: storageDirectoryURL,
+            withIntermediateDirectories: true
+        )
+    }
+
+    private static func resolveStorageDirectoryURL(
+        fileManager: FileManager,
+        override: URL?
+    ) -> URL {
+        if let override {
+            return override
+        }
+
+        if let appGroupURL = fileManager.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupIdentifier
+        ) {
+            return appGroupURL
+                .appendingPathComponent("automation_outputs", isDirectory: true)
+        }
+
+        let applicationSupportURL = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? fileManager.temporaryDirectory
+        return applicationSupportURL
+            .appendingPathComponent("alfred", isDirectory: true)
+            .appendingPathComponent("automation_outputs", isDirectory: true)
+    }
+
+    private static func receivedAtDescending(
+        _ lhs: AutomationOutputHistoryEntry,
+        _ rhs: AutomationOutputHistoryEntry
+    ) -> Bool {
+        if lhs.receivedAt == rhs.receivedAt {
+            return lhs.requestID > rhs.requestID
+        }
+        return lhs.receivedAt > rhs.receivedAt
+    }
+}

--- a/alfred/alfred/Views/AutomationOutputHistoryView.swift
+++ b/alfred/alfred/Views/AutomationOutputHistoryView.swift
@@ -1,0 +1,211 @@
+import AlfredAPIClient
+import SwiftUI
+
+struct AutomationOutputHistorySheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let store: AutomationOutputHistoryStore
+    let initialRequestID: String?
+
+    @State private var records: [AutomationOutputHistoryEntry] = []
+    @State private var path: [String] = []
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+    @State private var didApplyInitialRoute = false
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            Group {
+                if isLoading && records.isEmpty {
+                    ProgressView()
+                        .tint(AppTheme.Colors.accent)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(AppTheme.Colors.background)
+                } else if records.isEmpty {
+                    AutomationOutputHistoryEmptyState(errorMessage: errorMessage) {
+                        Task {
+                            await loadHistory()
+                        }
+                    }
+                } else {
+                    List(records) { record in
+                        NavigationLink(value: record.requestID) {
+                            AutomationOutputHistoryRow(record: record)
+                        }
+                        .listRowBackground(AppTheme.Colors.surface)
+                    }
+                    .scrollContentBackground(.hidden)
+                    .background(AppTheme.Colors.background)
+                }
+            }
+            .navigationTitle("Task Outputs")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Close") { dismiss() }
+                        .tint(AppTheme.Colors.textPrimary)
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        Task {
+                            await loadHistory()
+                        }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .tint(AppTheme.Colors.textPrimary)
+                    .disabled(isLoading)
+                }
+            }
+            .navigationDestination(for: String.self) { requestID in
+                if let record = records.first(where: { $0.requestID == requestID }) {
+                    AutomationOutputDetailView(record: record)
+                        .task {
+                            _ = try? await store.markOpened(requestID: requestID)
+                        }
+                } else {
+                    AutomationOutputDetailUnavailableView()
+                }
+            }
+        }
+        .appScreenBackground()
+        .task {
+            await loadHistory()
+        }
+    }
+
+    @MainActor
+    private func loadHistory() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            records = try await store.list()
+            errorMessage = nil
+            applyInitialRouteIfNeeded()
+        } catch {
+            records = []
+            errorMessage = "Unable to load task outputs."
+        }
+    }
+
+    private func applyInitialRouteIfNeeded() {
+        guard !didApplyInitialRoute else { return }
+        didApplyInitialRoute = true
+        guard let initialRequestID else { return }
+        guard records.contains(where: { $0.requestID == initialRequestID }) else { return }
+        path = [initialRequestID]
+    }
+}
+
+private struct AutomationOutputHistoryRow: View {
+    let record: AutomationOutputHistoryEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(record.title)
+                .font(.headline)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+                .lineLimit(2)
+
+            Text(record.body)
+                .font(.subheadline)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+                .lineLimit(3)
+
+            HStack(spacing: 10) {
+                Text(record.receivedAt.formatted(date: .abbreviated, time: .shortened))
+                    .font(.caption)
+                    .foregroundStyle(AppTheme.Colors.textSecondary)
+
+                if record.openedAt != nil {
+                    Text("Opened")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(AppTheme.Colors.success)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct AutomationOutputHistoryEmptyState: View {
+    let errorMessage: String?
+    let onRefresh: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 30, weight: .medium))
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+
+            Text(errorMessage == nil ? "No task outputs yet" : "Unable to load task outputs")
+                .font(.headline)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+
+            Text(errorMessage ?? "Delivered automation results will appear here.")
+                .font(.subheadline)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 24)
+
+            Button("Refresh", action: onRefresh)
+                .buttonStyle(.appSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, AppTheme.Layout.screenPadding)
+    }
+}
+
+private struct AutomationOutputDetailView: View {
+    let record: AutomationOutputHistoryEntry
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppTheme.Layout.sectionSpacing) {
+                AppCard {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(record.title)
+                            .font(.title3.weight(.semibold))
+                            .foregroundStyle(AppTheme.Colors.textPrimary)
+
+                        Text(record.receivedAt.formatted(date: .complete, time: .shortened))
+                            .font(.footnote)
+                            .foregroundStyle(AppTheme.Colors.textSecondary)
+
+                        Divider()
+                            .overlay(AppTheme.Colors.outline)
+
+                        Text(record.body)
+                            .font(.body)
+                            .foregroundStyle(AppTheme.Colors.textPrimary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+            .padding(.horizontal, AppTheme.Layout.screenPadding)
+            .padding(.vertical, AppTheme.Layout.sectionSpacing)
+        }
+        .appScreenBackground()
+        .navigationTitle("Output")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct AutomationOutputDetailUnavailableView: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            Text("Output not available")
+                .font(.headline)
+                .foregroundStyle(AppTheme.Colors.textPrimary)
+            Text("This output may have been removed from local history.")
+                .font(.footnote)
+                .foregroundStyle(AppTheme.Colors.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, AppTheme.Layout.screenPadding)
+        .appScreenBackground()
+    }
+}

--- a/alfred/alfred/alfred.entitlements
+++ b/alfred/alfred/alfred.entitlements
@@ -8,6 +8,10 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.prodata.alfred.shared</string>
+	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:obliging-mammoth-40.clerk.accounts.dev</string>

--- a/alfred/alfredNotificationServiceExtension/alfredNotificationServiceExtension.entitlements
+++ b/alfred/alfredNotificationServiceExtension/alfredNotificationServiceExtension.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.prodata.alfred.shared</string>
+    </array>
     <key>keychain-access-groups</key>
     <array>
         <string>$(AppIdentifierPrefix)com.prodata.alfred.shared</string>

--- a/alfred/alfredTests/AutomationOutputHistoryStoreTests.swift
+++ b/alfred/alfredTests/AutomationOutputHistoryStoreTests.swift
@@ -1,0 +1,81 @@
+import AlfredAPIClient
+import Foundation
+import XCTest
+
+final class AutomationOutputHistoryStoreTests: XCTestCase {
+    func testUpsertDeliveredAndListReturnNewestFirst() async throws {
+        let store = makeStore()
+        let firstDate = Date(timeIntervalSince1970: 100)
+        let secondDate = Date(timeIntervalSince1970: 200)
+
+        try await store.upsertDelivered(
+            requestID: "req-1",
+            title: "Morning Brief",
+            body: "First body",
+            receivedAt: firstDate
+        )
+        try await store.upsertDelivered(
+            requestID: "req-2",
+            title: "Inbox Summary",
+            body: "Second body",
+            receivedAt: secondDate
+        )
+
+        let entries = try await store.list()
+        XCTAssertEqual(entries.map(\.requestID), ["req-2", "req-1"])
+        XCTAssertEqual(entries.first?.title, "Inbox Summary")
+    }
+
+    func testUpsertOpenedFromTapSetsAndConsumesPendingOpenRequest() async throws {
+        let store = makeStore()
+        try await store.upsertOpenedFromNotificationTap(
+            requestID: "req-tap",
+            title: "Automation",
+            body: "Tap body",
+            openedAt: Date(timeIntervalSince1970: 300)
+        )
+
+        let pending = try await store.peekPendingOpenRequestID()
+        XCTAssertEqual(pending, "req-tap")
+
+        let consumed = try await store.consumePendingOpenRequestID()
+        XCTAssertEqual(consumed, "req-tap")
+
+        let afterConsume = try await store.peekPendingOpenRequestID()
+        XCTAssertNil(afterConsume)
+    }
+
+    func testRetentionCapKeepsMostRecentEntries() async throws {
+        let store = makeStore(maxEntries: 2)
+
+        try await store.upsertDelivered(
+            requestID: "req-1",
+            title: "One",
+            body: "Body one",
+            receivedAt: Date(timeIntervalSince1970: 10)
+        )
+        try await store.upsertDelivered(
+            requestID: "req-2",
+            title: "Two",
+            body: "Body two",
+            receivedAt: Date(timeIntervalSince1970: 20)
+        )
+        try await store.upsertDelivered(
+            requestID: "req-3",
+            title: "Three",
+            body: "Body three",
+            receivedAt: Date(timeIntervalSince1970: 30)
+        )
+
+        let entries = try await store.list()
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries.map(\.requestID), ["req-3", "req-2"])
+    }
+
+    private func makeStore(maxEntries: Int = 200) -> AutomationOutputHistoryStore {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("automation-output-history-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        return AutomationOutputHistoryStore(storageDirectoryURL: directoryURL, maxEntries: maxEntries)
+    }
+}


### PR DESCRIPTION
## Summary
- add a local automation output history store in `AlfredAPIClient` backed by app-group shared storage
- persist decrypted automation notification outputs in the Notification Service Extension
- on notification tap, queue/open the matching output and route users into the Tasks tab history sheet
- add a history sheet + detail UI in Automations/Tasks, including direct open from push and manual access via header icon
- add app-group entitlements for app + notification extension and tests for the new store behavior

## Validation
- `just ios-build`
- `just ios-test`